### PR TITLE
fix: make default tag seeding idempotent

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -3,6 +3,11 @@ package database
 import (
 	"os"
 	"testing"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestInitialize_EnvDefaults(t *testing.T) {
@@ -61,5 +66,65 @@ func TestInitialize_InvalidSSLMode(t *testing.T) {
 		if len(err.Error()) < len(expected) || err.Error()[:len(expected)] != expected {
 			t.Errorf("Expected error to start with '%s', got: %v", expected, err)
 		}
+	}
+}
+
+func TestCreateDefaultAnimalTags_RestoresSoftDeletedTag(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+
+	if err := db.AutoMigrate(&models.Group{}, &models.AnimalTag{}); err != nil {
+		t.Fatalf("failed to automigrate: %v", err)
+	}
+
+	group := models.Group{Name: "modsquad"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	if err := createDefaultAnimalTags(db); err != nil {
+		t.Fatalf("createDefaultAnimalTags failed: %v", err)
+	}
+
+	var iso models.AnimalTag
+	if err := db.Where("group_id = ? AND name = ?", group.ID, "iso").First(&iso).Error; err != nil {
+		t.Fatalf("failed to find iso tag: %v", err)
+	}
+
+	if iso.DeletedAt.Valid {
+		t.Fatalf("expected iso tag to be not deleted")
+	}
+
+	if err := db.Delete(&iso).Error; err != nil {
+		t.Fatalf("failed to soft-delete iso tag: %v", err)
+	}
+
+	// Ensure the soft-delete took effect.
+	var softDeleted models.AnimalTag
+	if err := db.Unscoped().Where("group_id = ? AND name = ?", group.ID, "iso").First(&softDeleted).Error; err != nil {
+		t.Fatalf("failed to find soft-deleted iso tag: %v", err)
+	}
+	if !softDeleted.DeletedAt.Valid {
+		t.Fatalf("expected iso tag to be soft-deleted")
+	}
+
+	// Guard against any clock precision edge cases.
+	if softDeleted.DeletedAt.Time.After(time.Now().Add(5 * time.Second)) {
+		t.Fatalf("unexpected deleted_at in the future: %v", softDeleted.DeletedAt.Time)
+	}
+
+	// Re-running default creation should restore (undelete) the tag instead of failing on uniqueness.
+	if err := createDefaultAnimalTags(db); err != nil {
+		t.Fatalf("createDefaultAnimalTags (second run) failed: %v", err)
+	}
+
+	var restored models.AnimalTag
+	if err := db.Unscoped().Where("group_id = ? AND name = ?", group.ID, "iso").First(&restored).Error; err != nil {
+		t.Fatalf("failed to find restored iso tag: %v", err)
+	}
+	if restored.DeletedAt.Valid {
+		t.Fatalf("expected iso tag to be restored (deleted_at cleared)")
 	}
 }


### PR DESCRIPTION
## Summary
Fixes startup migration failures when a default tag (e.g., `iso`) exists but is soft-deleted.

- Uses an upsert to avoid `unique constraint` violations under concurrent migrations
- Restores soft-deleted default tags by clearing `deleted_at`
- Adds a regression test for the soft-delete restoration case

## Roadmap Impact
None