### PR TITLE
fix: Grant site admins full group admin UI access

### DIFF
--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -571,12 +571,7 @@ const AnimalDetailPage: React.FC = () => {
                   📷 Photo Gallery
                 </Link>
                 
-                {isAdmin && (
-                  <button onClick={handleEdit} className="btn-edit">
-                    Edit Animal Details
-                  </button>
-                )}
-                {!isAdmin && (membership?.is_group_admin) && (
+                {(isAdmin || membership?.is_group_admin) && (
                   <button onClick={handleEdit} className="btn-edit">
                     Edit Animal Details
                   </button>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -105,9 +105,9 @@ const GroupPage: React.FC = () => {
     const viewParam = searchParams.get('view') as ViewMode;
     if (viewParam && (viewParam === 'activity' || viewParam === 'animals' || viewParam === 'protocols')) {
       setViewMode(viewParam);
-    } else if (viewParam === 'members' && membership?.is_member) {
+    } else if (viewParam === 'members' && (membership?.is_member || membership?.is_site_admin)) {
       setViewMode(viewParam);
-    } else if (viewParam === 'members' && !membership?.is_member) {
+    } else if (viewParam === 'members' && !membership?.is_member && !membership?.is_site_admin) {
       setViewMode('activity');
     }
   }, [searchParams, membership]);
@@ -409,7 +409,7 @@ const GroupPage: React.FC = () => {
             <span>Protocols</span>
           </button>
         )}
-        {membership?.is_member && (
+        {(membership?.is_member || membership?.is_site_admin) && (
           <button
             role="tab"
             aria-selected={viewMode === 'members'}
@@ -430,7 +430,7 @@ const GroupPage: React.FC = () => {
       </div>
 
       {/* Group Admin Quick Links - shown only to group admins (site admins already have nav bar) */}
-      {membership?.is_group_admin && !membership?.is_site_admin && (
+      {(membership?.is_group_admin || membership?.is_site_admin) && (
         <div className="group-admin-links" role="navigation" aria-label="Group administration links">
           <span className="group-admin-links__title">Quick Actions:</span>
           <Link to={`/groups/${id}/animals/new`} className="group-admin-link">
@@ -930,7 +930,7 @@ const GroupPage: React.FC = () => {
       )}
 
       {/* Members View */}
-      {viewMode === 'members' && membership?.is_member && (
+      {viewMode === 'members' && (membership?.is_member || membership?.is_site_admin) && (
         <div
           role="tabpanel"
           id="members-panel"


### PR DESCRIPTION
## Summary
- Site admins now see the **Quick Actions** bar (Add Animal, Announcement, Manage Tags, Add Protocol) on group pages
- Site admins can view the **Members tab** even if they aren't a member of the group
- Consolidated duplicate "Edit Animal Details" button logic on the animal detail page

## Context
The backend (`checkGroupAdminAccess()`) already grants site admins full group admin permissions, but the frontend was inconsistently hiding UI elements from them. This aligns the frontend visibility checks with the backend authorization.

## Files Changed
- `frontend/src/pages/GroupPage.tsx` — 4 condition fixes (Members tab, Quick Actions, URL param handling, panel rendering)
- `frontend/src/pages/AnimalDetailPage.tsx` — Deduplicated edit button into single `(isAdmin || is_group_admin)` check

## Test plan
- [ ] Log in as `admin` (site admin) → navigate to modsquad group → verify Quick Actions bar and Members tab are visible
- [ ] Click Add Animal and confirm the form loads
- [ ] Navigate to an animal detail page and verify "Edit Animal Details" button appears
- [ ] Log in as `merry` (group admin) → verify all controls still work
- [ ] Log in as `terry` (regular volunteer) → verify admin controls are NOT shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)