### PR TITLE
fix: show Open PDF button on mobile instead of blank iframe

### DIFF
--- a/frontend/src/components/ProtocolPdfViewer.tsx
+++ b/frontend/src/components/ProtocolPdfViewer.tsx
@@ -14,7 +14,7 @@ interface ProtocolPdfViewerProps {
   fileName?: string;
 }
 
-const ProtocolPdfViewer: React.FC<ProtocolPdfViewerProps> = ({ blob }) => {
+const ProtocolPdfViewer: React.FC<ProtocolPdfViewerProps> = ({ blob, fileName }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [pdf, setPdf] = useState<pdfjsLib.PDFDocumentProxy | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -191,7 +191,7 @@ const ProtocolPdfViewer: React.FC<ProtocolPdfViewerProps> = ({ blob }) => {
   }
 
   return (
-    <div className="protocol-pdf-viewer">
+    <div className="protocol-pdf-viewer" aria-label={fileName ? `PDF viewer: ${fileName}` : 'PDF viewer'}>
       <div className="protocol-pdf-controls">
         <div className="pdf-zoom-controls">
           <button

--- a/frontend/src/components/ScriptsList.css
+++ b/frontend/src/components/ScriptsList.css
@@ -380,6 +380,11 @@
   margin: 0 0 1.5rem;
 }
 
+.script-viewer-error {
+  color: var(--error, #e53e3e);
+  margin-bottom: 1rem;
+}
+
 .script-viewer-actions {
   display: flex;
   gap: 0.75rem;

--- a/frontend/src/components/ScriptsList.css
+++ b/frontend/src/components/ScriptsList.css
@@ -380,7 +380,6 @@
   margin: 0 0 1.5rem;
 }
 
-
 .script-viewer-actions {
   display: flex;
   gap: 0.75rem;

--- a/frontend/src/components/ScriptsList.css
+++ b/frontend/src/components/ScriptsList.css
@@ -387,6 +387,37 @@
   margin: 0 0 1.5rem;
 }
 
+.script-viewer-download .btn-primary {
+  display: inline-block;
+  padding: 0.75rem 2rem;
+  background: var(--brand);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: none;
+  margin-bottom: 1rem;
+  transition: all 0.2s ease;
+}
+
+.script-viewer-download .btn-primary:hover {
+  background: var(--brand-600);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 163, 173, 0.3);
+}
+
+.script-viewer-download .btn-primary:focus {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.script-viewer-download .btn-primary:active {
+  transform: translateY(0);
+}
+
 .script-viewer-actions {
   display: flex;
   gap: 0.75rem;

--- a/frontend/src/components/ScriptsList.css
+++ b/frontend/src/components/ScriptsList.css
@@ -254,13 +254,6 @@
   min-height: 200px;
 }
 
-.script-iframe {
-  width: 100%;
-  height: 55vh;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-}
-
 /* DOCX rendered HTML body */
 .script-docx-body {
   flex: 1;
@@ -387,36 +380,6 @@
   margin: 0 0 1.5rem;
 }
 
-.script-viewer-download .btn-primary {
-  display: inline-block;
-  padding: 0.75rem 2rem;
-  background: var(--brand);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
-  font-family: inherit;
-  text-decoration: none;
-  margin-bottom: 1rem;
-  transition: all 0.2s ease;
-}
-
-.script-viewer-download .btn-primary:hover {
-  background: var(--brand-600);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 163, 173, 0.3);
-}
-
-.script-viewer-download .btn-primary:focus {
-  outline: 2px solid var(--brand);
-  outline-offset: 2px;
-}
-
-.script-viewer-download .btn-primary:active {
-  transform: translateY(0);
-}
 
 .script-viewer-actions {
   display: flex;
@@ -550,9 +513,5 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
-  }
-
-  .script-iframe {
-    height: 60vh;
   }
 }

--- a/frontend/src/components/ScriptsList.tsx
+++ b/frontend/src/components/ScriptsList.tsx
@@ -456,11 +456,26 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
   }
 
   if (viewState.status === 'pdf') {
+    if (!viewState.blob) {
+      // Should not happen — blob is always set when status is 'pdf' — but fall
+      // through to the error UI rather than rendering an empty viewer.
+      return (
+        <div className="script-viewer script-viewer-download">
+          <div className="script-viewer-icon">{FILE_ICON}</div>
+          <p className="script-viewer-name">{script.file_name}</p>
+          <p style={{ color: 'var(--error, #e53e3e)', marginBottom: '1rem' }}>Unable to load file.</p>
+          {canEdit && (
+            <div className="script-viewer-actions">
+              <button className="btn-secondary" onClick={onEdit}>Edit</button>
+              <button className="btn-danger" onClick={onDelete}>Delete</button>
+            </div>
+          )}
+        </div>
+      );
+    }
     return (
       <div className="script-viewer">
-        {viewState.blob && (
-          <ProtocolPdfViewer blob={viewState.blob} fileName={script.file_name} />
-        )}
+        <ProtocolPdfViewer blob={viewState.blob} fileName={script.file_name} />
         {canEdit && (
           <div className="script-viewer-actions">
             <button className="btn-secondary" onClick={onEdit}>Edit</button>

--- a/frontend/src/components/ScriptsList.tsx
+++ b/frontend/src/components/ScriptsList.tsx
@@ -343,8 +343,13 @@ const ScriptsList: React.FC<ScriptsListProps> = ({
 
 // ─────────────────────────────────────────────
 // ScriptViewer: fetches the file with the stored JWT, then renders inline.
-// DOCX/DOC → HTML via mammoth.js | PDF → iframe | other → download link
+// DOCX/DOC → HTML via mammoth.js | PDF → iframe (desktop) / open link (mobile) | other → download link
 // ─────────────────────────────────────────────
+
+// Module-level constant — UA strings don't change mid-session.
+// Note: iPads with "Request Desktop Website" enabled send a macOS UA and will
+// receive the iframe path; that is intentional since their PDF support works.
+const IS_MOBILE = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
 export interface ScriptViewerProps {
   script: Script;
@@ -363,6 +368,7 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
   useEffect(() => {
     let activeBlobUrl: string | null = null;
     let cancelled = false;
+    let revocationTimer: ReturnType<typeof setTimeout> | null = null;
 
     const load = async () => {
       try {
@@ -403,7 +409,19 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
     load();
     return () => {
       cancelled = true;
-      if (activeBlobUrl) URL.revokeObjectURL(activeBlobUrl);
+      if (revocationTimer !== null) clearTimeout(revocationTimer);
+      if (activeBlobUrl) {
+        // On mobile the blob URL is opened in a new tab via "Open PDF". If we
+        // revoke immediately on unmount (e.g. the modal closes while the tab is
+        // loading) the new tab receives a broken document. Delay revocation to
+        // give the browser time to load the file. The timer is cancelled above
+        // if the effect re-runs before the 60 seconds elapse.
+        if (IS_MOBILE) {
+          revocationTimer = setTimeout(() => URL.revokeObjectURL(activeBlobUrl!), 60_000);
+        } else {
+          URL.revokeObjectURL(activeBlobUrl);
+        }
+      }
     };
   }, [script.file_url, script.file_name, script.file_type]);
 
@@ -450,14 +468,42 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
   }
 
   if (viewState.status === 'pdf') {
+    if (IS_MOBILE) {
+      return (
+        <div className="script-viewer script-viewer-download">
+          <div className="script-viewer-icon">{FILE_ICON}</div>
+          <p className="script-viewer-name">{script.file_name}</p>
+          {viewState.blobUrl && (
+            <a
+              href={viewState.blobUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary"
+              aria-label={`Open ${script.file_name}`}
+            >
+              Open PDF
+            </a>
+          )}
+          {canEdit && (
+            <div className="script-viewer-actions">
+              <button className="btn-secondary" onClick={onEdit}>Edit</button>
+              <button className="btn-danger" onClick={onDelete}>Delete</button>
+            </div>
+          )}
+        </div>
+      );
+    }
+
     return (
       <div className="script-viewer">
-        <iframe
-          src={viewState.blobUrl!}
-          title={script.title}
-          className="script-iframe"
-          aria-label={`${script.title} PDF viewer`}
-        />
+        {viewState.blobUrl && (
+          <iframe
+            src={viewState.blobUrl}
+            title={script.title}
+            className="script-iframe"
+            aria-label={`${script.title} PDF viewer`}
+          />
+        )}
         {canEdit && (
           <div className="script-viewer-actions">
             <button className="btn-secondary" onClick={onEdit}>Edit</button>

--- a/frontend/src/components/ScriptsList.tsx
+++ b/frontend/src/components/ScriptsList.tsx
@@ -8,6 +8,7 @@ import SkeletonLoader from './SkeletonLoader';
 import ErrorState from './ErrorState';
 import Modal from './Modal';
 import ConfirmDialog from './ConfirmDialog';
+import ProtocolPdfViewer from './ProtocolPdfViewer';
 import './ScriptsList.css';
 
 interface ScriptsListProps {
@@ -343,13 +344,8 @@ const ScriptsList: React.FC<ScriptsListProps> = ({
 
 // ─────────────────────────────────────────────
 // ScriptViewer: fetches the file with the stored JWT, then renders inline.
-// DOCX/DOC → HTML via mammoth.js | PDF → iframe (desktop) / open link (mobile) | other → download link
+// DOCX/DOC → HTML via mammoth.js | PDF → ProtocolPdfViewer (PDF.js) | other → download link
 // ─────────────────────────────────────────────
-
-// Module-level constant — UA strings don't change mid-session.
-// Note: iPads with "Request Desktop Website" enabled send a macOS UA and will
-// receive the iframe path; that is intentional since their PDF support works.
-const IS_MOBILE = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
 export interface ScriptViewerProps {
   script: Script;
@@ -361,14 +357,14 @@ export interface ScriptViewerProps {
 export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onEdit, onDelete }) => {
   const [viewState, setViewState] = useState<{
     status: 'loading' | 'pdf' | 'docx' | 'other' | 'error';
+    blob: Blob | null;
     blobUrl: string | null;
     htmlContent: string | null;
-  }>({ status: 'loading', blobUrl: null, htmlContent: null });
+  }>({ status: 'loading', blob: null, blobUrl: null, htmlContent: null });
 
   useEffect(() => {
     let activeBlobUrl: string | null = null;
     let cancelled = false;
-    let revocationTimer: ReturnType<typeof setTimeout> | null = null;
 
     const load = async () => {
       try {
@@ -393,35 +389,27 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
           if (cancelled) return;
           const DOMPurify = (await import('dompurify')).default;
           const safe = DOMPurify.sanitize(result.value);
-          setViewState({ status: 'docx', blobUrl: null, htmlContent: safe });
+          setViewState({ status: 'docx', blob: null, blobUrl: null, htmlContent: safe });
         } else {
           const blob = await res.blob();
           if (cancelled) return;
-          activeBlobUrl = URL.createObjectURL(blob);
           const isPdf = type === 'application/pdf' || name.endsWith('.pdf');
-          setViewState({ status: isPdf ? 'pdf' : 'other', blobUrl: activeBlobUrl, htmlContent: null });
+          if (isPdf) {
+            setViewState({ status: 'pdf', blob, blobUrl: null, htmlContent: null });
+          } else {
+            activeBlobUrl = URL.createObjectURL(blob);
+            setViewState({ status: 'other', blob: null, blobUrl: activeBlobUrl, htmlContent: null });
+          }
         }
       } catch {
-        if (!cancelled) setViewState({ status: 'error', blobUrl: null, htmlContent: null });
+        if (!cancelled) setViewState({ status: 'error', blob: null, blobUrl: null, htmlContent: null });
       }
     };
 
     load();
     return () => {
       cancelled = true;
-      if (revocationTimer !== null) clearTimeout(revocationTimer);
-      if (activeBlobUrl) {
-        // On mobile the blob URL is opened in a new tab via "Open PDF". If we
-        // revoke immediately on unmount (e.g. the modal closes while the tab is
-        // loading) the new tab receives a broken document. Delay revocation to
-        // give the browser time to load the file. The timer is cancelled above
-        // if the effect re-runs before the 60 seconds elapse.
-        if (IS_MOBILE) {
-          revocationTimer = setTimeout(() => URL.revokeObjectURL(activeBlobUrl!), 60_000);
-        } else {
-          URL.revokeObjectURL(activeBlobUrl);
-        }
-      }
+      if (activeBlobUrl) URL.revokeObjectURL(activeBlobUrl);
     };
   }, [script.file_url, script.file_name, script.file_type]);
 
@@ -468,41 +456,10 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
   }
 
   if (viewState.status === 'pdf') {
-    if (IS_MOBILE) {
-      return (
-        <div className="script-viewer script-viewer-download">
-          <div className="script-viewer-icon">{FILE_ICON}</div>
-          <p className="script-viewer-name">{script.file_name}</p>
-          {viewState.blobUrl && (
-            <a
-              href={viewState.blobUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-primary"
-              aria-label={`Open ${script.file_name}`}
-            >
-              Open PDF
-            </a>
-          )}
-          {canEdit && (
-            <div className="script-viewer-actions">
-              <button className="btn-secondary" onClick={onEdit}>Edit</button>
-              <button className="btn-danger" onClick={onDelete}>Delete</button>
-            </div>
-          )}
-        </div>
-      );
-    }
-
     return (
       <div className="script-viewer">
-        {viewState.blobUrl && (
-          <iframe
-            src={viewState.blobUrl}
-            title={script.title}
-            className="script-iframe"
-            aria-label={`${script.title} PDF viewer`}
-          />
+        {viewState.blob && (
+          <ProtocolPdfViewer blob={viewState.blob} fileName={script.file_name} />
         )}
         {canEdit && (
           <div className="script-viewer-actions">

--- a/frontend/src/components/ScriptsList.tsx
+++ b/frontend/src/components/ScriptsList.tsx
@@ -426,7 +426,7 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
       <div className="script-viewer script-viewer-download">
         <div className="script-viewer-icon">{FILE_ICON}</div>
         <p className="script-viewer-name">{script.file_name}</p>
-        <p style={{ color: 'var(--error, #e53e3e)', marginBottom: '1rem' }}>Unable to load file.</p>
+        <p className="script-viewer-error">Unable to load file.</p>
         {canEdit && (
           <div className="script-viewer-actions">
             <button className="btn-secondary" onClick={onEdit}>Edit</button>
@@ -463,7 +463,7 @@ export const ScriptViewer: React.FC<ScriptViewerProps> = ({ script, canEdit, onE
         <div className="script-viewer script-viewer-download">
           <div className="script-viewer-icon">{FILE_ICON}</div>
           <p className="script-viewer-name">{script.file_name}</p>
-          <p style={{ color: 'var(--error, #e53e3e)', marginBottom: '1rem' }}>Unable to load file.</p>
+          <p className="script-viewer-error">Unable to load file.</p>
           {canEdit && (
             <div className="script-viewer-actions">
               <button className="btn-secondary" onClick={onEdit}>Edit</button>


### PR DESCRIPTION
## Summary
- Mobile browsers (iOS Safari, Android Chrome) don't render PDFs inside \`<iframe>\` elements, resulting in a blank white area in the script viewer modal
- Replaced the iframe-based renderer with \`ProtocolPdfViewer\` (PDF.js canvas rendering) — the same component already used on the animals/protocol page
- PDFs are now stored as a \`Blob\` in state and passed directly to \`ProtocolPdfViewer\`, eliminating the need for object URLs, UA sniffing, or delayed revocation logic
- Also wired up the \`fileName\` prop in \`ProtocolPdfViewer\` that was previously accepted but silently discarded (now used as \`aria-label\`)
- Net: -84 lines

## Test plan
- [ ] Desktop: open a script PDF — renders via PDF.js with zoom controls and page counter, matching the animals page experience
- [ ] Mobile (iOS Safari / Android Chrome): open a script PDF — renders correctly, no blank white area
- [ ] Open a DOCX script — still renders via mammoth.js as before
- [ ] Open a non-PDF/DOCX script — download link still works
- [ ] Animals page protocol viewer — unaffected (ProtocolPdfViewer change is additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)