### PR TITLE
ci: disable automatic test workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test Suite
 
 on:
-  pull_request:
-    branches: [ main, develop ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Disables automatic runs of the heavy test suite workflow to avoid spending GitHub Actions minutes while the suite is expected to fail.

Change:
- `.github/workflows/test.yml` now triggers only via `workflow_dispatch` (manual runs).

Re-enable later by restoring the `pull_request` trigger.
