### PR TITLE
feat: Add GroupMe integration foundation (models + roadmap)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,46 @@ To create a vibrant, easy-to-use platform that connects shelter volunteers with 
 
 ---
 
-### 2. Test Coverage Improvements (Priority: P1)
+### 2. GroupMe Integration for Announcements (Priority: P1)
+
+**As a** group coordinator  
+**I want to** send announcements to GroupMe in addition to (or instead of) email  
+**So that** volunteers can receive notifications on their preferred communication channel
+
+**Acceptance Criteria:**
+- [ ] Add GroupMe bot ID configuration per group
+- [ ] Add "Send to GroupMe" checkbox on announcement creation form
+- [ ] Send announcement to configured GroupMe bot(s) when checkbox is selected
+- [ ] Support sending to both email AND GroupMe simultaneously
+- [ ] Admin UI to configure GroupMe bot IDs for each group
+- [ ] Error handling and logging for failed GroupMe sends
+- [ ] Display GroupMe send status in announcement history
+
+**Success Metrics:** 80%+ adoption by groups with active GroupMe chats  
+**Target Release:** v1.1.0  
+**Status:** In Progress (Branch: feature/groupme-integration)
+
+**Technical Requirements:**
+- Backend:
+  - Add `GroupMeBotID` and `GroupMeEnabled` fields to Group model
+  - Add `SendGroupMe` field to Announcement model
+  - Create GroupMe service with bot API integration
+  - Update announcement handler to support multi-channel delivery
+- Frontend:
+  - Add GroupMe checkbox to announcement creation form
+  - Add GroupMe bot configuration to admin group settings
+  - Display GroupMe status indicators
+
+**Implementation Notes:**
+- Uses GroupMe Bot API (POST to `https://api.groupme.com/v3/bots/post`)
+- Each group has its own GroupMe bot ID (configured per group)
+- Announcements are broadcast to all groups with GroupMe enabled
+- Supports both "Email only", "GroupMe only", or "Both" options
+- Bot IDs stored securely in database (not in code)
+
+---
+
+### 3. Test Coverage Improvements (Priority: P1)
 
 **As a** development team  
 **I want to** increase backend test coverage to 80%+  

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,19 +27,21 @@ type User struct {
 
 // Group represents a volunteer group (dogs, cats, modsquad, etc.)
 type Group struct {
-	ID           uint           `gorm:"primaryKey" json:"id"`
-	CreatedAt    time.Time      `json:"created_at"`
-	UpdatedAt    time.Time      `json:"updated_at"`
-	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
-	Name         string         `gorm:"uniqueIndex;not null" json:"name"`
-	Description  string         `json:"description"`
-	ImageURL     string         `json:"image_url"`
-	HeroImageURL string         `json:"hero_image_url"`
-	HasProtocols bool           `gorm:"default:false" json:"has_protocols"` // Enable protocols feature for this group
-	Users        []User         `gorm:"many2many:user_groups;" json:"users,omitempty"`
-	Animals      []Animal       `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
-	Updates      []Update       `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
-	Protocols    []Protocol     `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
+	ID            uint           `gorm:"primaryKey" json:"id"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	Name          string         `gorm:"uniqueIndex;not null" json:"name"`
+	Description   string         `json:"description"`
+	ImageURL      string         `json:"image_url"`
+	HeroImageURL  string         `json:"hero_image_url"`
+	HasProtocols  bool           `gorm:"default:false" json:"has_protocols"` // Enable protocols feature for this group
+	GroupMeBotID  string         `json:"groupme_bot_id"`                     // GroupMe Bot ID for sending messages
+	GroupMeEnabled bool          `gorm:"default:false" json:"groupme_enabled"` // Enable GroupMe integration for this group
+	Users         []User         `gorm:"many2many:user_groups;" json:"users,omitempty"`
+	Animals       []Animal       `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
+	Updates       []Update       `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
+	Protocols     []Protocol     `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
 }
 
 // Animal represents an animal in a group
@@ -114,15 +116,16 @@ type Update struct {
 
 // Announcement represents a site-wide announcement/update
 type Announcement struct {
-	ID        uint           `gorm:"primaryKey" json:"id"`
-	CreatedAt time.Time      `gorm:"index:idx_announcement_created" json:"created_at"`
-	UpdatedAt time.Time      `json:"updated_at"`
-	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
-	UserID    uint           `gorm:"not null;index" json:"user_id"`
-	Title     string         `gorm:"not null" json:"title"`
-	Content   string         `gorm:"not null" json:"content"`
-	SendEmail bool           `gorm:"default:false" json:"send_email"`
-	User      User           `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	ID          uint           `gorm:"primaryKey" json:"id"`
+	CreatedAt   time.Time      `gorm:"index:idx_announcement_created" json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID      uint           `gorm:"not null;index" json:"user_id"`
+	Title       string         `gorm:"not null" json:"title"`
+	Content     string         `gorm:"not null" json:"content"`
+	SendEmail   bool           `gorm:"default:false" json:"send_email"`
+	SendGroupMe bool           `gorm:"default:false" json:"send_groupme"`
+	User        User           `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }
 
 // AnimalComment represents a comment on an animal (social media style)


### PR DESCRIPTION
## Summary
Adds foundation for GroupMe integration with announcements, allowing multi-channel notification delivery (email, GroupMe, or both). This PR contains the database models and roadmap documentation for implementation.

## Changes

### Models (`internal/models/models.go`)
**Group Model:**
- ✅ Added `GroupMeBotID` field - stores bot ID for GroupMe API integration
- ✅ Added `GroupMeEnabled` field - enables/disables GroupMe for each group
- Each group can have its own GroupMe bot configuration

**Announcement Model:**
- ✅ Added `SendGroupMe` field - checkbox option for sending to GroupMe
- Works alongside existing `SendEmail` field for multi-channel delivery

### Roadmap (`ROADMAP.md`)
- ✅ Added "GroupMe Integration for Announcements" to "Now" (Q4 2025) section
- Priority: P1 (high team demand)
- Target: v1.1.0
- Status: In Progress
- Includes full acceptance criteria, technical requirements, and implementation notes

## Implementation Plan (for follow-up PRs)

### Backend (Next)
1. Create GroupMe service (`internal/groupme/groupme.go`)
   - POST to `https://api.groupme.com/v3/bots/post`
   - Bot ID from group configuration
   - Error handling and retries
2. Update announcement handler (`internal/handlers/announcement.go`)
   - Add `SendGroupMe` to `AnnouncementRequest`
   - Send to GroupMe when enabled
   - Support simultaneous email + GroupMe
3. Update group handler for bot configuration
   - Admin endpoint to set GroupMe bot ID per group

### Frontend (Next)
1. Announcement form updates
   - Add "Send to GroupMe" checkbox
   - Show both email and GroupMe options
2. Admin group settings
   - Add GroupMe bot ID input field
   - Enable/disable GroupMe per group
   - Validation and help text
3. Status indicators
   - Show which channels announcement was sent to

## Use Cases

**Email Only (existing):**
```json
{
  "title": "Important Update",
  "content": "Message here",
  "send_email": true,
  "send_groupme": false
}
```

**GroupMe Only:**
```json
{
  "title": "Quick Alert",
  "content": "Message here",
  "send_email": false,
  "send_groupme": true
}
```

**Both Channels:**
```json
{
  "title": "Critical Announcement",
  "content": "Message here",
  "send_email": true,
  "send_groupme": true
}
```

## Database Migration

GORM will auto-migrate the new fields:
- `groups.groupme_bot_id` (string, nullable)
- `groups.groupme_enabled` (boolean, default: false)
- `announcements.send_groupme` (boolean, default: false)

No manual migration required.

## Testing Plan (for implementation)
- [ ] Unit tests for GroupMe service
- [ ] Handler tests with both channels
- [ ] E2E test: create announcement with GroupMe enabled
- [ ] Verify bot ID configuration in admin UI
- [ ] Test error handling (invalid bot ID, API failures)

## GroupMe Bot Setup (Admin Documentation)

1. Create a GroupMe bot at: https://dev.groupme.com/bots
2. Select the group to integrate with
3. Copy the Bot ID (long string like `abc123def456...`)
4. In app admin settings, paste bot ID for the group
5. Enable GroupMe integration
6. Test with an announcement

## Success Metrics
- 80%+ adoption by groups with active GroupMe chats
- <3s delivery time for GroupMe messages
- <1% failed send rate

## Risks & Mitigations
- **Risk:** GroupMe API rate limits
  - **Mitigation:** Implement exponential backoff, queue messages
- **Risk:** Invalid bot IDs break announcements
  - **Mitigation:** Validate bot ID format, graceful error handling
- **Risk:** GroupMe changes API
  - **Mitigation:** Version locking, API monitoring

## Notes
- This PR is **non-breaking** - existing announcements continue to work
- GroupMe is opt-in per group (default: disabled)
- Bot IDs stored in database (not environment variables)
- Each group needs its own GroupMe bot created separately

## Next Steps
1. Merge this PR (models + roadmap)
2. Implement GroupMe service (backend)
3. Update announcement handler
4. Add frontend UI
5. Write tests
6. Deploy and test with real GroupMe group

## Questions?
- GroupMe Bot API docs: https://dev.groupme.com/docs/v3
- Bot creation: https://dev.groupme.com/bots