### PR TITLE
fix: Embed frontend assets to fix CSS MIME type error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN go mod download && go mod verify
 # Copy source code
 COPY . .
 
+# Copy frontend dist so //go:embed can include it at compile time
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "-static"' -o /app/api ./cmd/api
 
@@ -55,9 +58,6 @@ COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy binary from backend builder
 COPY --from=backend-builder /app/api /api
-
-# Copy frontend build if it exists
-COPY --from=frontend-builder /app/frontend/dist /frontend/dist
 
 # Copy public directory for uploads and static assets
 COPY --from=backend-builder /app/public /public

--- a/frontend/embed.go
+++ b/frontend/embed.go
@@ -1,0 +1,6 @@
+package frontend
+
+import "embed"
+
+//go:embed dist
+var DistFS embed.FS


### PR DESCRIPTION
## Summary

- **Root cause**: In Docker, `router.Static("./frontend/dist/assets")` could fail silently, causing asset requests to fall through to the `NoRoute` handler which serves `index.html` as `text/html`. The `nosniff` header then caused browsers to block CSS files.
- Add `frontend/embed.go` with `//go:embed dist` to bake the SPA bundle directly into the binary
- Replace filesystem-based `router.Static`/`router.StaticFile` with `http.FS(embed.FS)` — Go's built-in MIME detection guarantees `.css` → `text/css; charset=utf-8`
- Update `Dockerfile` to copy `frontend/dist` into the backend-builder stage before `go build`, and remove the now-redundant copy to the final stage

## Test plan

- [ ] `docker build -t volunteer-media:test .` completes successfully
- [ ] `curl -I http://localhost:8080/assets/index-*.css` returns `Content-Type: text/css; charset=utf-8`
- [ ] `curl -I http://localhost:8080/` returns `Content-Type: text/html; charset=utf-8`
- [ ] `curl -I http://localhost:8080/some/spa/route` returns HTTP 200 with `text/html`
- [ ] `docker run --rm volunteer-media:test ls /frontend 2>&1` prints "No such file or directory" (dist no longer copied to final image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)