### PR TITLE
fix: Correct View Profile link on group members tab

### DIFF
--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -985,7 +985,7 @@ const GroupPage: React.FC = () => {
                           </div>
                         )}
                       </div>
-                      <Link to={`/users/${member.user_id}`} className="btn-view-profile">
+                      <Link to={`/users/${member.user_id}/profile`} className="btn-view-profile">
                         View Profile
                       </Link>
                     </div>


### PR DESCRIPTION
## Summary
- Fixed the "View Profile" link on the group members tab navigating to `/users/:id` instead of `/users/:id/profile`, which caused a "No routes matched" error

## Test plan
- [ ] Navigate to a group page and click the "Members" tab
- [ ] Click "View Profile" on any member
- [ ] Confirm it navigates to `/users/{id}/profile` and renders the profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)