### PR TITLE
Fix indentation in ExportAnimalCommentsCSV handler

### DIFF
--- a/internal/handlers/animal.go
+++ b/internal/handlers/animal.go
@@ -733,21 +733,21 @@ func ExportAnimalCommentsCSV(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-	// Load animal details for each comment
-	animalIDs := make([]uint, 0, len(comments))
-	for _, comment := range comments {
-		animalIDs = append(animalIDs, comment.AnimalID)
-	}
-
-	// Get all animals in one query
-	var animals []models.Animal
-	if len(animalIDs) > 0 {
-		if err := db.Where("id IN ?", animalIDs).Find(&animals).Error; err != nil {
-			logger.Error("Failed to fetch animals", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch animal details"})
-			return
+		// Load animal details for each comment
+		animalIDs := make([]uint, 0, len(comments))
+		for _, comment := range comments {
+			animalIDs = append(animalIDs, comment.AnimalID)
 		}
-	}		// Create animal lookup map
+
+		// Get all animals in one query
+		var animals []models.Animal
+		if len(animalIDs) > 0 {
+			if err := db.Where("id IN ?", animalIDs).Find(&animals).Error; err != nil {
+				logger.Error("Failed to fetch animals", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch animal details"})
+				return
+			}
+		} // Create animal lookup map
 		animalMap := make(map[uint]models.Animal)
 		for _, animal := range animals {
 			animalMap[animal.ID] = animal


### PR DESCRIPTION
## Problem

After the merge of PR #36, the indentation in the `ExportAnimalCommentsCSV` handler became incorrect. The code block for loading animal details (lines 736-750) was indented too far left, making it appear to be outside the handler function's scope.

## Changes

- Fixed indentation for the animal details loading block
- Corrected comment spacing: `} // Create animal lookup map`
- Ensured all code is properly nested within the handler function

## Impact

This is purely a formatting fix - no functional changes. The code compiles and runs correctly, but the indentation was misleading for readability.

## Testing

✅ Backend builds successfully
✅ No functional changes
✅ Code formatting now matches project standards

## Type of Change

- [x] Code style/formatting fix (non-breaking change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change