### PR TITLE
fix: send email notifications for bite quarantine announcements

### DIFF
--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -541,9 +541,9 @@ const AnimalForm: React.FC = () => {
         `Details:\n${quarantineContext}\n\n` +
         `#behavior`;
 
-      // Create group update (shows in activity feed) with GroupMe notification
+      // Create group update (shows in activity feed) with email and GroupMe notification
       // Parameters: (groupId, title, content, send_email, send_groupme, image_url?)
-      await updatesApi.create(parseInt(groupId), updateTitle, updateContent, false, true);
+      await updatesApi.create(parseInt(groupId), updateTitle, updateContent, true, true);
 
       toast.showSuccess('Animal updated, comment added, and announcement posted successfully!');
       setShowQuarantineModal(false);

--- a/internal/handlers/update_test.go
+++ b/internal/handlers/update_test.go
@@ -252,6 +252,54 @@ func TestCreateUpdateWithSendEmailFlagForNonAdminIsForcedFalse(t *testing.T) {
 	assert.False(t, created.SendEmail)
 }
 
+// TestCreateUpdateWithSendEmailFlagForGroupAdminIsAllowed covers the bite quarantine
+// announcement path: the frontend sends send_email:true as a group admin, and the
+// backend must preserve that flag so opted-in users receive the notification.
+func TestCreateUpdateWithSendEmailFlagForGroupAdminIsAllowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	defer func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	}()
+
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Group{}, &models.Update{}, &models.UserGroup{}))
+
+	groupAdmin := models.User{Username: "gadmin", Email: "gadmin@example.com", Password: "hashed", IsAdmin: false}
+	require.NoError(t, db.Create(&groupAdmin).Error)
+
+	group := models.Group{Name: "Test Group", Description: "desc"}
+	require.NoError(t, db.Create(&group).Error)
+
+	require.NoError(t, db.Create(&models.UserGroup{UserID: groupAdmin.ID, GroupID: group.ID, IsGroupAdmin: true}).Error)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	reqBody := UpdateRequest{
+		Title:     "🚨 Bite Quarantine: Max",
+		Content:   "Max has been placed in bite quarantine.\n\n#behavior",
+		SendEmail: true,
+	}
+	bodyBytes, _ := json.Marshal(reqBody)
+	c.Request = httptest.NewRequest("POST", "/groups/1/updates", bytes.NewBuffer(bodyBytes))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user_id", groupAdmin.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatUint(uint64(group.ID), 10)}}
+
+	handler := CreateUpdate(db, email.NewService(db), groupme.NewService())
+	handler(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var created models.Update
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	assert.True(t, created.SendEmail, "group admin bite quarantine announcement must have send_email=true")
+}
+
 func TestCreateUpdateWithSendEmailFlagForSiteAdminIsAllowed(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

Fixes a bug where users registered for email notifications were not receiving emails when an animal was placed in bite quarantine.

## Root Cause

In `AnimalForm.tsx` `handleQuarantineSubmit()`, the call to `updatesApi.create()` had `send_email` hardcoded to `false` while `send_groupme` was `true`:

```js
// Before (broken)
await updatesApi.create(parseInt(groupId), updateTitle, updateContent, false, true);
```

## Fix

Changed `send_email` to `true` so the announcement email is sent alongside the GroupMe notification:

```js
// After (fixed)
await updatesApi.create(parseInt(groupId), updateTitle, updateContent, true, true);
```

## Testing

1. Add an animal to bite quarantine via the animal form
2. Confirm users with `email_notifications_enabled = true` receive the bite quarantine announcement email
3. Confirm GroupMe notification still fires as before

## 📋 Roadmap Impact

This is a bug fix with no roadmap item — the feature was already shipped but broken.