### PR TITLE
fix: accept PDFs with leading bytes before %PDF header

### DIFF
--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -212,9 +212,11 @@ func ValidateDocumentUpload(file *multipart.FileHeader, maxSize int64) error {
 		}
 	}
 
-	// PDF files start with %PDF
+	// PDF files contain the %PDF- header within the first 1024 bytes.
+	// Some generators prepend a UTF-8 BOM or whitespace before the header,
+	// so search within the buffer rather than requiring it at byte 0.
 	if !validContentType && ext == ".pdf" {
-		if bytes.HasPrefix(buffer, []byte("%PDF")) {
+		if bytes.Contains(buffer[:n], []byte("%PDF")) {
 			validContentType = true
 		}
 	}

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -214,8 +214,14 @@ func ValidateDocumentUpload(file *multipart.FileHeader, maxSize int64) error {
 
 	// Some PDF generators prepend a UTF-8 BOM or whitespace before the
 	// %PDF- header. Strip those known prefixes, then check at byte 0.
+	// Cap the preamble window to 64 bytes so only legitimate small
+	// prefixes are tolerated, not large amounts of padding.
 	if !validContentType && ext == ".pdf" {
+		const maxPreamble = 64
 		b := buffer[:n]
+		if len(b) > maxPreamble {
+			b = b[:maxPreamble]
+		}
 		if bytes.HasPrefix(b, []byte{0xEF, 0xBB, 0xBF}) {
 			b = b[3:]
 		}

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -212,11 +212,15 @@ func ValidateDocumentUpload(file *multipart.FileHeader, maxSize int64) error {
 		}
 	}
 
-	// PDF files contain the %PDF- header within the first 1024 bytes.
-	// Some generators prepend a UTF-8 BOM or whitespace before the header,
-	// so search within the buffer rather than requiring it at byte 0.
+	// Some PDF generators prepend a UTF-8 BOM or whitespace before the
+	// %PDF- header. Strip those known prefixes, then check at byte 0.
 	if !validContentType && ext == ".pdf" {
-		if bytes.Contains(buffer[:n], []byte("%PDF")) {
+		b := buffer[:n]
+		if bytes.HasPrefix(b, []byte{0xEF, 0xBB, 0xBF}) {
+			b = b[3:]
+		}
+		b = bytes.TrimLeft(b, " \t\r\n")
+		if bytes.HasPrefix(b, []byte("%PDF-")) {
 			validContentType = true
 		}
 	}

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -207,15 +207,14 @@ func ValidateDocumentUpload(file *multipart.FileHeader, maxSize int64) error {
 	// DOCX and XLSX are both ZIP archives; accept either ZIP local-file or
 	// end-of-central-directory signatures.
 	if !validContentType && (ext == ".docx" || ext == ".xlsx") {
-		if bytes.HasPrefix(buffer, []byte{0x50, 0x4B, 0x03, 0x04}) || bytes.HasPrefix(buffer, []byte{0x50, 0x4B, 0x05, 0x06}) {
+		if bytes.HasPrefix(buffer[:n], []byte{0x50, 0x4B, 0x03, 0x04}) || bytes.HasPrefix(buffer[:n], []byte{0x50, 0x4B, 0x05, 0x06}) {
 			validContentType = true
 		}
 	}
 
 	// Some PDF generators prepend a UTF-8 BOM or whitespace before the
 	// %PDF- header. Strip those known prefixes, then check at byte 0.
-	// Cap the preamble window to 64 bytes so only legitimate small
-	// prefixes are tolerated, not large amounts of padding.
+	// Cap the combined preamble (BOM + whitespace) to 64 bytes.
 	if !validContentType && ext == ".pdf" {
 		const maxPreamble = 64
 		b := buffer[:n]

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -214,18 +214,18 @@ func ValidateDocumentUpload(file *multipart.FileHeader, maxSize int64) error {
 
 	// Some PDF generators prepend a UTF-8 BOM or whitespace before the
 	// %PDF- header. Strip those known prefixes, then check at byte 0.
-	// Cap the combined preamble (BOM + whitespace) to 64 bytes.
+	// Reject if the combined preamble (BOM + whitespace) exceeds 64 bytes.
 	if !validContentType && ext == ".pdf" {
 		const maxPreamble = 64
 		b := buffer[:n]
-		if len(b) > maxPreamble {
-			b = b[:maxPreamble]
-		}
+		skipped := 0
 		if bytes.HasPrefix(b, []byte{0xEF, 0xBB, 0xBF}) {
 			b = b[3:]
+			skipped += 3
 		}
-		b = bytes.TrimLeft(b, " \t\r\n")
-		if bytes.HasPrefix(b, []byte("%PDF-")) {
+		trimmed := bytes.TrimLeft(b, " \t\r\n")
+		skipped += len(b) - len(trimmed)
+		if skipped <= maxPreamble && bytes.HasPrefix(trimmed, []byte("%PDF-")) {
 			validContentType = true
 		}
 	}

--- a/internal/upload/validation_document_test.go
+++ b/internal/upload/validation_document_test.go
@@ -105,6 +105,14 @@ func TestValidateDocumentUpload(t *testing.T) {
 			maxSize:     MaxDocumentSize,
 			expectError: false,
 		},
+		{
+			name:        "Non-PDF file containing %PDF string",
+			filename:    "fake.pdf",
+			content:     []byte("This document references %PDF format but is not one"),
+			maxSize:     MaxDocumentSize,
+			expectError: true,
+			errorMsg:    "file does not appear to be a valid PDF document",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/upload/validation_document_test.go
+++ b/internal/upload/validation_document_test.go
@@ -91,6 +91,20 @@ func TestValidateDocumentUpload(t *testing.T) {
 			maxSize:     MaxDocumentSize,
 			expectError: false,
 		},
+		{
+			name:        "PDF with UTF-8 BOM prefix",
+			filename:    "bom.pdf",
+			content:     append([]byte{0xEF, 0xBB, 0xBF}, []byte("%PDF-1.7\ntest content")...),
+			maxSize:     MaxDocumentSize,
+			expectError: false,
+		},
+		{
+			name:        "PDF with leading whitespace",
+			filename:    "whitespace.pdf",
+			content:     append([]byte("\n\n"), []byte("%PDF-1.4\ntest content")...),
+			maxSize:     MaxDocumentSize,
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/upload/validation_document_test.go
+++ b/internal/upload/validation_document_test.go
@@ -113,6 +113,29 @@ func TestValidateDocumentUpload(t *testing.T) {
 			expectError: true,
 			errorMsg:    "file does not appear to be a valid PDF document",
 		},
+		{
+			name:        "PDF with BOM and whitespace combined",
+			filename:    "bom-ws.pdf",
+			content:     append([]byte{0xEF, 0xBB, 0xBF}, []byte("\n%PDF-1.7\ntest content")...),
+			maxSize:     MaxDocumentSize,
+			expectError: false,
+		},
+		{
+			name:        "PDF header without hyphen is rejected",
+			filename:    "nohyphen.pdf",
+			content:     []byte("%PDF1.4\ntest content"),
+			maxSize:     MaxDocumentSize,
+			expectError: true,
+			errorMsg:    "file does not appear to be a valid PDF document",
+		},
+		{
+			name:        "Excessive whitespace before PDF header is rejected",
+			filename:    "padded.pdf",
+			content:     append(bytes.Repeat([]byte(" "), 100), []byte("%PDF-1.4\ntest content")...),
+			maxSize:     MaxDocumentSize,
+			expectError: true,
+			errorMsg:    "file does not appear to be a valid PDF document",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

PDF uploads were returning 400 errors while DOCX uploads worked fine.

**Root cause:** `ValidateDocumentUpload` required the `%PDF` magic bytes at byte 0 (`bytes.HasPrefix`). Go's `http.DetectContentType` also only matches `%PDF-` at position 0. Some PDF generators prepend a UTF-8 BOM (`EF BB BF`) or whitespace before the header, causing both checks to fail.

## Fix

Strip known preamble bytes (UTF-8 BOM, then leading whitespace) before checking for `%PDF-` with `bytes.HasPrefix`. The preamble window is capped to 64 bytes so excessive padding is rejected. The check now uses `%PDF-` (with dash) per the PDF spec for tighter validation.

## Testing

- BOM-prefixed PDF → accepted
- Whitespace-prefixed PDF → accepted
- BOM + whitespace combined → accepted
- Non-PDF containing `%PDF` in prose → rejected
- `%PDF` without hyphen → rejected
- Excessive whitespace (100+ bytes) → rejected
- All existing document validation tests pass (17 total)

## 📋 Roadmap Impact

None — this is a bug fix for existing functionality.