### PR TITLE
Fix comment tags migration error by renaming join table

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -90,7 +90,7 @@ type AnimalComment struct {
 	UserID    uint           `gorm:"not null;index" json:"user_id"`
 	Content   string         `gorm:"not null" json:"content"`
 	ImageURL  string         `json:"image_url"`
-	Tags      []CommentTag   `gorm:"many2many:comment_tags;" json:"tags,omitempty"`
+	Tags      []CommentTag   `gorm:"many2many:animal_comment_tags;" json:"tags,omitempty"`
 	User      User           `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }
 


### PR DESCRIPTION
## Problem

The database migration was failing with this error:
```
ERROR: column "id" referenced in foreign key constraint does not exist (SQLSTATE 42703)
```

The many-to-many relationship between `AnimalComment` and `CommentTag` was using `comment_tags` as the join table name, which conflicted with the actual `comment_tags` table for the `CommentTag` model.

## Solution

Renamed the join table from `comment_tags` to `animal_comment_tags` in the `Tags` field of the `AnimalComment` struct.

## Changes

- Changed `gorm:"many2many:comment_tags;"` to `gorm:"many2many:animal_comment_tags;"` in `internal/models/models.go`

## Result

Now GORM correctly creates:
- `comment_tags` table (for the CommentTag model with id, name, color, is_system columns)
- `animal_comment_tags` join table (with animal_comment_id and comment_tag_id foreign keys)

The migration now completes successfully. ✅

## Testing

Verified by running the API server with test database - migrations completed without errors.