### PR TITLE
fix: allow blob: in CSP frame-src

### DIFF
--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -538,6 +538,7 @@ func TestSecurityHeaders(t *testing.T) {
 			// Verify CSP contains key directives
 			expectedCSPDirectives := []string{
 				"default-src 'self'",
+				"frame-src 'self' blob:",
 				"frame-ancestors 'none'",
 				"base-uri 'self'",
 			}

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -25,6 +25,7 @@ func SecurityHeaders() gin.HandlerFunc {
 			"style-src 'self' 'unsafe-inline'; " +
 			"img-src 'self' data: blob: https:; " +
 			"font-src 'self' data:; " +
+			"frame-src 'self' blob:; " +
 			"connect-src 'self'; " +
 			"frame-ancestors 'none'; " +
 			"base-uri 'self'; " +


### PR DESCRIPTION
Fixes CSP blocking `blob:` iframe URLs (needed for protocol PDF preview which uses a Blob URL in an `<iframe>`).

**Change**
- Adds `frame-src 'self' blob:` to `Content-Security-Policy`
- Updates middleware test expectation

**Testing**
- `go test ./internal/middleware -run TestSecurityHeaders`