### PR TITLE
ux: hide additional tags when no custom tags exist

### DIFF
--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import type { AnimalComment, CommentTag, SessionMetadata } from '../api/client';
 import './SessionReportForm.css';
 
@@ -60,7 +60,9 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
   
   // Track which tags were auto-applied vs manually selected
   const [autoAppliedTags, setAutoAppliedTags] = useState<number[]>([]);
-  
+
+  const customTags = useMemo(() => availableTags.filter(t => !t.is_system), [availableTags]);
+
   // Mobile accordion state
   const [expandedSection, setExpandedSection] = useState<'timing' | 'goals' | 'concerns' | 'rating' | null>('timing');
 
@@ -289,6 +291,13 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
       setAutoAppliedTags(newAutoAppliedTags);
     }
   }, [behaviorNotes, medicalNotes, availableTags]);
+
+  // Remove manually selected custom tags if they disappear from availableTags
+  useEffect(() => {
+    if (customTags.length === 0) {
+      setSelectedTags(prev => prev.filter(id => autoAppliedTags.includes(id)));
+    }
+  }, [customTags, autoAppliedTags]);
 
   const findTagByType = (tags: CommentTag[], type: 'behavior' | 'medical'): CommentTag | null => {
     // 1. First, try exact name match (case-insensitive)
@@ -1031,7 +1040,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
       )}
 
       {/* Tags Selection (both modes) - only shown when non-system tags exist */}
-      {availableTags.some(t => !t.is_system) && (
+      {customTags.length > 0 && (
         <div className="tags-section">
           <details>
             <summary className="tags-toggle">
@@ -1039,7 +1048,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
             </summary>
             <div className="tags-content">
               <div className="tags-grid">
-                {availableTags.filter(t => !t.is_system).map((tag) => (
+                {customTags.map((tag) => (
                   <label key={tag.id} className="tag-checkbox-label">
                     <input
                       type="checkbox"

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -425,6 +425,8 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
     return count;
   };
 
+  const manuallySelectedTags = selectedTags.filter(id => !autoAppliedTags.includes(id));
+
   return (
     <form onSubmit={handleSubmit} className="session-report-form">
       {/* Draft Restore Prompt */}
@@ -1032,54 +1034,56 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
       {availableTags.some(t => !t.is_system) && (
         <div className="tags-section">
           <details>
-            <summary className="tags-toggle">🏷️ Additional Tags {selectedTags.filter(id => !autoAppliedTags.includes(id)).length > 0 && `(${selectedTags.filter(id => !autoAppliedTags.includes(id)).length})`}</summary>
+            <summary className="tags-toggle">
+              🏷️ Additional Tags {manuallySelectedTags.length > 0 && `(${manuallySelectedTags.length})`}
+            </summary>
             <div className="tags-content">
               <div className="tags-grid">
-                  {availableTags.filter(t => !t.is_system).map((tag) => (
-                    <label key={tag.id} className="tag-checkbox-label">
-                      <input
-                        type="checkbox"
-                        checked={selectedTags.includes(tag.id)}
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            setSelectedTags([...selectedTags, tag.id]);
-                          } else {
-                            setSelectedTags(selectedTags.filter(id => id !== tag.id));
-                          }
-                        }}
-                        disabled={submitting}
-                      />
-                      <span className="tag-badge" style={{ backgroundColor: tag.color }}>
-                        {tag.name}
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-            </details>
-
-            {selectedTags.filter(id => !autoAppliedTags.includes(id)).length > 0 && (
-              <div className="selected-tags-preview">
-                {selectedTags.filter(id => !autoAppliedTags.includes(id)).map(tagId => {
-                  const tag = availableTags.find(t => t.id === tagId);
-                  return tag ? (
-                    <span key={tagId} className="tag-badge" style={{ backgroundColor: tag.color }}>
+                {availableTags.filter(t => !t.is_system).map((tag) => (
+                  <label key={tag.id} className="tag-checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={selectedTags.includes(tag.id)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setSelectedTags([...selectedTags, tag.id]);
+                        } else {
+                          setSelectedTags(selectedTags.filter(id => id !== tag.id));
+                        }
+                      }}
+                      disabled={submitting}
+                    />
+                    <span className="tag-badge" style={{ backgroundColor: tag.color }}>
                       {tag.name}
-                      <button
-                        type="button"
-                        className="remove-tag"
-                        onClick={() => setSelectedTags(selectedTags.filter(t => t !== tagId))}
-                        aria-label={`Remove ${tag.name} tag`}
-                      >
-                        ×
-                      </button>
                     </span>
-                  ) : null;
-                })}
+                  </label>
+                ))}
               </div>
-            )}
-          </div>
-        )}
+            </div>
+          </details>
+
+          {manuallySelectedTags.length > 0 && (
+            <div className="selected-tags-preview">
+              {manuallySelectedTags.map(tagId => {
+                const tag = availableTags.find(t => t.id === tagId);
+                return tag ? (
+                  <span key={tagId} className="tag-badge" style={{ backgroundColor: tag.color }}>
+                    {tag.name}
+                    <button
+                      type="button"
+                      className="remove-tag"
+                      onClick={() => setSelectedTags(selectedTags.filter(t => t !== tagId))}
+                      aria-label={`Remove ${tag.name} tag`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ) : null;
+              })}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Submit Button */}
       <div className="form-actions">

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -1028,7 +1028,8 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
         </div>
       )}
 
-      {/* Tags Selection (both modes) */}
+      {/* Tags Selection (both modes) - only shown when non-system tags exist */}
+      {availableTags.some(t => !t.is_system) && (
       <div className="tags-section">
         <details>
           <summary className="tags-toggle">🏷️ Additional Tags {selectedTags.length > 0 && `(${selectedTags.length})`}</summary>
@@ -1078,6 +1079,7 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
           </div>
         )}
       </div>
+      )}
 
       {/* Submit Button */}
       <div className="form-actions">

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -1030,56 +1030,56 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
 
       {/* Tags Selection (both modes) - only shown when non-system tags exist */}
       {availableTags.some(t => !t.is_system) && (
-      <div className="tags-section">
-        <details>
-          <summary className="tags-toggle">🏷️ Additional Tags {selectedTags.length > 0 && `(${selectedTags.length})`}</summary>
-          <div className="tags-content">
-            <div className="tags-grid">
-              {availableTags.map((tag) => (
-                <label key={tag.id} className="tag-checkbox-label">
-                  <input
-                    type="checkbox"
-                    checked={selectedTags.includes(tag.id)}
-                    onChange={(e) => {
-                      if (e.target.checked) {
-                        setSelectedTags([...selectedTags, tag.id]);
-                      } else {
-                        setSelectedTags(selectedTags.filter(id => id !== tag.id));
-                      }
-                    }}
-                    disabled={submitting}
-                  />
-                  <span className="tag-badge" style={{ backgroundColor: tag.color }}>
-                    {tag.name}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-        </details>
-        
-        {selectedTags.length > 0 && (
-          <div className="selected-tags-preview">
-            {selectedTags.map(tagId => {
-              const tag = availableTags.find(t => t.id === tagId);
-              return tag ? (
-                <span key={tagId} className="tag-badge" style={{ backgroundColor: tag.color }}>
-                  {tag.name}
-                  <button
-                    type="button"
-                    className="remove-tag"
-                    onClick={() => setSelectedTags(selectedTags.filter(t => t !== tagId))}
-                    aria-label={`Remove ${tag.name} tag`}
-                  >
-                    ×
-                  </button>
-                </span>
-              ) : null;
-            })}
+        <div className="tags-section">
+          <details>
+            <summary className="tags-toggle">🏷️ Additional Tags {selectedTags.filter(id => !autoAppliedTags.includes(id)).length > 0 && `(${selectedTags.filter(id => !autoAppliedTags.includes(id)).length})`}</summary>
+            <div className="tags-content">
+              <div className="tags-grid">
+                  {availableTags.filter(t => !t.is_system).map((tag) => (
+                    <label key={tag.id} className="tag-checkbox-label">
+                      <input
+                        type="checkbox"
+                        checked={selectedTags.includes(tag.id)}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setSelectedTags([...selectedTags, tag.id]);
+                          } else {
+                            setSelectedTags(selectedTags.filter(id => id !== tag.id));
+                          }
+                        }}
+                        disabled={submitting}
+                      />
+                      <span className="tag-badge" style={{ backgroundColor: tag.color }}>
+                        {tag.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </details>
+
+            {selectedTags.filter(id => !autoAppliedTags.includes(id)).length > 0 && (
+              <div className="selected-tags-preview">
+                {selectedTags.filter(id => !autoAppliedTags.includes(id)).map(tagId => {
+                  const tag = availableTags.find(t => t.id === tagId);
+                  return tag ? (
+                    <span key={tagId} className="tag-badge" style={{ backgroundColor: tag.color }}>
+                      {tag.name}
+                      <button
+                        type="button"
+                        className="remove-tag"
+                        onClick={() => setSelectedTags(selectedTags.filter(t => t !== tagId))}
+                        aria-label={`Remove ${tag.name} tag`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ) : null;
+                })}
+              </div>
+            )}
           </div>
         )}
-      </div>
-      )}
 
       {/* Submit Button */}
       <div className="form-actions">

--- a/frontend/src/components/SessionReportForm.tsx
+++ b/frontend/src/components/SessionReportForm.tsx
@@ -292,12 +292,11 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
     }
   }, [behaviorNotes, medicalNotes, availableTags]);
 
-  // Remove manually selected custom tags if they disappear from availableTags
+  // Drop any selected tag IDs that no longer exist in availableTags
   useEffect(() => {
-    if (customTags.length === 0) {
-      setSelectedTags(prev => prev.filter(id => autoAppliedTags.includes(id)));
-    }
-  }, [customTags, autoAppliedTags]);
+    const validIds = new Set(availableTags.map(t => t.id));
+    setSelectedTags(prev => prev.filter(id => validIds.has(id)));
+  }, [availableTags]);
 
   const findTagByType = (tags: CommentTag[], type: 'behavior' | 'medical'): CommentTag | null => {
     // 1. First, try exact name match (case-insensitive)
@@ -434,7 +433,10 @@ const SessionReportForm: React.FC<SessionReportFormProps> = ({
     return count;
   };
 
-  const manuallySelectedTags = selectedTags.filter(id => !autoAppliedTags.includes(id));
+  const manuallySelectedTags = useMemo(
+    () => selectedTags.filter(id => !autoAppliedTags.includes(id)),
+    [selectedTags, autoAppliedTags],
+  );
 
   return (
     <form onSubmit={handleSubmit} className="session-report-form">


### PR DESCRIPTION
## Summary
- The \"Additional Tags\" section in the session report form is now hidden unless the group has at least one custom (non-system) tag configured
- Behavior and medical tags are system tags (`is_system: true`) that get auto-applied — there's no reason to show the manual tag picker for them
- No visual changes for groups with custom tags

## Test Plan
- [ ] Confirm \"Additional Tags\" section does not appear when only behavior/medical tags exist
- [ ] Confirm section appears normally once a group admin adds a custom tag