### PR TITLE
Fix: Correct GroupMe bot ID validation to 26 characters

### DIFF
--- a/internal/handlers/group.go
+++ b/internal/handlers/group.go
@@ -27,12 +27,12 @@ type GroupRequest struct {
 	GroupMeEnabled bool   `json:"groupme_enabled"`
 }
 
-// isValidGroupMeBotID validates the GroupMe bot ID format (40-char hex string)
+// isValidGroupMeBotID validates the GroupMe bot ID format (26-char hex string)
 func isValidGroupMeBotID(id string) bool {
 	if id == "" {
 		return true // allow empty (not configured)
 	}
-	if len(id) != 40 {
+	if len(id) != 26 {
 		return false
 	}
 	for _, c := range id {
@@ -175,7 +175,7 @@ func CreateGroup(db *gorm.DB) gin.HandlerFunc {
 
 		// Validate GroupMeBotID
 		if !isValidGroupMeBotID(req.GroupMeBotID) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid GroupMe bot ID. Must be a 40-character hexadecimal string."})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid GroupMe bot ID. Must be a 26-character hexadecimal string."})
 			return
 		}
 
@@ -221,7 +221,7 @@ func UpdateGroup(db *gorm.DB) gin.HandlerFunc {
 		group.HasProtocols = req.HasProtocols
 		// Validate GroupMeBotID
 		if !isValidGroupMeBotID(req.GroupMeBotID) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid GroupMe bot ID. Must be a 40-character hexadecimal string."})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid GroupMe bot ID. Must be a 26-character hexadecimal string."})
 			return
 		}
 		group.GroupMeBotID = req.GroupMeBotID

--- a/internal/handlers/group_test.go
+++ b/internal/handlers/group_test.go
@@ -444,7 +444,7 @@ func TestCreateGroup(t *testing.T) {
 			name: "accepts valid GroupMe bot id",
 			payload: map[string]interface{}{
 				"name":           "GroupMe Valid",
-				"groupme_bot_id": "0123456789abcdef0123456789abcdef01234567",
+				"groupme_bot_id": "abcdef0123456789abcdef0123",
 			},
 			expectedStatus: http.StatusCreated,
 			checkFunc: func(t *testing.T, db *gorm.DB, w *httptest.ResponseRecorder) {
@@ -452,7 +452,7 @@ func TestCreateGroup(t *testing.T) {
 				if err := json.Unmarshal(w.Body.Bytes(), &group); err != nil {
 					t.Fatalf("Failed to unmarshal response: %v", err)
 				}
-				if group.GroupMeBotID != "0123456789abcdef0123456789abcdef01234567" {
+				if group.GroupMeBotID != "abcdef0123456789abcdef0123" {
 					t.Errorf("Expected GroupMeBotID to be set, got '%s'", group.GroupMeBotID)
 				}
 			},
@@ -581,7 +581,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 			payload: map[string]interface{}{
 				"name":           "GroupMe Update",
-				"groupme_bot_id": "0123456789abcdef0123456789abcdef01234567",
+				"groupme_bot_id": "abcdef0123456789abcdef0123",
 			},
 			expectedStatus: http.StatusOK,
 			checkFunc: func(t *testing.T, db *gorm.DB, groupID uint) {
@@ -589,7 +589,7 @@ func TestUpdateGroup(t *testing.T) {
 				if err := db.First(&group, groupID).Error; err != nil {
 					t.Fatalf("Failed to find updated group: %v", err)
 				}
-				if group.GroupMeBotID != "0123456789abcdef0123456789abcdef01234567" {
+				if group.GroupMeBotID != "abcdef0123456789abcdef0123" {
 					t.Errorf("Expected GroupMeBotID to be set, got '%s'", group.GroupMeBotID)
 				}
 			},
@@ -883,12 +883,13 @@ func TestIsValidGroupMeBotID(t *testing.T) {
 		want bool
 	}{
 		{"empty is valid", "", true},
-		{"valid lowercase hex", "0123456789abcdef0123456789abcdef01234567", true},
-		{"valid uppercase hex", "0123456789ABCDEF0123456789ABCDEF01234567", true},
+		{"valid lowercase hex", "0123456789abcdef0123456789", true},
+		{"valid uppercase hex", "0123456789ABCDEF0123456789", true},
+		{"valid mixed case", "0123456789aBcDeF0123456789", true},
 		{"too short", "0123456789abcdef", false},
 		{"too long", "0123456789abcdef0123456789abcdef0123456789abcdef", false},
-		{"non-hex char", "0123456789abcdef0123456789abcdef0123456g", false},
-		{"special chars", "0123456789abcdef0123456789abcdef0123456!", false},
+		{"non-hex char", "0123456789abcdef012345678g", false},
+		{"special chars", "0123456789abcdef012345678!", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem
GroupMe bot IDs are 26-character hexadecimal strings, but our validation was incorrectly checking for 40 characters. This caused valid bot IDs from dev.groupme.com to be rejected.

## Solution
- Updated `isValidGroupMeBotID` function to check for 26 characters instead of 40
- Updated error messages to reflect the correct format
- Updated all test cases with proper 26-character hex test values
- All tests passing (52/52)

## Changes
- `internal/handlers/group.go`: Fixed validation length from 40 to 26 characters
- `internal/handlers/group_test.go`: Updated test cases to use 26-character test IDs

## Testing
- ✅ Unit tests for `isValidGroupMeBotID` validation function
- ✅ Handler tests for `CreateGroup` with invalid/valid bot IDs
- ✅ Handler tests for `UpdateGroup` with invalid/valid bot IDs
- ✅ All 52 tests passing

## Validation Rules
- Empty string: ✅ Allowed (group not configured for GroupMe)
- 26 characters: ✅ Required length
- Hexadecimal only: ✅ Characters 0-9, a-f, A-F
- Case insensitive: ✅ Both uppercase and lowercase accepted