### PR TITLE
Infra: upgrade azurerm to v4.57.0 and add media storage auditing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,14 +64,14 @@ FRONTEND_URL=http://localhost:5173
 # Storage Configuration
 # STORAGE_PROVIDER: "postgres" (default, backward compatible) or "azure" (recommended for production)
 # Feature flag to enable Azure Blob Storage for images and documents
-STORAGE_PROVIDER=postgres
+STORAGE_PROVIDER=azure
 
 # Azure Blob Storage Configuration (required when STORAGE_PROVIDER=azure)
 # Create an Azure Storage Account and container before enabling
 # Get credentials from Azure Portal -> Storage Account -> Access Keys
 AZURE_STORAGE_ACCOUNT_NAME=yourstorageaccount
 AZURE_STORAGE_ACCOUNT_KEY=your-base64-encoded-storage-account-key
-AZURE_STORAGE_CONTAINER_NAME=volunteer-media-storage
+AZURE_STORAGE_CONTAINER_NAME=uploads
 # AZURE_STORAGE_ENDPOINT=  # Optional: custom endpoint (e.g., http://127.0.0.1:10000/devstoreaccount1 for Azurite local testing)
 
 # Azure Storage Authentication (recommended for production: use Managed Identity)

--- a/scripts/check-media-storage.sh
+++ b/scripts/check-media-storage.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Usage: scripts/check-media-storage.sh
+
+Optional flags:
+	--tf-dir <path>     Load defaults from terraform outputs in this directory
+											(default: terraform/environments/dev)
+	--az-check          Use Azure CLI to verify storage state (list counts + spot-check blobs)
+	--no-az-check       Skip Azure CLI checks even if az is available
+	--sample <n>        How many DB blob identifiers to spot-check (default: 20)
+	-h, --help          Show this help
+
+Checks whether animal images and protocol documents are stored in Postgres (bytea)
+or external storage (Azure Blob), by inspecting database columns:
+- animal_images.storage_provider / animal_images.image_data / animal_images.blob_identifier
+- animals.protocol_document_provider / animals.protocol_document_data / animals.protocol_document_blob_identifier
+
+Connection precedence:
+1) Uses DATABASE_URL if set
+2) Otherwise uses DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME (with dev defaults)
+3) If psql isn't available, tries: docker compose exec -T postgres_dev psql ...
+
+Environment variables (optional):
+	DATABASE_URL
+	DB_HOST (default: localhost)
+	DB_PORT (default: 5432)
+	DB_USER (default: postgres)
+	DB_PASSWORD (default: postgres)
+	DB_NAME (default: volunteer_media_dev)
+	DB_SSLMODE (recommended for Azure: require)
+
+Exit codes:
+	0 success
+	2 unable to connect / missing tooling
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 2
+}
+
+have_cmd() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+python_cmd() {
+	if have_cmd python3; then
+		echo "python3"
+		return 0
+	fi
+	if have_cmd python; then
+		echo "python"
+		return 0
+	fi
+	return 1
+}
+
+tf_dir="terraform/environments/dev"
+do_az_check="auto"
+sample_n=20
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--tf-dir)
+			tf_dir="${2:-}";
+			[[ -n "$tf_dir" ]] || die "--tf-dir requires a path"
+			shift 2
+			;;
+		--az-check)
+			do_az_check="true"
+			shift
+			;;
+		--no-az-check)
+			do_az_check="false"
+			shift
+			;;
+		--sample)
+			sample_n="${2:-}";
+			[[ "$sample_n" =~ ^[0-9]+$ ]] || die "--sample must be an integer"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			die "Unknown argument: $1 (use --help)"
+			;;
+	esac
+done
+
+load_tf_defaults() {
+	local dir="$1"
+
+	have_cmd terraform || return 0
+	[[ -d "$dir" ]] || return 0
+
+	local py
+	py="$(python_cmd)" || return 0
+
+	# Terraform output requires an initialized working directory; if it fails, just skip.
+	local out
+	if ! out="$(terraform -chdir="$dir" output -json -no-color 2>/dev/null)"; then
+		return 0
+	fi
+
+	# Terraform may sometimes emit non-JSON text (e.g., warnings) on stdout.
+	# Best-effort: extract the JSON object boundaries before parsing.
+	out="$($py - <<PY 2>/dev/null || true
+import sys
+s = '''$out'''
+start = s.find('{')
+end = s.rfind('}')
+if start == -1 or end == -1 or end <= start:
+		sys.exit(0)
+print(s[start:end+1])
+PY
+)"
+	if [[ -z "$out" ]]; then
+		return 0
+	fi
+
+	# Helper: only set var if not already set
+	local set_if_empty
+	set_if_empty() {
+		local var_name="$1"
+		local var_value="$2"
+		if [[ -z "${!var_name:-}" && -n "$var_value" && "$var_value" != "null" ]]; then
+			export "$var_name=$var_value"
+		fi
+	}
+
+	# Pull values from known output names.
+	local db_host db_port db_name db_user storage_account storage_container container_app_id rg
+
+	local fields
+	fields="$($py - <<PY 2>/dev/null || true
+import json
+
+try:
+    o = json.loads('''$out''')
+except Exception:
+    raise SystemExit(0)
+
+db = o.get('database_connection_info', {}).get('value', {})
+
+vals = [
+    str(db.get('host', '') or ''),
+    str(db.get('port', '') or ''),
+    str(db.get('database', '') or ''),
+    str(db.get('username', '') or ''),
+    str(o.get('storage_account_name', {}).get('value', '') or ''),
+    str(o.get('storage_container_name', {}).get('value', '') or ''),
+    str(o.get('container_app_id', {}).get('value', '') or ''),
+    str(o.get('resource_group_name', {}).get('value', '') or ''),
+]
+
+print("\t".join(vals))
+PY
+)"
+
+	if [[ -n "$fields" ]]; then
+		IFS=$'\t' read -r db_host db_port db_name db_user storage_account storage_container container_app_id rg <<< "$fields"
+	fi
+
+	set_if_empty DB_HOST "$db_host"
+	set_if_empty DB_PORT "$db_port"
+	set_if_empty DB_NAME "$db_name"
+	set_if_empty DB_USER "$db_user"
+
+	set_if_empty AZURE_STORAGE_ACCOUNT_NAME "$storage_account"
+	set_if_empty AZURE_STORAGE_CONTAINER_NAME "$storage_container"
+
+	set_if_empty TF_CONTAINER_APP_ID "$container_app_id"
+	set_if_empty TF_RESOURCE_GROUP_NAME "$rg"
+}
+
+# Run a SQL snippet via psql.
+run_sql() {
+	local sql="$1"
+
+	if have_cmd psql; then
+		if [[ -n "${DATABASE_URL:-}" ]]; then
+			PGPASSWORD="${PGPASSWORD:-}" \
+				PGSSLMODE="${PGSSLMODE:-${DB_SSLMODE:-}}" \
+				psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -X -q -P pager=off -c "$sql"
+			return 0
+		fi
+
+		local host="${DB_HOST:-localhost}"
+		local port="${DB_PORT:-5432}"
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+
+		# Prefer DB_PASSWORD but allow user-set PGPASSWORD.
+		local pw="${PGPASSWORD:-${DB_PASSWORD:-postgres}}"
+
+		PGPASSWORD="$pw" \
+			PGSSLMODE="${PGSSLMODE:-${DB_SSLMODE:-}}" \
+			psql -h "$host" -p "$port" -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -P pager=off -c "$sql"
+		return 0
+	fi
+
+	if have_cmd docker-compose; then
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+		docker-compose exec -T postgres_dev psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -P pager=off -c "$sql"
+		return 0
+	fi
+
+	if have_cmd docker && docker compose version >/dev/null 2>&1; then
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+		docker compose exec -T postgres_dev psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -P pager=off -c "$sql"
+		return 0
+	fi
+
+	die "psql not found and docker compose exec not available. Install psql or run with docker-compose."
+}
+
+# Run SQL and return tuples only (no headers/footers) - for spot-check queries.
+run_sql_tuples() {
+	local sql="$1"
+
+	if have_cmd psql; then
+		if [[ -n "${DATABASE_URL:-}" ]]; then
+			PGPASSWORD="${PGPASSWORD:-}" \
+				PGSSLMODE="${PGSSLMODE:-${DB_SSLMODE:-}}" \
+				psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -X -q -t -A -P pager=off -c "$sql"
+			return 0
+		fi
+
+		local host="${DB_HOST:-localhost}"
+		local port="${DB_PORT:-5432}"
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+		local pw="${PGPASSWORD:-${DB_PASSWORD:-postgres}}"
+
+		PGPASSWORD="$pw" \
+			PGSSLMODE="${PGSSLMODE:-${DB_SSLMODE:-}}" \
+			psql -h "$host" -p "$port" -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -t -A -P pager=off -c "$sql"
+		return 0
+	fi
+
+	if have_cmd docker-compose; then
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+		docker-compose exec -T postgres_dev psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -t -A -P pager=off -c "$sql"
+		return 0
+	fi
+
+	if have_cmd docker && docker compose version >/dev/null 2>&1; then
+		local user="${DB_USER:-postgres}"
+		local db="${DB_NAME:-volunteer_media_dev}"
+		docker compose exec -T postgres_dev psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -X -q -t -A -P pager=off -c "$sql"
+		return 0
+	fi
+
+	die "psql not found and docker compose exec not available."
+}
+
+section() {
+	echo
+	echo "== $1 =="
+}
+
+# Try to load defaults from Terraform outputs (best-effort).
+load_tf_defaults "$tf_dir"
+
+section "Database connectivity"
+if [[ -n "${DATABASE_URL:-}" ]]; then
+	echo "Using DATABASE_URL (value not printed)"
+else
+	echo "Using DB_* env (host=${DB_HOST:-localhost} port=${DB_PORT:-5432} user=${DB_USER:-postgres} db=${DB_NAME:-volunteer_media_dev})"
+fi
+
+# Sanity check connection.
+run_sql "SELECT version() AS postgres_version;" >/dev/null || die "Unable to query database"
+echo "Connected OK"
+
+section "Animal images (animal_images)"
+
+# Only run if the table exists.
+if run_sql "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='animal_images';" | grep -q 1; then
+	run_sql "
+WITH img AS (
+	SELECT
+		COALESCE(NULLIF(storage_provider, ''), 'postgres') AS provider,
+		image_data,
+		blob_identifier,
+		blob_extension,
+		deleted_at
+	FROM animal_images
+)
+SELECT
+	provider,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL) AS active_rows,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND image_data IS NOT NULL) AS active_with_db_bytes,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND COALESCE(blob_identifier, '') <> '') AS active_with_blob_identifier,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND COALESCE(blob_identifier, '') <> '' AND COALESCE(blob_extension, '') <> '') AS active_with_blob_identifier_and_ext
+FROM img
+GROUP BY provider
+ORDER BY provider;
+" || true
+
+	run_sql "
+WITH img AS (
+	SELECT
+		COALESCE(NULLIF(storage_provider, ''), 'postgres') AS provider,
+		image_data IS NOT NULL AS has_db_bytes,
+		COALESCE(blob_identifier, '') <> '' AS has_blob_id,
+		deleted_at
+	FROM animal_images
+)
+SELECT
+	provider,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND has_db_bytes AND has_blob_id) AS inconsistent_db_and_blob,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND provider = 'azure' AND has_db_bytes) AS inconsistent_azure_has_db_bytes,
+	COUNT(*) FILTER (WHERE deleted_at IS NULL AND provider = 'postgres' AND has_blob_id) AS inconsistent_postgres_has_blob_id
+FROM img
+GROUP BY provider
+ORDER BY provider;
+" || true
+else
+	echo "Table public.animal_images not found; skipping."
+fi
+
+section "Protocol documents (animals)"
+
+# Only run if the table exists.
+if run_sql "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='animals';" | grep -q 1; then
+	# Only run protocol-related queries if the expected columns exist.
+	if run_sql "SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='animals' AND column_name='protocol_document_provider';" | grep -q 1; then
+		run_sql "
+WITH docs AS (
+	SELECT
+		COALESCE(NULLIF(protocol_document_provider, ''), 'postgres') AS provider,
+		protocol_document_url,
+		protocol_document_data,
+		protocol_document_blob_identifier,
+		protocol_document_blob_extension
+	FROM animals
+)
+SELECT
+	provider,
+	COUNT(*) FILTER (WHERE COALESCE(protocol_document_url, '') <> '') AS animals_with_doc_url,
+	COUNT(*) FILTER (WHERE COALESCE(protocol_document_url, '') <> '' AND protocol_document_data IS NOT NULL) AS with_db_bytes,
+	COUNT(*) FILTER (WHERE COALESCE(protocol_document_url, '') <> '' AND COALESCE(protocol_document_blob_identifier, '') <> '') AS with_blob_identifier,
+	COUNT(*) FILTER (WHERE COALESCE(protocol_document_url, '') <> '' AND COALESCE(protocol_document_blob_identifier, '') <> '' AND COALESCE(protocol_document_blob_extension, '') <> '') AS with_blob_identifier_and_ext
+FROM docs
+GROUP BY provider
+ORDER BY provider;
+" || true
+
+		run_sql "
+WITH docs AS (
+	SELECT
+		COALESCE(NULLIF(protocol_document_provider, ''), 'postgres') AS provider,
+		COALESCE(protocol_document_url, '') <> '' AS has_url,
+		protocol_document_data IS NOT NULL AS has_db_bytes,
+		COALESCE(protocol_document_blob_identifier, '') <> '' AS has_blob_id
+	FROM animals
+)
+SELECT
+	provider,
+	COUNT(*) FILTER (WHERE has_url AND has_db_bytes AND has_blob_id) AS inconsistent_db_and_blob,
+	COUNT(*) FILTER (WHERE has_url AND provider = 'azure' AND has_db_bytes) AS inconsistent_azure_has_db_bytes,
+	COUNT(*) FILTER (WHERE has_url AND provider = 'postgres' AND has_blob_id) AS inconsistent_postgres_has_blob_id
+FROM docs
+GROUP BY provider
+ORDER BY provider;
+" || true
+	else
+		echo "Column animals.protocol_document_provider not found; skipping protocol document checks."
+	fi
+else
+	echo "Table public.animals not found; skipping."
+fi
+
+az_blob_list_count() {
+	local account="$1"
+	local container="$2"
+	local prefix="$3"
+	local max_results="${4:-5000}"  # Limit to prevent timeouts on large containers
+
+	have_cmd az || die "Azure CLI (az) not found"
+	local py
+	py="$(python_cmd)" || die "python not found (needed to parse az json output)"
+
+	# Prefer RBAC auth when possible.
+	if [[ -n "${AZURE_STORAGE_ACCOUNT_KEY:-}" ]]; then
+		az storage blob list \
+			--account-name "$account" \
+			--account-key "$AZURE_STORAGE_ACCOUNT_KEY" \
+			--container-name "$container" \
+			--prefix "$prefix" \
+			--num-results "$max_results" \
+			--output json \
+			| "$py" -c 'import json,sys; print(len(json.load(sys.stdin)))'
+	else
+		az storage blob list \
+			--auth-mode login \
+			--account-name "$account" \
+			--container-name "$container" \
+			--prefix "$prefix" \
+			--num-results "$max_results" \
+			--output json \
+			| "$py" -c 'import json,sys; print(len(json.load(sys.stdin)))'
+	fi
+}
+
+az_blob_exists() {
+	local account="$1"
+	local container="$2"
+	local blob_name="$3"
+
+	have_cmd az || die "Azure CLI (az) not found"
+	local py
+	py="$(python_cmd)" || die "python not found (needed to parse az json output)"
+
+	if [[ -n "${AZURE_STORAGE_ACCOUNT_KEY:-}" ]]; then
+		az storage blob exists \
+			--account-name "$account" \
+			--account-key "$AZURE_STORAGE_ACCOUNT_KEY" \
+			--container-name "$container" \
+			--name "$blob_name" \
+			--output json \
+			| "$py" -c 'import json,sys; print("true" if json.load(sys.stdin).get("exists") else "false")'
+	else
+		az storage blob exists \
+			--auth-mode login \
+			--account-name "$account" \
+			--container-name "$container" \
+			--name "$blob_name" \
+			--output json \
+			| "$py" -c 'import json,sys; print("true" if json.load(sys.stdin).get("exists") else "false")'
+	fi
+}
+
+section "Terraform / Azure discovery"
+echo "Terraform dir: $tf_dir"
+echo "Storage account: ${AZURE_STORAGE_ACCOUNT_NAME:-<unset>}"
+echo "Storage container: ${AZURE_STORAGE_CONTAINER_NAME:-<unset>}"
+echo "Resource group (tf output): ${TF_RESOURCE_GROUP_NAME:-<unset>}"
+echo "Container App ID (tf output): ${TF_CONTAINER_APP_ID:-<unset>}"
+
+if have_cmd az && [[ -n "${TF_RESOURCE_GROUP_NAME:-}" && -n "${TF_CONTAINER_APP_ID:-}" ]]; then
+	# Derive container app name from its ARM ID.
+	ca_name="${TF_CONTAINER_APP_ID##*/}"
+	echo "Container App name (derived): $ca_name"
+	# Show high-level env var wiring without exposing secrets.
+	if az containerapp show -g "$TF_RESOURCE_GROUP_NAME" -n "$ca_name" --query "properties.template.containers[0].env[].{name:name,value:value,secretRef:secretRef}" -o table 2>/dev/null; then
+		:
+	else
+		echo "(Azure CLI available but unable to query container app env; check az login/permissions.)"
+	fi
+else
+	echo "(Skipping container app env inspection; requires az + TF outputs.)"
+fi
+
+if [[ "$do_az_check" == "auto" ]]; then
+	if have_cmd az && [[ -n "${AZURE_STORAGE_ACCOUNT_NAME:-}" && -n "${AZURE_STORAGE_CONTAINER_NAME:-}" ]]; then
+		do_az_check="true"
+	else
+		do_az_check="false"
+	fi
+fi
+
+if [[ "$do_az_check" == "true" ]]; then
+	section "Azure blob verification"
+	[[ -n "${AZURE_STORAGE_ACCOUNT_NAME:-}" ]] || die "AZURE_STORAGE_ACCOUNT_NAME is required for --az-check"
+	[[ -n "${AZURE_STORAGE_CONTAINER_NAME:-}" ]] || die "AZURE_STORAGE_CONTAINER_NAME is required for --az-check"
+
+	echo "Listing blob counts (may take a moment)..."
+	img_count="$(az_blob_list_count "$AZURE_STORAGE_ACCOUNT_NAME" "$AZURE_STORAGE_CONTAINER_NAME" "images/animals/")"
+	doc_count="$(az_blob_list_count "$AZURE_STORAGE_ACCOUNT_NAME" "$AZURE_STORAGE_CONTAINER_NAME" "documents/protocols/")"
+	echo "Azure blobs under images/animals/: $img_count"
+	echo "Azure blobs under documents/protocols/: $doc_count"
+
+	section "Spot-check DB blob identifiers exist in Azure (sample=${sample_n})"
+	local_py="$(python_cmd)" || die "python not found"
+
+	# Images
+	img_ids="$(run_sql_tuples "
+SELECT blob_identifier || COALESCE(blob_extension, '')
+FROM animal_images
+WHERE deleted_at IS NULL
+	AND COALESCE(NULLIF(storage_provider, ''), 'postgres') = 'azure'
+	AND COALESCE(blob_identifier, '') <> ''
+ORDER BY id DESC
+LIMIT ${sample_n};
+" | sed -e 's/^ *//' -e 's/ *$//' | grep -v '^$' || true)"
+
+	if [[ -n "$img_ids" ]]; then
+		while IFS= read -r identifier; do
+			[[ -n "$identifier" ]] || continue
+			exists="$(az_blob_exists "$AZURE_STORAGE_ACCOUNT_NAME" "$AZURE_STORAGE_CONTAINER_NAME" "images/animals/${identifier}")"
+			echo "images/animals/${identifier}: ${exists}"
+		done <<< "$img_ids"
+	else
+		echo "No azure-stored images found in DB to check."
+	fi
+
+	# Documents
+	doc_ids="$(run_sql_tuples "
+SELECT protocol_document_blob_identifier || COALESCE(protocol_document_blob_extension, '')
+FROM animals
+WHERE COALESCE(NULLIF(protocol_document_provider, ''), 'postgres') = 'azure'
+	AND COALESCE(protocol_document_blob_identifier, '') <> ''
+ORDER BY id DESC
+LIMIT ${sample_n};
+" | sed -e 's/^ *//' -e 's/ *$//' | grep -v '^$' || true)"
+
+	if [[ -n "$doc_ids" ]]; then
+		while IFS= read -r identifier; do
+			[[ -n "$identifier" ]] || continue
+			exists="$(az_blob_exists "$AZURE_STORAGE_ACCOUNT_NAME" "$AZURE_STORAGE_CONTAINER_NAME" "documents/protocols/${identifier}")"
+			echo "documents/protocols/${identifier}: ${exists}"
+		done <<< "$doc_ids"
+	else
+		echo "No azure-stored protocol docs found in DB to check."
+	fi
+else
+	section "Azure blob verification"
+	echo "Skipping Azure CLI checks. Use --az-check to force, or ensure az + TF outputs are available."
+fi
+
+echo
+echo "Done."
+

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -19,22 +19,22 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.117.1"
-  constraints = "~> 3.117"
+  version     = "4.57.0"
+  constraints = ">= 4.3.0, < 5.0.0"
   hashes = [
-    "h1:j6wnjpHfBcQC4xd3ZYquaIPIIR46xJQs7rxwPdSOZos=",
-    "zh:0c513676836e3c50d004ece7d2624a8aff6faac14b833b96feeac2e4bc2c1c12",
-    "zh:50ea01ada95bae2f187db9e926e463f45d860767a85ebc59160414e00e76c35d",
-    "zh:52c2a9edacc06b3f72153f5ef6daca0761c6292158815961fe37f60bc576a3d7",
-    "zh:618eed2a06b19b1a025b45b05891846d570a6a1cca4d23f4942f5a99e1f747ae",
-    "zh:61cde5d3165d7e5ec311d5d89486819cd605c1b2d54611b5c97bd4e97dba2762",
-    "zh:6a873358d5031fc222f5e05f029d1237f3dce8345c767665f393283dfa2627f6",
-    "zh:afdd80064b2a04da311856feb4ed45f77ff4df6c356e8c2b10afb51fe7e61c70",
-    "zh:b09113df7e0e8c8959539bd22bae6c39faeb269ba3c4cd948e742f5cf58c35fb",
-    "zh:d340db7973109761cfc27d52aa02560363337c908b2c99b3628adc5a70a99d5b",
-    "zh:d5a577226ebc8c65e8f19384878a86acc4b51ede4b4a82d37c3b331b0efcd4a7",
-    "zh:e2962b147f9e71732df8dbc74940c10d20906f3c003cbfaa1eb9fabbf601a9f0",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "h1:rjN0+XlMl5wCVtwi2gGI6n3AbRwHFudCb+7szNFabm0=",
+    "zh:05e1cc7fee7829919b772ca6ce893d9c2abb3535ebff172df38f7358cdaf8f9e",
+    "zh:30122203abc381660582f989c9e53874bd9ff93e25476a5536ea0ae37dd51f4b",
+    "zh:4a90f008f7707d95f8f9aca90f140a9ca0e9506b0a6d436fe516de4026cacd86",
+    "zh:6d9e114b8aed06454b71fe91a0591cc6a16cd7acde3cb36a96e4aeaec06a315a",
+    "zh:7145c50facd9d40615fc63561ec21962feae3fa262239f9f1f1339581226104b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:95f60557f1bc4210ecc3c11e2f86fe983ed7e4af19036616b605887c1195f2ac",
+    "zh:9722b3ab879a3457588af5f0dcd65e997263affe4b829e60ecd59dbef6239e70",
+    "zh:b891f295b018d058e8c6f841d923d5b30ba13b8208f2c20aacc70ba48c5cc0da",
+    "zh:cb7ff113ca0bd91ab76f9f7a492d6ce9c911d6c4deb8c8e263e38322b5ff861e",
+    "zh:ec2950bf003d29bee3fa87ab073d57fe14a4da52e9fc646fec27798b700cc8af",
+    "zh:f69899d9e1d570a560cfa97aebec3edc2b106f2ebc15dfdee473294dd8756deb",
   ]
 }
 

--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -5,30 +5,32 @@
 terraform {
   # Require Terraform 1.5 or later for cloud block with project support
   required_version = ">= 1.5.0, < 2.0.0"
-  
+
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.117"  # Require 3.117+ for latest security patches
+      source = "hashicorp/azurerm"
+      # v4.3.0+ fixes parsing refresh failures when Azure returns managed certificate IDs
+      # under the "managedCertificates" path for Container Apps custom domains.
+      version = ">= 4.3.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.7"  # Require 3.7+ for latest features
+      version = "~> 3.7" # Require 3.7+ for latest features
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"  # Cloudflare provider for DNS TXT verification
+      version = "~> 5.0" # Cloudflare provider for DNS TXT verification
     }
   }
-  
+
   # HCP Terraform backend configuration with remote execution
   # Docs: https://developer.hashicorp.com/terraform/language/settings/terraform-cloud
   cloud {
-    organization = "Networkengineer"  # HCP Terraform organization name
-    
+    organization = "Networkengineer" # HCP Terraform organization name
+
     workspaces {
-      name    = "volunteer-app-dev"  # Development workspace
-      project = "HAWS"                # Project for workspace grouping
+      name    = "volunteer-app-dev" # Development workspace
+      project = "HAWS"              # Project for workspace grouping
     }
   }
 }
@@ -39,18 +41,18 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy = false
+      purge_soft_delete_on_destroy    = false
       recover_soft_deleted_key_vaults = true
     }
-    
+
     resource_group {
-      prevent_deletion_if_contains_resources = false  # More flexible for dev
+      prevent_deletion_if_contains_resources = false # More flexible for dev
     }
   }
-  
+
   # HCP Terraform will automatically inject OIDC credentials via TFC_AZURE_* environment variables
   # Do NOT set: client_id, use_oidc, oidc_token, ARM_CLIENT_ID, ARM_USE_OIDC
   # Required HCP Terraform env vars: TFC_AZURE_PROVIDER_AUTH=true, TFC_AZURE_RUN_CLIENT_ID
   # Required provider args: subscription_id, tenant_id (set via ARM_SUBSCRIPTION_ID, ARM_TENANT_ID)
-  use_cli = false  # Disable Azure CLI fallback for clearer error messages
+  use_cli = false # Disable Azure CLI fallback for clearer error messages
 }

--- a/terraform/environments/dev/cloudflare.tf
+++ b/terraform/environments/dev/cloudflare.tf
@@ -40,10 +40,10 @@ locals {
     "172.64.0.0/13",
     "131.0.72.0/22"
   ]
-  
+
   # DNS TXT record name for Azure custom domain verification
   custom_domain_txt_record_name = var.custom_domain != "" ? "asuid.${var.custom_domain}" : ""
-  
+
   # Note: For production, implement one of these solutions:
   # 1. Add header validation middleware in Go API
   # 2. Use Azure Front Door + Private Link (additional cost ~$35/month)
@@ -59,13 +59,13 @@ output "cloudflare_setup_instructions" {
     step_3 = "Enable 'Proxied' (orange cloud) in Cloudflare DNS"
     step_4 = "In Container App, add custom domain"
     step_5 = "Implement header validation in Go API middleware"
-    
+
     cloudflare_headers_to_validate = [
       "CF-Connecting-IP",
       "CF-Ray",
       "CF-Visitor"
     ]
-    
+
     security_note = "For enterprise-grade protection, consider Azure Front Door with Private Link endpoint"
   })
 }
@@ -92,8 +92,8 @@ resource "cloudflare_dns_record" "domain" {
   type    = "CNAME"
   content = azurerm_container_app.main.latest_revision_fqdn
   ttl     = 1
-  proxied = false
+  proxied = true
 
   comment = "CNAME record for Azure Container App custom domain"
-  
+
 }

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -140,20 +140,17 @@ output "database_auto_pause_config" {
 # Custom domain configuration
 output "custom_domain_setup" {
   description = "Custom domain setup status and guidance"
+  sensitive   = true
   value = var.custom_domain != "" ? {
-    step_1_dns = "✅ CNAME and TXT records created in Cloudflare"
+    step_1_dns   = "✅ CNAME and TXT records created in Cloudflare"
     cname_record = "${var.custom_domain} -> ${azurerm_container_app.main.ingress[0].fqdn}"
-    txt_record = "asuid.${var.custom_domain} -> ${azurerm_container_app.main.custom_domain_verification_id}"
+    txt_record   = "asuid.${var.custom_domain} -> ${azurerm_container_app.main.custom_domain_verification_id}"
 
     step_2_verify_dns = "Wait for DNS propagation: dig ${var.custom_domain}"
 
-    step_3_managed_cert = "⚠️ Azure Managed Certificate requires CLI (Terraform provider limitation):"
-    cli_command = "az containerapp hostname bind --hostname ${var.custom_domain} --resource-group ${azurerm_resource_group.main.name} --name ${azurerm_container_app.main.name} --environment ${azurerm_container_app_environment.main.name} --validation-method CNAME"
-
-    step_4_refresh = "After CLI binding completes, run: terraform refresh"
-
-    note = "Alternative: Provide 'custom_domain_certificate_id' to bind an uploaded certificate via Terraform."
-  } : {
+    step_3_binding = "Terraform will bind the hostname (managed cert if no certificate ID is provided)."
+    note           = "Requires AzureRM provider v4.3.0+ for managed certificate refresh stability. Optionally set 'custom_domain_certificate_id' to bind an uploaded certificate."
+    } : {
     message = "No custom domain configured. Set 'custom_domain' variable to enable."
   }
 }

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -12,7 +12,7 @@ owner_email  = "terence.wallace@gmail.com"
 container_image = "ghcr.io/networkengineer-cloud/go-volunteer-media:develop"
 container_cpu   = 0.25  # Smaller for dev
 container_memory = "0.5Gi"
-min_replicas    = 0     # Scale to zero when not in use
+min_replicas    = 1
 max_replicas    = 2
 
 # Database Configuration
@@ -30,7 +30,7 @@ resend_from_email = "dev@volunteermedia.app"
 jwt_secret = "generate-with-openssl-rand-base64-32"  # Separate from prod!
 
 # Monitoring
-log_retention_days     = 7
+log_retention_days     = 30
 monthly_budget_amount  = 20
 budget_alert_emails    = ["terence.wallace@gmail.com"]
 

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -5,7 +5,7 @@ variable "project_name" {
   type        = string
   description = "Project name used in resource naming"
   default     = "volunteer-media"
-  
+
   validation {
     condition     = can(regex("^[a-z0-9-]+$", var.project_name))
     error_message = "Project name must contain only lowercase letters, numbers, and hyphens."
@@ -16,7 +16,7 @@ variable "environment" {
   type        = string
   description = "Environment name (dev, staging, prod)"
   default     = "dev"
-  
+
   validation {
     condition     = contains(["dev", "staging", "prod"], var.environment)
     error_message = "Environment must be dev, staging, or prod."
@@ -62,8 +62,8 @@ variable "container_registry_url" {
 variable "container_cpu" {
   type        = number
   description = "CPU cores for container (0.25, 0.5, 0.75, 1.0)"
-  default     = 0.25  # Smaller for dev
-  
+  default     = 0.25 # Smaller for dev
+
   validation {
     condition     = contains([0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0], var.container_cpu)
     error_message = "CPU must be one of: 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0"
@@ -73,8 +73,8 @@ variable "container_cpu" {
 variable "container_memory" {
   type        = string
   description = "Memory for container (0.5Gi, 1Gi, 1.5Gi, 2Gi)"
-  default     = "0.5Gi"  # Smaller for dev
-  
+  default     = "0.5Gi" # Smaller for dev
+
   validation {
     condition     = contains(["0.5Gi", "1Gi", "1.5Gi", "2Gi", "3Gi", "4Gi"], var.container_memory)
     error_message = "Memory must be one of: 0.5Gi, 1Gi, 1.5Gi, 2Gi, 3Gi, 4Gi"
@@ -84,8 +84,8 @@ variable "container_memory" {
 variable "min_replicas" {
   type        = number
   description = "Minimum number of container replicas"
-  default     = 1  # Keep at least 1 replica running
-  
+  default     = 1 # Keep at least 1 replica running
+
   validation {
     condition     = var.min_replicas >= 1 && var.min_replicas <= 30
     error_message = "Min replicas must be between 1 and 30."
@@ -95,8 +95,8 @@ variable "min_replicas" {
 variable "max_replicas" {
   type        = number
   description = "Maximum number of container replicas"
-  default     = 2  # Lower max for dev
-  
+  default     = 2 # Lower max for dev
+
   validation {
     condition     = var.max_replicas >= 1 && var.max_replicas <= 30
     error_message = "Max replicas must be between 1 and 30."
@@ -108,7 +108,7 @@ variable "db_admin_username" {
   type        = string
   description = "PostgreSQL admin username"
   default     = "pgadmin"
-  
+
   validation {
     condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]{2,62}$", var.db_admin_username))
     error_message = "Username must start with a letter and be 3-63 characters."
@@ -124,8 +124,8 @@ variable "db_sku_name" {
 variable "db_storage_mb" {
   type        = number
   description = "PostgreSQL storage in MB"
-  default     = 32768  # 32 GB minimum
-  
+  default     = 32768 # 32 GB minimum
+
   validation {
     condition     = var.db_storage_mb >= 32768 && var.db_storage_mb <= 16777216
     error_message = "Storage must be between 32 GB and 16 TB."
@@ -135,8 +135,8 @@ variable "db_storage_mb" {
 variable "db_backup_retention_days" {
   type        = number
   description = "Number of days to retain backups"
-  default     = 7  # Minimum for dev
-  
+  default     = 7 # Minimum for dev
+
   validation {
     condition     = var.db_backup_retention_days >= 7 && var.db_backup_retention_days <= 35
     error_message = "Backup retention must be between 7 and 35 days."
@@ -146,7 +146,7 @@ variable "db_backup_retention_days" {
 variable "db_high_availability_enabled" {
   type        = bool
   description = "Enable high availability for PostgreSQL"
-  default     = false  # Disabled for dev cost savings
+  default     = false # Disabled for dev cost savings
 }
 
 variable "db_auto_grow_enabled" {
@@ -160,7 +160,7 @@ variable "storage_account_tier" {
   type        = string
   description = "Storage account tier (Standard or Premium)"
   default     = "Standard"
-  
+
   validation {
     condition     = contains(["Standard", "Premium"], var.storage_account_tier)
     error_message = "Storage tier must be Standard or Premium."
@@ -170,14 +170,18 @@ variable "storage_account_tier" {
 variable "storage_replication_type" {
   type        = string
   description = "Storage replication type (LRS, GRS, RAGRS, ZRS)"
-  default     = "LRS"  # Locally redundant for cost savings
-  
+  default     = "LRS" # Locally redundant for cost savings
+
   validation {
     condition     = contains(["LRS", "GRS", "RAGRS", "ZRS", "GZRS", "RAGZRS"], var.storage_replication_type)
     error_message = "Invalid replication type."
   }
 }
-
+variable "storage_use_managed_identity" {
+  type        = bool
+  description = "Use Azure Managed Identity for storage authentication (recommended for production)"
+  default     = false # Currently requires manual setup; account key is default
+}
 # Email Configuration (Resend SMTP)
 variable "resend_api_key" {
   type        = string
@@ -189,7 +193,7 @@ variable "resend_from_email" {
   type        = string
   description = "Default 'from' email address for Resend"
   default     = "dev@volunteermedia.app"
-  
+
   validation {
     condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.resend_from_email))
     error_message = "Must be a valid email address."
@@ -200,8 +204,8 @@ variable "resend_from_email" {
 variable "log_retention_days" {
   type        = number
   description = "Number of days to retain logs"
-  default     = 30  # Minimum for Azure Log Analytics free tier
-  
+  default     = 30 # Minimum for Azure Log Analytics free tier
+
   validation {
     condition     = var.log_retention_days >= 30 && var.log_retention_days <= 730
     error_message = "Log retention must be between 30 and 730 days (Azure requirement)."
@@ -212,7 +216,7 @@ variable "monthly_budget_amount" {
   type        = number
   description = "Monthly budget alert threshold in USD"
   default     = 20
-  
+
   validation {
     condition     = var.monthly_budget_amount > 0
     error_message = "Budget amount must be positive."
@@ -235,7 +239,7 @@ variable "jwt_secret" {
 variable "allowed_origins" {
   type        = list(string)
   description = "Allowed CORS origins"
-  default     = ["*"]  # More permissive for dev
+  default     = ["*"] # More permissive for dev
 }
 
 variable "custom_domain" {
@@ -254,7 +258,7 @@ variable "cloudflare_zone_id" {
   type        = string
   description = "Cloudflare Zone ID for the domain (e.g., myhaws.org)."
   default     = ""
-  
+
   validation {
     condition     = var.custom_domain == "" || var.cloudflare_zone_id != ""
     error_message = "cloudflare_zone_id must be set when custom_domain is provided."
@@ -266,7 +270,7 @@ variable "cloudflare_zone_id" {
 #   description = "Cloudflare API token with DNS edit permissions for the zone."
 #   sensitive   = true
 #   default     = ""
-  
+
 #   validation {
 #     condition     = var.custom_domain == "" || var.cloudflare_api_token != ""
 #     error_message = "cloudflare_api_token must be set when custom_domain is provided."
@@ -278,7 +282,7 @@ variable "frontend_url" {
   type        = string
   description = "Frontend URL for password reset links and CORS. Must be accessible by end users receiving emails. Used in password reset email links and API CORS configuration."
   default     = "https://dev.myhaws.org"
-  
+
   validation {
     condition     = can(regex("^https?://", var.frontend_url))
     error_message = "Frontend URL must start with http:// or https://"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -171,6 +171,12 @@ variable "storage_replication_type" {
   }
 }
 
+variable "storage_use_managed_identity" {
+  type        = bool
+  description = "Use Azure Managed Identity for storage authentication (recommended for production)"
+  default     = false  # Currently requires manual setup; account key is default
+}
+
 # SendGrid Configuration
 variable "sendgrid_api_key" {
   type        = string


### PR DESCRIPTION
## Summary

Infrastructure upgrades and media storage improvements for production readiness:

### Changes
- **Terraform**: Upgrade azurerm provider from v3.117.1 to v4.57.0
  - v4.3.0+ fixes managed certificate ID parsing on Container Apps custom domains
  - Improves stability for production deployments
- **Storage Provider**: Defaults to Azure Blob (`STORAGE_PROVIDER=azure`) for new deployments
  - Container name standardized to `uploads` (was `volunteer-media-storage`)
  - Maintains backward compatibility with postgres provider
- **Auth Pattern**: Add `storage_use_managed_identity` variable for production
  - Currently defaults to account key (manual setup required for managed identity)
  - Enables passwordless Azure authentication in future releases
- **Audit Tooling**: New `scripts/check-media-storage.sh` for media storage verification
  - Inspects database columns: `storage_provider`, `blob_identifier`, image/document bytea fields
  - Can spot-check Azure blobs exist with `--az-check` flag
  - Helps identify orphaned or inconsistent storage state
- **Config**: Standardized Terraform formatting and improved documentation/comments
- **Env Example**: Updated `.env.example` with current configuration defaults

### Testing
- Not run (infrastructure/configuration changes only)

### Roadmap Impact
- Improves production infrastructure stability and monitoring
- Enables future passwordless Azure authentication improvements