### PR TITLE
fix: prevent nested MaxRequestBodySize from silently capping large uploads

### DIFF
--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1435,53 +1435,53 @@
   padding: 0 0 2rem;
 }
 
-/* Upload form card */
+/* Upload form card — uses neutral-50 tint to distinguish from list cards */
 .document-upload-form {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-200);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-lg);
 }
 
 .document-upload-form h3 {
-  margin: 0 0 1.25rem;
-  font-size: 1rem;
-  font-weight: 600;
+  margin: 0 0 var(--space-md);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   color: var(--text-primary);
 }
 
 .document-upload-form .form-group {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-md);
 }
 
 .document-upload-form .form-group label {
   display: block;
-  margin-bottom: 0.375rem;
-  font-size: 0.875rem;
-  font-weight: 500;
+  margin-bottom: var(--space-xs);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
   color: var(--text-secondary);
 }
 
 .document-upload-form .form-control {
   width: 100%;
   padding: 0.5rem 0.75rem;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--neutral-200);
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
-  font-size: 0.9375rem;
-  transition: border-color 0.2s;
+  font-size: var(--text-base);
+  transition: border-color var(--transition-base);
   box-sizing: border-box;
 }
 
 .document-upload-form .form-control:focus {
   outline: none;
   border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(0, 163, 173, 0.1);
+  box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.1);
 }
 
-/* Style the file input to match other form controls */
+/* File input — style the browser button to match brand */
 .document-upload-form input[type="file"].form-control {
   padding: 0.375rem 0.75rem;
   cursor: pointer;
@@ -1491,13 +1491,13 @@
   padding: 0.25rem 0.75rem;
   margin-right: 0.75rem;
   background: var(--brand);
-  color: white;
+  color: var(--brand-contrast);
   border: none;
-  border-radius: 6px;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background var(--transition-base);
 }
 
 .document-upload-form input[type="file"].form-control::file-selector-button:hover {
@@ -1505,9 +1505,9 @@
 }
 
 .document-upload-form .form-error {
-  margin: 0.25rem 0 0;
-  font-size: 0.8125rem;
-  color: var(--danger, #ef4444);
+  margin: var(--space-xs) 0 0;
+  font-size: var(--text-sm);
+  color: var(--danger);
 }
 
 /* Document list */
@@ -1517,23 +1517,26 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-sm);
 }
 
+/* Matches member-card pattern: surface bg, neutral-200 border, 10px radius */
 .document-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  gap: var(--space-md);
+  background: var(--surface);
+  border: 1px solid var(--neutral-200);
   border-radius: 10px;
-  padding: 1rem 1.25rem;
-  transition: box-shadow 0.15s;
+  padding: var(--space-md) 1.25rem;
+  transition: box-shadow var(--transition-base), border-color var(--transition-base);
+  box-shadow: var(--shadow-sm);
 }
 
 .document-item:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-md);
+  border-color: var(--brand);
 }
 
 .document-item__info {
@@ -1542,17 +1545,17 @@
 }
 
 .document-item__title {
-  font-weight: 600;
-  font-size: 0.9375rem;
+  font-weight: var(--font-semibold);
+  font-size: var(--text-base);
   color: var(--text-primary);
-  margin-bottom: 0.1875rem;
+  margin-bottom: 0.125rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .document-item__description {
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   margin-bottom: 0.25rem;
   white-space: nowrap;
@@ -1563,23 +1566,23 @@
 .document-item__meta {
   display: flex;
   align-items: center;
-  gap: 0;
   flex-wrap: wrap;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
 }
 
+/* Dot separator between meta spans */
 .document-item__meta span + span::before {
   content: "·";
   margin: 0 0.375rem;
-  color: var(--border-color);
+  color: var(--neutral-300);
 }
 
-/* Action buttons — scoped to document items */
+/* Action buttons — scoped so they don't bleed globally */
 .document-item__actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-sm);
   flex-shrink: 0;
 }
 
@@ -1587,23 +1590,24 @@
   display: inline-flex;
   align-items: center;
   padding: 0.375rem 0.75rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  border-radius: 6px;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-md);
   border: none;
   cursor: pointer;
   white-space: nowrap;
-  transition: all 0.15s;
+  transition: all var(--transition-base);
   line-height: 1.4;
 }
 
 .document-item__actions .btn-primary {
   background: var(--brand);
-  color: white;
+  color: var(--brand-contrast);
+  /* Override GroupPage's global btn-primary lift/shadow — not appropriate at this size */
   box-shadow: none;
   transform: none;
-  font-size: 0.8125rem;
   padding: 0.375rem 0.75rem;
+  font-size: var(--text-sm);
 }
 
 .document-item__actions .btn-primary:hover {
@@ -1613,35 +1617,28 @@
 }
 
 .document-item__actions .btn-secondary {
-  background: var(--bg-primary);
+  background: var(--surface);
   color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--neutral-200);
 }
 
 .document-item__actions .btn-secondary:hover {
-  background: var(--bg-tertiary);
+  background: var(--neutral-100);
+  border-color: var(--neutral-300);
 }
 
 .document-item__actions .btn-danger {
-  background: var(--danger, #ef4444);
+  background: var(--danger);
   color: white;
 }
 
 .document-item__actions .btn-danger:hover {
-  background: #dc2626;
+  background: var(--danger-600);
 }
 
 .document-item__actions .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-[data-theme='dark'] .document-item {
-  border-color: var(--border-color);
-}
-
-[data-theme='dark'] .document-upload-form {
-  border-color: var(--border-color);
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1606,7 +1606,6 @@
   /* Override GroupPage's global btn-primary lift/shadow — not appropriate at this size */
   box-shadow: none;
   transform: none;
-  padding: 0.375rem 0.75rem;
   font-size: var(--text-sm);
 }
 

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1426,3 +1426,232 @@
     transform: none;
   }
 }
+
+/* ============================================================
+   Group Documents Section
+   ============================================================ */
+
+.documents-section {
+  padding: 0 0 2rem;
+}
+
+/* Upload form card */
+.document-upload-form {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.document-upload-form h3 {
+  margin: 0 0 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.document-upload-form .form-group {
+  margin-bottom: 1rem;
+}
+
+.document-upload-form .form-group label {
+  display: block;
+  margin-bottom: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.document-upload-form .form-control {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.document-upload-form .form-control:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 163, 173, 0.1);
+}
+
+/* Style the file input to match other form controls */
+.document-upload-form input[type="file"].form-control {
+  padding: 0.375rem 0.75rem;
+  cursor: pointer;
+}
+
+.document-upload-form input[type="file"].form-control::file-selector-button {
+  padding: 0.25rem 0.75rem;
+  margin-right: 0.75rem;
+  background: var(--brand);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.document-upload-form input[type="file"].form-control::file-selector-button:hover {
+  background: var(--brand-600);
+}
+
+.document-upload-form .form-error {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--danger, #ef4444);
+}
+
+/* Document list */
+.document-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.document-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  transition: box-shadow 0.15s;
+}
+
+.document-item:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.document-item__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.document-item__title {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+  margin-bottom: 0.1875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.document-item__description {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.document-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.document-item__meta span + span::before {
+  content: "·";
+  margin: 0 0.375rem;
+  color: var(--border-color);
+}
+
+/* Action buttons — scoped to document items */
+.document-item__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.document-item__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  line-height: 1.4;
+}
+
+.document-item__actions .btn-primary {
+  background: var(--brand);
+  color: white;
+  box-shadow: none;
+  transform: none;
+  font-size: 0.8125rem;
+  padding: 0.375rem 0.75rem;
+}
+
+.document-item__actions .btn-primary:hover {
+  background: var(--brand-600);
+  transform: none;
+  box-shadow: none;
+}
+
+.document-item__actions .btn-secondary {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.document-item__actions .btn-secondary:hover {
+  background: var(--bg-tertiary);
+}
+
+.document-item__actions .btn-danger {
+  background: var(--danger, #ef4444);
+  color: white;
+}
+
+.document-item__actions .btn-danger:hover {
+  background: #dc2626;
+}
+
+.document-item__actions .btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+[data-theme='dark'] .document-item {
+  border-color: var(--border-color);
+}
+
+[data-theme='dark'] .document-upload-form {
+  border-color: var(--border-color);
+}
+
+@media (max-width: 600px) {
+  .document-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .document-item__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1520,7 +1520,7 @@
   gap: var(--space-sm);
 }
 
-/* Matches member-card pattern: surface bg, neutral-200 border, 10px radius */
+/* document-item: surface bg, neutral-200 border, --radius-lg radius */
 .document-item {
   display: flex;
   align-items: center;
@@ -1528,7 +1528,7 @@
   gap: var(--space-md);
   background: var(--surface);
   border: 1px solid var(--neutral-200);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: var(--space-md) 1.25rem;
   transition: box-shadow var(--transition-base), border-color var(--transition-base);
   box-shadow: var(--shadow-sm);

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1363,7 +1363,7 @@ const GroupPage: React.FC = () => {
                     <div className="document-item__actions">
                       <button
                         type="button"
-                        className="btn btn-primary btn-sm"
+                        className="btn btn-primary"
                         disabled={openingDocId === doc.id}
                         onClick={async () => {
                           setOpeningDocId(doc.id);
@@ -1388,7 +1388,7 @@ const GroupPage: React.FC = () => {
                       </button>
                       <button
                         type="button"
-                        className="btn btn-secondary btn-sm"
+                        className="btn btn-secondary"
                         disabled={downloadingDocId === doc.id}
                         onClick={async () => {
                           setDownloadingDocId(doc.id);
@@ -1412,7 +1412,7 @@ const GroupPage: React.FC = () => {
                       {(membership?.is_group_admin || membership?.is_site_admin) && (
                         <button
                           type="button"
-                          className="btn btn-danger btn-sm"
+                          className="btn btn-danger"
                           onClick={() => setDocDeleteConfirm({ show: true, doc })}
                         >
                           Delete

--- a/internal/middleware/request_size.go
+++ b/internal/middleware/request_size.go
@@ -2,23 +2,38 @@ package middleware
 
 import (
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-// MaxRequestBodySize limits the size of request bodies to prevent DOS attacks
-// Default limit is 10MB, but can be overridden per route
+// originalBodyCtxKey is the context key used to store the raw request body before
+// any MaxRequestBodySize wrapper has been applied.
+const originalBodyCtxKey = "_mw_original_body"
+
+// MaxRequestBodySize limits the size of request bodies to prevent DOS attacks.
+// When applied multiple times (e.g. a global default and a per-route override),
+// the per-route call replaces the global limit rather than nesting inside it.
+// The original unwrapped body is saved in the Gin context on the first call so
+// that subsequent calls can wrap it directly at the requested size.
 func MaxRequestBodySize(maxBytes int64) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Set max bytes for request body
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		// Use the original, unwrapped body so that nested calls (e.g. a per-route
+		// override applied after the global middleware) replace the limit instead
+		// of layering a larger limit inside a smaller one.
+		body := c.Request.Body
+		if orig, exists := c.Get(originalBodyCtxKey); exists {
+			body = orig.(io.ReadCloser)
+		} else {
+			c.Set(originalBodyCtxKey, body)
+		}
+		c.Request.Body = http.MaxBytesReader(c.Writer, body, maxBytes)
 
 		c.Next()
 
 		// Check if body size limit was exceeded
 		if c.Errors.Last() != nil {
-			// Check for common body too large errors
 			errMsg := c.Errors.Last().Err.Error()
 			if errors.Is(c.Errors.Last().Err, http.ErrHandlerTimeout) ||
 				errMsg == "http: request body too large" {

--- a/internal/middleware/request_size.go
+++ b/internal/middleware/request_size.go
@@ -24,7 +24,10 @@ func MaxRequestBodySize(maxBytes int64) gin.HandlerFunc {
 		// of layering a larger limit inside a smaller one.
 		body := c.Request.Body
 		if orig, exists := c.Get(originalBodyCtxKey); exists {
-			body = orig.(io.ReadCloser)
+			rc, ok := orig.(io.ReadCloser)
+			if ok {
+				body = rc
+			}
 		} else {
 			c.Set(originalBodyCtxKey, body)
 		}

--- a/internal/middleware/request_size.go
+++ b/internal/middleware/request_size.go
@@ -37,9 +37,9 @@ func MaxRequestBodySize(maxBytes int64) gin.HandlerFunc {
 
 		// Check if body size limit was exceeded
 		if c.Errors.Last() != nil {
-			errMsg := c.Errors.Last().Err.Error()
+			var mbe *http.MaxBytesError
 			if errors.Is(c.Errors.Last().Err, http.ErrHandlerTimeout) ||
-				errMsg == "http: request body too large" {
+				errors.As(c.Errors.Last().Err, &mbe) {
 				c.JSON(http.StatusRequestEntityTooLarge, gin.H{
 					"error": "Request body too large",
 				})

--- a/internal/middleware/request_size_test.go
+++ b/internal/middleware/request_size_test.go
@@ -1,0 +1,85 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestMaxRequestBodySizeOverride verifies that applying MaxRequestBodySize a second
+// time (e.g. a per-route override after a global middleware) replaces the limit
+// rather than nesting it.  Before the fix a 12 MB body was rejected even when the
+// per-route limit was raised to 25 MB, because the 10 MB global wrapper was still
+// the innermost reader.
+func TestMaxRequestBodySizeOverride(t *testing.T) {
+	const (
+		globalLimit   = 10 * 1024 * 1024 // 10 MB
+		perRouteLimit = 25 * 1024 * 1024 // 25 MB
+		bodySize      = 12 * 1024 * 1024 // 12 MB — between the two limits
+	)
+
+	router := gin.New()
+	// Simulate the global middleware applied to all routes.
+	router.Use(MaxRequestBodySize(globalLimit))
+
+	// The per-route middleware raises the limit to 25 MB.
+	router.POST("/upload", MaxRequestBodySize(perRouteLimit), func(c *gin.Context) {
+		// Read the entire body to trigger MaxBytesReader enforcement.
+		buf := new(bytes.Buffer)
+		if _, err := buf.ReadFrom(c.Request.Body); err != nil {
+			c.Status(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	body := strings.NewReader(strings.Repeat("x", bodySize))
+	req, _ := http.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 OK for %d-byte body with %d-byte per-route limit, got %d; "+
+			"the global %d-byte limit may be incorrectly nesting the per-route override",
+			bodySize, perRouteLimit, w.Code, globalLimit)
+	}
+}
+
+// TestMaxRequestBodySizeGlobalEnforced verifies that the global limit still
+// rejects bodies that exceed both the global and per-route thresholds.
+func TestMaxRequestBodySizeGlobalEnforced(t *testing.T) {
+	const (
+		globalLimit = 10 * 1024 * 1024 // 10 MB
+		bodySize    = 11 * 1024 * 1024 // 11 MB — exceeds global limit, no per-route override
+	)
+
+	router := gin.New()
+	router.Use(MaxRequestBodySize(globalLimit))
+
+	router.POST("/upload", func(c *gin.Context) {
+		buf := new(bytes.Buffer)
+		if _, err := buf.ReadFrom(c.Request.Body); err != nil {
+			c.Status(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	body := strings.NewReader(strings.Repeat("x", bodySize))
+	req, _ := http.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("expected a non-200 response for %d-byte body exceeding the %d-byte global limit",
+			bodySize, globalLimit)
+	}
+}

--- a/internal/middleware/request_size_test.go
+++ b/internal/middleware/request_size_test.go
@@ -51,6 +51,41 @@ func TestMaxRequestBodySizeOverride(t *testing.T) {
 	}
 }
 
+// TestMaxRequestBodySizePerRouteEnforced verifies that the per-route limit still
+// rejects bodies that exceed it, ensuring the fix did not simply disable
+// per-route enforcement.
+func TestMaxRequestBodySizePerRouteEnforced(t *testing.T) {
+	const (
+		globalLimit   = 10 * 1024 * 1024 // 10 MB
+		perRouteLimit = 25 * 1024 * 1024 // 25 MB
+		bodySize      = 30 * 1024 * 1024 // 30 MB — exceeds per-route limit
+	)
+
+	router := gin.New()
+	router.Use(MaxRequestBodySize(globalLimit))
+
+	router.POST("/upload", MaxRequestBodySize(perRouteLimit), func(c *gin.Context) {
+		buf := new(bytes.Buffer)
+		if _, err := buf.ReadFrom(c.Request.Body); err != nil {
+			c.Status(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	body := strings.NewReader(strings.Repeat("x", bodySize))
+	req, _ := http.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("expected rejection for %d-byte body exceeding the %d-byte per-route limit, got 200",
+			bodySize, perRouteLimit)
+	}
+}
+
 // TestMaxRequestBodySizeGlobalEnforced verifies that the global limit still
 // rejects bodies that exceed both the global and per-route thresholds.
 func TestMaxRequestBodySizeGlobalEnforced(t *testing.T) {

--- a/internal/middleware/request_size_test.go
+++ b/internal/middleware/request_size_test.go
@@ -80,9 +80,42 @@ func TestMaxRequestBodySizePerRouteEnforced(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code == http.StatusOK {
-		t.Errorf("expected rejection for %d-byte body exceeding the %d-byte per-route limit, got 200",
-			bodySize, perRouteLimit)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 RequestEntityTooLarge for %d-byte body exceeding the %d-byte per-route limit, got %d",
+			bodySize, perRouteLimit, w.Code)
+	}
+}
+
+// TestMaxRequestBodySizeGlobalHappyPath verifies that a body under the global
+// limit is accepted on a route that has no per-route override.
+func TestMaxRequestBodySizeGlobalHappyPath(t *testing.T) {
+	const (
+		globalLimit = 10 * 1024 * 1024 // 10 MB
+		bodySize    = 5 * 1024 * 1024  // 5 MB — under global limit
+	)
+
+	router := gin.New()
+	router.Use(MaxRequestBodySize(globalLimit))
+
+	router.POST("/upload", func(c *gin.Context) {
+		buf := new(bytes.Buffer)
+		if _, err := buf.ReadFrom(c.Request.Body); err != nil {
+			c.Status(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	body := strings.NewReader(strings.Repeat("x", bodySize))
+	req, _ := http.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 OK for %d-byte body under the %d-byte global limit, got %d",
+			bodySize, globalLimit, w.Code)
 	}
 }
 
@@ -113,8 +146,8 @@ func TestMaxRequestBodySizeGlobalEnforced(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code == http.StatusOK {
-		t.Errorf("expected a non-200 response for %d-byte body exceeding the %d-byte global limit",
-			bodySize, globalLimit)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 RequestEntityTooLarge for %d-byte body exceeding the %d-byte global limit, got %d",
+			bodySize, globalLimit, w.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Two independent fixes bundled in one branch:

1. **Middleware bug** — nested `MaxRequestBodySize` silently capped all uploads at the global 10MB limit, even on routes with a higher per-route override
2. **Document list UX** — all CSS for the Group Documents section was missing, causing unstyled bullet points, run-together metadata, and a massively oversized Download button

---

## Fix 1 — Nested MaxRequestBodySize middleware

### Root Cause

`http.MaxBytesReader` wraps an `io.ReadCloser`. Wrapping an already-limited body with a *larger* limit still keeps the inner (smaller) limit. The per-route 25MB middleware was wrapping a body already constrained to 10MB by the global middleware.

### Fix

On first call, save the original unwrapped body in the Gin context under `_mw_original_body`. Subsequent (per-route) calls wrap the original body instead of the already-limited one.

### Behavior

| File size | Route | Before | After |
|-----------|-------|--------|-------|
| 0–10 MB | Any | ✅ Allowed | ✅ Allowed |
| 10–25 MB | Document upload | ❌ Silently rejected | ✅ Allowed |
| > 25 MB | Document upload | ❌ Rejected | ✅ Rejected |
| > 10 MB | Other routes | ✅ Rejected | ✅ Rejected |

### Tests (`internal/middleware/request_size_test.go`)

- `TestMaxRequestBodySizeOverride` — 12 MB body, 10 MB global + 25 MB per-route → 200 OK
- `TestMaxRequestBodySizeGlobalEnforced` — 11 MB body, 10 MB global only → rejected
- `TestMaxRequestBodySizePerRouteEnforced` — 30 MB body, 25 MB per-route → rejected (proves per-route enforcement wasn't disabled by the fix)

---

## Fix 2 — Group Documents UX (`frontend/src/pages/GroupPage.css`)

### Root Cause

`GroupPage.tsx` references ~10 CSS classes for the documents section (`document-list`, `document-item`, `document-item__info`, `document-item__meta`, `document-item__actions`, etc.) that had **no definitions** in `GroupPage.css`.

Side effects:
- Document list rendered as an unstyled `<ul>` bullet list
- Metadata (filename / size / date) concatenated without separators: *Rocky Protocol.pdf37.6 KB4/18/2026*
- Download button inherited the global `.btn` base from `AnnouncementsTab.css` (padding: 0.75rem 1.5rem) while the Open button was overridden by the scoped `.btn-primary` rule — making Download appear 2× taller
- Upload form had no visual distinction from the surrounding page

### Fix

Added ~230 lines of CSS following existing page conventions:

- **Cards** — document items match `member-card` / `activity-card` patterns (surface background, neutral-200 border, shadow-sm/md, brand border on hover)
- **Meta separators** — `span + span::before { content: "·" }` — no TSX changes needed
- **Compact buttons** — all three actions (Open / Download / Delete) scoped under `.document-item__actions .btn` with consistent small sizing; overrides the global `.btn` bleed
- **Upload form** — styled as a distinct card with neutral-50 background
- **File picker** — `::file-selector-button` styled to match brand green
- **Mobile** — items stack vertically at ≤ 600px, actions right-align
- **Design tokens** — all values use `var(--surface)`, `var(--shadow-*)`, `var(--radius-*)`, `var(--transition-base)`, `var(--brand-rgb)`, etc. from `index.css`; no undefined variables introduced

Also removed the meaningless `btn-sm` class from the three action buttons in `GroupPage.tsx` (no definition exists in scope; compact sizing is handled by the scoped CSS rule).

---

## Files Changed

| File | Change |
|------|--------|
| `internal/middleware/request_size.go` | Middleware bug fix |
| `internal/middleware/request_size_test.go` | 3 new tests |
| `frontend/src/pages/GroupPage.css` | +229 lines of document section CSS |
| `frontend/src/pages/GroupPage.tsx` | Remove ghost `btn-sm` class from 3 buttons |

## Roadmap Impact

Bug fix — not a tracked roadmap item. No roadmap update needed.