### PR TITLE
Make protocol documents publicly accessible

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -120,6 +120,8 @@ func main() {
 
 	// Serve images from database (public endpoint, no auth required)
 	api.GET("/images/:uuid", handlers.ServeImage(db))
+	// Serve protocol documents (public, no auth required)
+	api.GET("/documents/:uuid", handlers.ServeAnimalProtocolDocument(db))
 
 	// Public routes (with rate limiting for auth endpoints)
 	authLimiter := middleware.RateLimit(5, 1*time.Minute) // 5 requests per minute
@@ -157,8 +159,8 @@ func main() {
 		// Image upload (authenticated users only) - stores in database
 		protected.POST("/animals/upload-image", handlers.UploadAnimalImageSimple(db))
 
-		// Document serving route (accessible by authenticated users)
-		protected.GET("/documents/:uuid", handlers.ServeAnimalProtocolDocument(db))
+		// Document serving route (PUBLIC): protocol documents should be viewable by anyone
+		// Moved to public API routes above to remove auth requirement
 
 		// Statistics routes (accessible by authenticated users, filtered by permissions)
 		protected.GET("/statistics/comment-tags", handlers.GetCommentTagStatistics(db))


### PR DESCRIPTION
## Summary
Protocol documents (PDFs) should be viewable by anyone via shared link. This PR moves `/api/documents/:uuid` to public API routes to remove the auth requirement.

## Changes
- Move `GET /api/documents/:uuid` from protected routes to public routes in `cmd/api/main.go`
- Keep existing image serving (`/api/images/:uuid`) consistent with public access

## Rationale
- Group admins reported 401 errors when viewing protocol documents
- Protocol documents are intended to be accessible without login for volunteers and external viewers

## Testing
- From a logged-out browser, request `/api/documents/{uuid}` → should return 200 and the document
- Logged-in users continue to have access (no change needed)

## Security Considerations
- Documents are identified by UUID; public access is acceptable per product requirements
- No write or listing endpoints exposed; only direct GET by UUID is public

## Roadmap Impact
None — aligns behavior with current UX expectations and permissions