### PR TITLE
Fix email service compilation errors

### DIFF
--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -170,8 +170,9 @@ func (s *Service) SendPasswordResetEmail(to, username, resetToken string) error 
 func (s *Service) SendAnnouncementEmail(to, title, content string) error {
 	subject := fmt.Sprintf("Announcement: %s - Haws Volunteers", title)
 
-	// Convert newlines to HTML line breaks
-	htmlContent := strings.ReplaceAll(content, "\n", "<br>")
+	// Escape HTML in title and convert newlines to HTML line breaks in content
+	escapedTitle := html.EscapeString(title)
+	htmlContent := strings.ReplaceAll(html.EscapeString(content), "\n", "<br>")
 
 	body := fmt.Sprintf(`
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
This PR fixes compilation errors in the email service that were preventing the backend from starting.

## Changes
- Add missing `escapedTitle` variable definition using `html.EscapeString()`
- Properly escape HTML content in announcement emails to prevent XSS attacks
- Resolves `undefined: escapedTitle` error
- Resolves `'html' imported and not used` error

## Testing
- Backend starts successfully with `go run cmd/api/main.go`
- Email service compiles without errors
- HTML content is properly escaped for security