### PR TITLE
Fix Terraform prod env vars to match app and use Resend

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -267,9 +267,11 @@ resource "azurerm_container_app" "main" {
       memory = var.container_memory
 
       # Environment variables
+
+      # Application
       env {
-        name  = "GIN_MODE"
-        value = "release"
+        name  = "ENV"
+        value = "production"
       }
 
       env {
@@ -277,12 +279,29 @@ resource "azurerm_container_app" "main" {
         value = "8080"
       }
 
-      # Environment identifier for logging and monitoring
+      # Logging
       env {
-        name  = "ENV"
-        value = "production"
+        name  = "LOG_LEVEL"
+        value = "INFO"
       }
 
+      env {
+        name  = "LOG_FORMAT"
+        value = "json"
+      }
+
+      # Authentication
+      env {
+        name        = "JWT_SECRET"
+        secret_name = "jwt-secret"
+      }
+
+      env {
+        name  = "ALLOWED_ORIGINS"
+        value = join(",", var.allowed_origins)
+      }
+
+      # Database
       env {
         name  = "DB_HOST"
         value = azurerm_postgresql_flexible_server.main.fqdn
@@ -313,16 +332,15 @@ resource "azurerm_container_app" "main" {
         value = "require"
       }
 
-      # Database Logging (reduce verbosity)
       env {
         name  = "DB_LOG_LEVEL"
         value = "warn"
       }
 
-      # Email Configuration (DISABLED until ready)
+      # Email (Resend)
       env {
         name  = "EMAIL_ENABLED"
-        value = "false"
+        value = "true"
       }
 
       env {
@@ -330,67 +348,48 @@ resource "azurerm_container_app" "main" {
         value = "resend"
       }
 
-      # Frontend URL (for password reset links when email is enabled)
+      env {
+        name        = "RESEND_API_KEY"
+        secret_name = "resend-api-key"
+      }
+
+      env {
+        name  = "RESEND_FROM_EMAIL"
+        value = var.resend_from_email
+      }
+
+      env {
+        name  = "RESEND_FROM_NAME"
+        value = var.resend_from_name
+      }
+
       env {
         name  = "FRONTEND_URL"
         value = var.frontend_url
       }
 
-      # Resend SMTP Configuration (placeholder - email disabled)
+      # Storage (Azure Blob)
       env {
-        name  = "SMTP_HOST"
-        value = "smtp.resend.com"
+        name  = "STORAGE_PROVIDER"
+        value = "azure"
       }
 
       env {
-        name  = "SMTP_PORT"
-        value = "587"
-      }
-
-      env {
-        name  = "SMTP_USER"
-        value = "resend"
-      }
-
-      env {
-        name        = "SMTP_PASS"
-        secret_name = "resend-api-key"
-      }
-
-      env {
-        name  = "SMTP_FROM"
-        value = var.resend_from_email
-      }
-
-      # Azure Storage Configuration
-      env {
-        name  = "AZURE_STORAGE_ACCOUNT"
+        name  = "AZURE_STORAGE_ACCOUNT_NAME"
         value = azurerm_storage_account.main.name
       }
 
       env {
-        name        = "AZURE_STORAGE_KEY"
+        name        = "AZURE_STORAGE_ACCOUNT_KEY"
         secret_name = "storage-account-key"
       }
 
       env {
-        name  = "AZURE_STORAGE_CONTAINER"
+        name  = "AZURE_STORAGE_CONTAINER_NAME"
         value = azurerm_storage_container.uploads.name
       }
 
-      # JWT Secret
-      env {
-        name        = "JWT_SECRET"
-        secret_name = "jwt-secret"
-      }
-
-      # CORS Configuration
-      env {
-        name  = "ALLOWED_ORIGINS"
-        value = join(",", var.allowed_origins)
-      }
-
-      # Application Insights
+      # Monitoring
       env {
         name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
         value = azurerm_application_insights.main.connection_string

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -162,12 +162,11 @@ output "database_connection_info" {
 
 # Resend configuration (for verification)
 output "resend_configuration" {
-  description = "Resend SMTP configuration"
+  description = "Resend email configuration"
   value = {
-    smtp_host  = "smtp.resend.com"
-    smtp_port  = 587
-    smtp_user  = "resend"
+    provider   = "resend"
     from_email = var.resend_from_email
+    from_name  = var.resend_from_name
   }
 }
 

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -42,10 +42,11 @@ db_high_availability_enabled = false             # Set true for production HA
 storage_account_tier     = "Standard"
 storage_replication_type = "LRS"  # LRS for low cost, GRS for geo-redundancy
 
-# SendGrid Configuration
-# Get your API key from: https://app.sendgrid.com/settings/api_keys
-sendgrid_api_key    = "SG.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-sendgrid_from_email = "noreply@yourdomain.com"  # Must be verified in SendGrid
+# Resend Configuration
+# Get your API key from: https://resend.com
+resend_api_key    = "re_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+resend_from_email = "noreply@notifications.yourdomain.com"  # Must use a verified domain in Resend
+resend_from_name  = "Haws Volunteers"                       # Display name for email sender
 
 # Application Configuration
 # Generate a strong JWT secret: openssl rand -base64 32

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -194,6 +194,12 @@ variable "resend_from_email" {
   }
 }
 
+variable "resend_from_name" {
+  type        = string
+  description = "Display name for the email sender"
+  default     = "Haws Volunteers"
+}
+
 # Monitoring Configuration
 variable "log_retention_days" {
   type        = number


### PR DESCRIPTION
## Summary
- **Fix 3 wrong Azure Storage env var names** (`AZURE_STORAGE_ACCOUNT` → `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_KEY` → `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_STORAGE_CONTAINER` → `AZURE_STORAGE_CONTAINER_NAME`) — the app couldn't find these values
- **Switch email from SMTP to Resend API** — replace `SMTP_HOST/PORT/USER/PASS/FROM` with `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME` and enable `EMAIL_ENABLED=true`
- **Add missing production env vars** — `STORAGE_PROVIDER=azure` (app defaulted to postgres storage), `LOG_LEVEL=INFO`, `LOG_FORMAT=json`
- **Remove no-op `GIN_MODE`** — app hardcodes `gin.SetMode(gin.ReleaseMode)` in code

## Test plan
- [ ] Run `terraform plan` in prod workspace to verify no unexpected resource recreation
- [ ] Confirm new env var names match `os.Getenv()` calls in Go source (`internal/storage/storage.go`, `internal/email/resend_provider.go`)
- [ ] Verify Resend API key is set in HCP Terraform workspace variables
- [ ] Deploy and confirm email delivery works (trigger a password reset)
- [ ] Confirm Azure Blob storage is used for image uploads (not postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)