### PR TITLE
ux: session form escalation clarity + mobile fixes

### DIFF
--- a/frontend/src/components/SessionReportForm.css
+++ b/frontend/src/components/SessionReportForm.css
@@ -190,6 +190,13 @@
   gap: 0.5rem;
 }
 
+.concern-field label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
 .optional-label {
   font-weight: 400;
   font-size: 0.875rem;
@@ -285,6 +292,62 @@
   gap: 0.25rem;
 }
 
+/* Desktop form tabs */
+.session-form-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--neutral-200);
+  margin-bottom: 1.25rem;
+}
+
+.session-form-tab {
+  padding: 0.5rem 1.25rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  position: relative;
+  bottom: -2px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.session-form-tab:hover {
+  color: var(--brand);
+}
+
+.session-form-tab:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.session-form-tab--active {
+  color: var(--brand);
+  border-bottom-color: var(--brand);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .session-form-tabs {
+  border-bottom-color: var(--neutral-300);
+}
+
+.escalations-intro {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0 0 1rem;
+}
+
+.field-help-text {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: normal;
+}
+
 /* Concerns Row (side-by-side on desktop) */
 .concerns-row {
   display: grid;
@@ -304,12 +367,16 @@
 }
 
 .concern-field:has(#behavior-notes:focus),
-.concern-field:has(#behavior-notes:not(:placeholder-shown)) {
+.concern-field:has(#behavior-notes:not(:placeholder-shown)),
+.concern-field:has(#behavior-notes-mobile:focus),
+.concern-field:has(#behavior-notes-mobile:not(:placeholder-shown)) {
   border-left-color: var(--warning); /* Amber */
 }
 
 .concern-field:has(#medical-notes:focus),
-.concern-field:has(#medical-notes:not(:placeholder-shown)) {
+.concern-field:has(#medical-notes:not(:placeholder-shown)),
+.concern-field:has(#medical-notes-mobile:focus),
+.concern-field:has(#medical-notes-mobile:not(:placeholder-shown)) {
   border-left-color: var(--danger); /* Red */
 }
 
@@ -654,6 +721,10 @@ details[open] .tags-toggle::before {
 
   .tags-toggle::before {
     transition: none;
+  }
+
+  .accordion-content {
+    animation: none;
   }
 }
 

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -70,7 +70,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
   const tabOrder: Array<'session' | 'escalations'> = ['session', 'escalations'];
 
   const handleTabKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
-    let next = currentIndex;
+    let next: number;
     if (e.key === 'ArrowRight') next = (currentIndex + 1) % tabOrder.length;
     else if (e.key === 'ArrowLeft') next = (currentIndex - 1 + tabOrder.length) % tabOrder.length;
     else if (e.key === 'Home') next = 0;

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -66,6 +66,20 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
 
   // Desktop tab state
   const [desktopTab, setDesktopTab] = useState<'session' | 'escalations'>('session');
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tabOrder: Array<'session' | 'escalations'> = ['session', 'escalations'];
+
+  const handleTabKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
+    let next = currentIndex;
+    if (e.key === 'ArrowRight') next = (currentIndex + 1) % tabOrder.length;
+    else if (e.key === 'ArrowLeft') next = (currentIndex - 1 + tabOrder.length) % tabOrder.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = tabOrder.length - 1;
+    else return;
+    e.preventDefault();
+    setDesktopTab(tabOrder[next]);
+    tabRefs.current[next]?.focus();
+  };
 
   // Use refs to access current state in interval callback
   const stateRef = useRef({
@@ -757,24 +771,30 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
             {/* Desktop Tabs */}
             <div className="session-form-tabs" role="tablist">
               <button
+                ref={(el) => { tabRefs.current[0] = el; }}
                 type="button"
                 role="tab"
                 id="tab-session"
                 aria-selected={desktopTab === 'session'}
                 aria-controls="tabpanel-session"
+                tabIndex={desktopTab === 'session' ? 0 : -1}
                 className={`session-form-tab ${desktopTab === 'session' ? 'session-form-tab--active' : ''}`}
                 onClick={() => setDesktopTab('session')}
+                onKeyDown={(e) => handleTabKeyDown(e, 0)}
               >
                 📝 Session
               </button>
               <button
+                ref={(el) => { tabRefs.current[1] = el; }}
                 type="button"
                 role="tab"
                 id="tab-escalations"
                 aria-selected={desktopTab === 'escalations'}
                 aria-controls="tabpanel-escalations"
+                tabIndex={desktopTab === 'escalations' ? 0 : -1}
                 className={`session-form-tab ${desktopTab === 'escalations' ? 'session-form-tab--active' : ''}`}
                 onClick={() => setDesktopTab('escalations')}
+                onKeyDown={(e) => handleTabKeyDown(e, 1)}
               >
                 ⚠️ Escalations{getConcernCount() > 0 ? <span aria-hidden="true"> ({getConcernCount()})</span> : ''}
               </button>

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -62,7 +62,10 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
   const [autoAppliedTags, setAutoAppliedTags] = useState<number[]>([]);
   
   // Mobile accordion state
-  const [expandedSection, setExpandedSection] = useState<'timing' | 'goals' | 'concerns' | 'rating' | null>('goals');
+  const [expandedSection, setExpandedSection] = useState<'timing' | 'goals' | 'concerns' | 'rating' | null>('timing');
+
+  // Desktop tab state
+  const [desktopTab, setDesktopTab] = useState<'session' | 'escalations'>('session');
 
   // Use refs to access current state in interval callback
   const stateRef = useRef({
@@ -164,6 +167,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
     if (editingComment.metadata) {
       // Structured session report
       setMode('structured');
+      setDesktopTab(editingComment.metadata.behavior_notes || editingComment.metadata.medical_notes ? 'escalations' : 'session');
       setSessionGoal(editingComment.metadata.session_goal || '');
       setSessionOutcome(editingComment.metadata.session_outcome || '');
       setBehaviorNotes(editingComment.metadata.behavior_notes || '');
@@ -360,6 +364,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
       setSessionDate(getTodayDate());
       setSessionStartTime('');
       setSessionEndTime('');
+      setDesktopTab('session');
     }
   };
 
@@ -614,74 +619,6 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
               )}
             </div>
 
-            {/* Concerns Section */}
-            <div className="accordion-section">
-              <button
-                type="button"
-                className={`accordion-header ${expandedSection === 'concerns' ? 'expanded' : ''}`}
-                onClick={() => toggleSection('concerns')}
-                aria-expanded={expandedSection === 'concerns'}
-                data-testid="accordion-concerns"
-              >
-                <span className="accordion-icon">{expandedSection === 'concerns' ? '▼' : '▶'}</span>
-                <span className="accordion-title">⚠️ Concerns ({getConcernCount()})</span>
-              </button>
-              {expandedSection === 'concerns' && (
-                <div className="accordion-content">
-                  {/* Behavior Concerns */}
-                  <div className="form-field concern-field">
-                    <label htmlFor="behavior-notes-mobile">
-                      🐕 Behavior
-                    </label>
-                    <textarea
-                      id="behavior-notes-mobile"
-                      data-testid="behavior-concerns"
-                      placeholder="Any behavior observations?"
-                      value={behaviorNotes}
-                      onChange={(e) => setBehaviorNotes(e.target.value)}
-                      rows={3}
-                      maxLength={FIELD_LIMITS.behavior_notes}
-                      disabled={submitting}
-                      aria-label="Behavior concerns"
-                    />
-                    <span className="char-count">
-                      {behaviorNotes.length} / {FIELD_LIMITS.behavior_notes}
-                    </span>
-                    {behaviorNotes.trim() && findTagByType(availableTags, 'behavior') && (
-                      <span className="auto-tag-indicator" role="status">
-                        Auto-tag: 🏷️ behavior
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Medical Concerns */}
-                  <div className="form-field concern-field">
-                    <label htmlFor="medical-notes-mobile">
-                      🏥 Medical
-                    </label>
-                    <textarea
-                      id="medical-notes-mobile"
-                      placeholder="Any medical observations?"
-                      value={medicalNotes}
-                      onChange={(e) => setMedicalNotes(e.target.value)}
-                      rows={3}
-                      maxLength={FIELD_LIMITS.medical_notes}
-                      disabled={submitting}
-                      aria-label="Medical concerns"
-                    />
-                    <span className="char-count">
-                      {medicalNotes.length} / {FIELD_LIMITS.medical_notes}
-                    </span>
-                    {medicalNotes.trim() && findTagByType(availableTags, 'medical') && (
-                      <span className="auto-tag-indicator" role="status">
-                        Auto-tag: 🏷️ medical
-                      </span>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-
             {/* Rating & Notes Section */}
             <div className="accordion-section">
               <button
@@ -742,10 +679,108 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
                 </div>
               )}
             </div>
+
+            {/* Concerns Section */}
+            <div className="accordion-section">
+              <button
+                type="button"
+                className={`accordion-header ${expandedSection === 'concerns' ? 'expanded' : ''}`}
+                onClick={() => toggleSection('concerns')}
+                aria-expanded={expandedSection === 'concerns'}
+                data-testid="accordion-concerns"
+              >
+                <span className="accordion-icon">{expandedSection === 'concerns' ? '▼' : '▶'}</span>
+                <span className="accordion-title">{getConcernCount() > 0 ? '⚠️' : '📋'} Escalations ({getConcernCount()})</span>
+              </button>
+              {expandedSection === 'concerns' && (
+                <div className="accordion-content">
+                  <p className="escalations-intro">Only fill these in if there's something worth flagging — leave both blank for routine sessions.</p>
+                  {/* Behavior Concerns */}
+                  <div className="form-field concern-field">
+                    <label htmlFor="behavior-notes-mobile">
+                      🐕 Behavior
+                      <small className="field-help-text">For notable behavior observations — these can be filtered and shared with the team. Leave blank if nothing to flag.</small>
+                    </label>
+                    <textarea
+                      id="behavior-notes-mobile"
+                      data-testid="behavior-concerns"
+                      placeholder="Worth flagging to the behavior team?"
+                      value={behaviorNotes}
+                      onChange={(e) => setBehaviorNotes(e.target.value)}
+                      rows={3}
+                      maxLength={FIELD_LIMITS.behavior_notes}
+                      disabled={submitting}
+                      aria-label="Behavior concerns"
+                    />
+                    <span className="char-count">
+                      {behaviorNotes.length} / {FIELD_LIMITS.behavior_notes}
+                    </span>
+                    {behaviorNotes.trim() && findTagByType(availableTags, 'behavior') && (
+                      <span className="auto-tag-indicator" role="status">
+                        Auto-tag: 🏷️ behavior
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Medical Concerns */}
+                  <div className="form-field concern-field">
+                    <label htmlFor="medical-notes-mobile">
+                      🏥 Medical
+                      <small className="field-help-text">For health concerns worth flagging — these can be filtered and shared with staff. Leave blank if nothing to flag.</small>
+                    </label>
+                    <textarea
+                      id="medical-notes-mobile"
+                      placeholder="Any health concerns worth noting for staff?"
+                      value={medicalNotes}
+                      onChange={(e) => setMedicalNotes(e.target.value)}
+                      rows={3}
+                      maxLength={FIELD_LIMITS.medical_notes}
+                      disabled={submitting}
+                      aria-label="Medical concerns"
+                    />
+                    <span className="char-count">
+                      {medicalNotes.length} / {FIELD_LIMITS.medical_notes}
+                    </span>
+                    {medicalNotes.trim() && findTagByType(availableTags, 'medical') && (
+                      <span className="auto-tag-indicator" role="status">
+                        Auto-tag: 🏷️ medical
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Desktop Non-Accordion Layout */}
           <div className="desktop-only">
+            {/* Desktop Tabs */}
+            <div className="session-form-tabs" role="tablist">
+              <button
+                type="button"
+                role="tab"
+                id="tab-session"
+                aria-selected={desktopTab === 'session'}
+                aria-controls="tabpanel-session"
+                className={`session-form-tab ${desktopTab === 'session' ? 'session-form-tab--active' : ''}`}
+                onClick={() => setDesktopTab('session')}
+              >
+                📝 Session
+              </button>
+              <button
+                type="button"
+                role="tab"
+                id="tab-escalations"
+                aria-selected={desktopTab === 'escalations'}
+                aria-controls="tabpanel-escalations"
+                className={`session-form-tab ${desktopTab === 'escalations' ? 'session-form-tab--active' : ''}`}
+                onClick={() => setDesktopTab('escalations')}
+              >
+                ⚠️ Escalations{getConcernCount() > 0 ? <span aria-hidden="true"> ({getConcernCount()})</span> : ''}
+              </button>
+            </div>
+
+            {desktopTab === 'session' && <div role="tabpanel" id="tabpanel-session" aria-labelledby="tab-session">
             {/* Session Date + Time */}
             <div className="form-field">
               <label htmlFor="session-date">
@@ -850,60 +885,6 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
             </span>
           </div>
 
-          {/* Concerns (side-by-side on desktop) */}
-          <div className="concerns-row">
-            {/* Behavior Concerns */}
-            <div className="form-field concern-field">
-              <label htmlFor="behavior-notes">
-                ⚠️ Behavior Concerns
-              </label>
-              <textarea
-                id="behavior-notes"
-                data-testid="behavior-concerns"
-                placeholder="Any behavior observations to note?"
-                value={behaviorNotes}
-                onChange={(e) => setBehaviorNotes(e.target.value)}
-                rows={3}
-                maxLength={FIELD_LIMITS.behavior_notes}
-                disabled={submitting}
-                aria-label="Behavior concerns"
-              />
-              <span className="char-count">
-                {behaviorNotes.length} / {FIELD_LIMITS.behavior_notes}
-              </span>
-              {behaviorNotes.trim() && findTagByType(availableTags, 'behavior') && (
-                <span className="auto-tag-indicator" role="status">
-                  Auto-tag: 🏷️ behavior
-                </span>
-              )}
-            </div>
-
-            {/* Medical Concerns */}
-            <div className="form-field concern-field">
-              <label htmlFor="medical-notes">
-                🏥 Medical Concerns
-              </label>
-              <textarea
-                id="medical-notes"
-                placeholder="Any health or medical observations?"
-                value={medicalNotes}
-                onChange={(e) => setMedicalNotes(e.target.value)}
-                rows={3}
-                maxLength={FIELD_LIMITS.medical_notes}
-                disabled={submitting}
-                aria-label="Medical concerns"
-              />
-              <span className="char-count">
-                {medicalNotes.length} / {FIELD_LIMITS.medical_notes}
-              </span>
-              {medicalNotes.trim() && findTagByType(availableTags, 'medical') && (
-                <span className="auto-tag-indicator" role="status">
-                  Auto-tag: 🏷️ medical
-                </span>
-              )}
-            </div>
-          </div>
-
           {/* Session Rating */}
           <div className="form-field">
             <label>⭐ Session Success</label>
@@ -948,6 +929,66 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
               {otherNotes.length} / {FIELD_LIMITS.other_notes}
             </span>
           </div>
+          </div>}
+
+          {desktopTab === 'escalations' && <div role="tabpanel" id="tabpanel-escalations" aria-labelledby="tab-escalations">
+            <p className="escalations-intro">Only fill these in if there's something worth flagging — leave both blank for routine sessions.</p>
+            {/* Concerns (side-by-side on desktop) */}
+            <div className="concerns-row">
+              {/* Behavior Concerns */}
+              <div className="form-field concern-field">
+                <label htmlFor="behavior-notes">
+                  🐕 Behavior Escalation
+                  <small className="field-help-text">For notable behavior observations — these can be filtered and shared with the team.</small>
+                </label>
+                <textarea
+                  id="behavior-notes"
+                  data-testid="behavior-concerns-desktop"
+                  placeholder="Worth flagging to the behavior team?"
+                  value={behaviorNotes}
+                  onChange={(e) => setBehaviorNotes(e.target.value)}
+                  rows={3}
+                  maxLength={FIELD_LIMITS.behavior_notes}
+                  disabled={submitting}
+                  aria-label="Behavior concerns"
+                />
+                <span className="char-count">
+                  {behaviorNotes.length} / {FIELD_LIMITS.behavior_notes}
+                </span>
+                {behaviorNotes.trim() && findTagByType(availableTags, 'behavior') && (
+                  <span className="auto-tag-indicator" role="status">
+                    Auto-tag: 🏷️ behavior
+                  </span>
+                )}
+              </div>
+
+              {/* Medical Concerns */}
+              <div className="form-field concern-field">
+                <label htmlFor="medical-notes">
+                  🏥 Medical Escalation
+                  <small className="field-help-text">For health concerns worth flagging — these can be filtered and shared with staff.</small>
+                </label>
+                <textarea
+                  id="medical-notes"
+                  placeholder="Any health concerns worth noting for staff?"
+                  value={medicalNotes}
+                  onChange={(e) => setMedicalNotes(e.target.value)}
+                  rows={3}
+                  maxLength={FIELD_LIMITS.medical_notes}
+                  disabled={submitting}
+                  aria-label="Medical concerns"
+                />
+                <span className="char-count">
+                  {medicalNotes.length} / {FIELD_LIMITS.medical_notes}
+                </span>
+                {medicalNotes.trim() && findTagByType(availableTags, 'medical') && (
+                  <span className="auto-tag-indicator" role="status">
+                    Auto-tag: 🏷️ medical
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>}
           </div>
         </div>
       )}

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -649,6 +649,7 @@
 
   .group-tab {
     white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .quick-actions-bar {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',


### PR DESCRIPTION
## Summary

- **Session form escalation fields** renamed and reworded to communicate they're for flagging notable issues only — not routine notes. Labels updated to "Behavior Escalation" / "Medical Escalation" with helper text and an intro paragraph on both desktop and mobile
- **Desktop tab split** — session form now has two tabs: 📝 Session (date/time, goal, outcome, rating, notes) and ⚠️ Escalations (behavior + medical fields), with full ARIA wiring
- **Mobile accordion reorder** — Escalations moved to last position; Session Timing is now the default open section
- **Mobile tab bar fix** (`GroupPage.css`) — `flex-shrink: 0` prevents tab labels from compressing and overlapping on narrow viewports
- **Vite `host: true`** — binds dev server to all interfaces for Tailscale local dev access

## Accessibility & UX improvements (from code review)

- ARIA: `role="tabpanel"`, `aria-controls`, `aria-labelledby` wiring on desktop tabs
- Desktop tab count badge wrapped in `aria-hidden` to prevent screen reader interruption mid-typing
- `⚠️` emoji on mobile accordion header only shown when escalation content exists
- Escalations intro paragraph added to mobile accordion (was desktop-only)
- `prefers-reduced-motion` now suppresses accordion slide animation
- `:focus-visible` ring added to desktop session form tabs
- Dark mode tab separator contrast improved (`--neutral-300` instead of `--neutral-200`)
- Fixed `.concern-field:has()` left-border selectors to cover mobile field IDs (pre-existing bug)

## Test plan

- [ ] Desktop: session form shows two tabs; Session tab contains date/time/goal/outcome/rating/notes; Escalations tab shows intro paragraph and both fields side-by-side
- [ ] Desktop: submitting resets to Session tab; editing a comment with escalation content opens on Escalations tab
- [ ] Mobile (< 640px): accordion order is Timing → Goals → Rating → Escalations; Timing opens by default
- [ ] Mobile: Escalations accordion shows intro paragraph when expanded; `📋` icon when empty, `⚠️` when filled
- [ ] Mobile: GroupPage tabs scroll horizontally without text overlap on narrow viewports
- [ ] Keyboard: tab buttons have visible focus ring
- [ ] Dark mode: tab separator is visible
- [ ] `prefers-reduced-motion`: accordion opens without animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)