### PR TITLE
Fix export animal comments CSV: remove unsupported Group preload

### DIFF
--- a/internal/handlers/animal.go
+++ b/internal/handlers/animal.go
@@ -733,23 +733,21 @@ func ExportAnimalCommentsCSV(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		// Load animal details for each comment
-		animalIDs := make([]uint, 0, len(comments))
-		for _, comment := range comments {
-			animalIDs = append(animalIDs, comment.AnimalID)
-		}
+	// Load animal details for each comment
+	animalIDs := make([]uint, 0, len(comments))
+	for _, comment := range comments {
+		animalIDs = append(animalIDs, comment.AnimalID)
+	}
 
-		// Get all animals in one query
-		var animals []models.Animal
-		if len(animalIDs) > 0 {
-			if err := db.Preload("Group").Where("id IN ?", animalIDs).Find(&animals).Error; err != nil {
-				logger.Error("Failed to fetch animals", err)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch animal details"})
-				return
-			}
+	// Get all animals in one query
+	var animals []models.Animal
+	if len(animalIDs) > 0 {
+		if err := db.Where("id IN ?", animalIDs).Find(&animals).Error; err != nil {
+			logger.Error("Failed to fetch animals", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch animal details"})
+			return
 		}
-
-		// Create animal lookup map
+	}		// Create animal lookup map
 		animalMap := make(map[uint]models.Animal)
 		for _, animal := range animals {
 			animalMap[animal.ID] = animal


### PR DESCRIPTION
## Problem

The export animal comments feature was failing with the error:
```
Group: unsupported relations for schema Animal
```

This was causing a 500 Internal Server Error when trying to export animal comments to CSV.

## Root Cause

The code was attempting to preload a `Group` relationship on the `Animal` model at line 745:
```go
db.Preload("Group").Where("id IN ?", animalIDs).Find(&animals)
```

However, the `Animal` model only has a `GroupID` field (foreign key) but no `Group` relationship defined in the struct. GORM couldn't find the relationship to preload, causing the query to fail.

## Solution

Removed the unnecessary `Preload("Group")` call since:
1. The Animal model doesn't define a Group relationship
2. Groups are already being fetched separately in the next section of code
3. A group lookup map is created and used to get group names

## Changes Made

- **File**: `internal/handlers/animal.go` (line 745)
- **Change**: Removed `.Preload("Group")` from the animals query
- **Result**: Export now works correctly using the existing group lookup logic

## Testing

✅ Backend builds successfully  
✅ No compile errors  
✅ Code follows existing patterns for fetching related data  
✅ Export functionality restored

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)