### PR TITLE
Add multi-tag filtering for animal comments with CSV export support

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -168,10 +168,11 @@ export const animalsApi = {
       responseType: 'blob' 
     });
   },
-  exportCommentsCSV: (groupId?: number, animalId?: number) => {
+  exportCommentsCSV: (groupId?: number, animalId?: number, tags?: string) => {
     const params: any = {};
     if (groupId) params.group_id = groupId;
     if (animalId) params.animal_id = animalId;
+    if (tags) params.tags = tags;
     return api.get('/admin/animals/export-comments-csv', {
       params,
       responseType: 'blob'

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -223,6 +223,14 @@
   border-color: var(--brand);
 }
 
+.filter-hint {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-style: italic;
+  padding: 0.4rem 0.8rem;
+  align-self: center;
+}
+
 .comment-tags-selection {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Adds multi-tag filtering capability for animal comments with full CSV export support. Users can now select multiple tags simultaneously to filter comments, and the export function respects these filters.

## Features

### Multi-Tag Selection
- ✅ Multiple tags can be selected at once for filtering
- ✅ Uses OR logic: shows comments with ANY of the selected tags
- ✅ Visual feedback with colored backgrounds for active tags
- ✅ Filter hint displays current selection (e.g., "Showing comments with: behavior OR medical")

### Enhanced Export
- ✅ CSV export now accepts tag filter parameter
- ✅ Only comments matching selected tags are exported when filters active
- ✅ Exported filename includes applied tags for clarity
  - Example: `buddy-comments-filtered-behavior-medical.csv`

### UX Improvements
- ✅ Click tags to toggle selection (no need to hold Ctrl/Cmd)
- ✅ Active tags visually distinct with color fill
- ✅ "All" button clears all filters
- ✅ Filter state shown clearly in UI

## Technical Changes

### Backend (`internal/handlers/`)
- **animal_comment.go**: Enhanced `GetAnimalComments` to trim whitespace from tag filter values
- **animal.go**: Updated `ExportAnimalCommentsCSV` to:
  - Accept `tags` query parameter (comma-separated)
  - Apply tag filter with JOIN to comment_tags table
  - Use OR logic for multiple tags
  - Log tag filter in structured logging

### Frontend
- **api/client.ts**: Added `tags` parameter to `exportCommentsCSV()`
- **AnimalDetailPage.tsx**:
  - Changed from single `tagFilter` string to `filterTags` array
  - Multi-select tag filter buttons with toggle behavior
  - Pass filters to export function
  - Include filter tags in export filename
- **AnimalDetailPage.css**: Added styling for filter hint and active state

## Database Query

The filter uses efficient JOINs:
```sql
SELECT animal_comments.* 
FROM animal_comments
JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id
JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id
WHERE comment_tags.name IN ('behavior', 'medical')
GROUP BY animal_comments.id
```

## Testing

✅ Backend builds successfully  
✅ Frontend builds successfully  
✅ Tag filtering logic updated in both Get and Export handlers  
✅ CSV export respects active filters  
✅ Proper handling of comma-separated tags with whitespace trimming

## Screenshots

**Before:** Single tag selection only  
**After:** Multiple tags can be selected simultaneously with visual feedback

## Use Cases

1. **Filter by behavior AND medical**: Select both tags to see only comments tagged with either
2. **Export filtered results**: Admin can export only comments matching specific criteria
3. **Quick overview**: Visual indicator shows which filters are active

## Breaking Changes

None - backward compatible with existing API