### PR TITLE
fix: Prevent duplicate key error on container restart

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -391,6 +391,7 @@ func createDefaultGroups(db *gorm.DB) error {
 	for _, group := range defaultGroups {
 		// Use upsert to avoid duplicate-key errors under concurrent migrations
 		// OnConflict will update description and has_protocols if group exists
+		// This intentionally updates existing modsquad groups to enable protocols
 		if err := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "name"}},
 			DoUpdates: clause.AssignmentColumns([]string{"description", "has_protocols"}),


### PR DESCRIPTION
## Problem

Container startup was failing with a fatal error:
```
ERROR: duplicate key value violates unique constraint "idx_groups_name" (SQLSTATE 23505)
failed to create default group activity-sandbox
```

This happened when:
- Containers restarted with persistent database volumes
- Running migrations multiple times
- The database already contained default groups

## Root Cause

The `createDefaultGroups()` function used a check-then-create pattern that wasn't idempotent:
1. Check if group exists with `db.Where().First()`
2. If not found, create with `db.Create()`

This pattern failed when the group existed, causing duplicate key constraint violations during restarts.

## Solution

### 1. Migration Fix (`database.go`)
- **Replaced** check-then-create with GORM's `OnConflict` upsert pattern
- **Removed** `activity-sandbox` from default migration groups
- **Kept** only `modsquad` as the essential production group
- **Removed** unused `errors` import

### 2. Test Support (`seed.go`)
- **Added** `ensureSandboxGroup()` to create test group when needed
- **Updated** `SeedData()` to ensure sandbox group exists before assignments
- **Updated** `ensureSandboxMembership()` to call `ensureSandboxGroup()` first

## Why This Approach?

✅ **Production migrations** only create essential default groups  
✅ **Test/dev environments** get sandbox group through seeding (`make seed`)  
✅ **Idempotent operations** prevent duplicate key errors on restarts  
✅ **Consistent pattern** matches how tags are handled (using upsert)

## Testing

### ✅ Backend Tests
All 12 Go test packages passed:
```
ok  internal/auth       1.984s
ok  internal/database   0.290s
ok  internal/handlers   15.768s
... (9 more packages)
```

### ✅ Migration Idempotency
Tested 3 consecutive runs simulating container restarts:
- ✅ Run 1: No duplicate key errors
- ✅ Run 2 (restart): No duplicate key errors  
- ✅ Run 3 (verify): Migrations are idempotent

### ✅ Database Integrity
Verified data structures after seeding:
```
Group Name       | Users | Animals
-----------------+-------+---------
modsquad         |   5   |   10
activity-sandbox |   4   |    0
```

### ✅ Container Startup
Server starts successfully without FATAL errors or constraint violations.

## Changes Summary

**Files Modified:**
- `internal/database/database.go` (33 lines: +12, -21)
- `internal/database/seed.go` (38 lines: +38)

**Commits:**
- `bb92485` - fix: Use upsert for default groups to prevent duplicate key errors
- `eb69ad6` - feat: Create activity-sandbox group during seeding for tests

## Checklist

- [x] All tests pass (`go test ./...`)
- [x] Migrations are idempotent (tested 3x)
- [x] No duplicate key errors on restart
- [x] Backward compatible (existing databases work)
- [x] Seed data creates test group correctly
- [x] Code follows project style guides
- [x] Commit messages follow conventions

## Roadmap Impact

This fix ensures stable container deployments and removes a blocker for production rollouts. The migration system is now more robust and follows best practices for idempotency.

**Suggested Roadmap Update:**
Move this to "Shipped" section under Infrastructure Improvements as it fixes a critical deployment issue.

Fixes the container startup failure reported on 2026-02-15.