### PR TITLE
feat: group documents UX redesign — card grid + modal upload

### DIFF
--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1589,8 +1589,8 @@
 }
 
 .document-card__icon-btn--danger:hover {
-  background: #fef2f2;
-  border-color: #fecaca;
+  background: var(--danger-bg);
+  border-color: var(--danger-border);
 }
 
 [data-theme='dark'] .document-card__icon-btn {
@@ -1616,6 +1616,12 @@
 .document-card__icon-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.document-card__open-btn:focus-visible,
+.document-card__icon-btn:focus-visible {
+  outline: 2px solid rgba(var(--brand-rgb), 0.5);
+  outline-offset: 2px;
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1427,227 +1427,199 @@
   }
 }
 
-/* ============================================================
-   Group Documents Section
-   ============================================================ */
+/* ── Group Documents ─────────────────────────────────────────── */
 
 .documents-section {
   padding: 0 0 2rem;
 }
 
-/* Upload form card — uses neutral-50 tint to distinguish from list cards */
-.document-upload-form {
-  background: var(--neutral-50);
-  border: 1px solid var(--neutral-200);
-  border-radius: var(--radius-xl);
-  padding: var(--space-lg);
-  margin-bottom: var(--space-lg);
-}
-
-.document-upload-form h3 {
-  margin: 0 0 var(--space-md);
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-}
-
-.document-upload-form .form-group {
-  margin-bottom: var(--space-md);
-}
-
-.document-upload-form .form-group label {
-  display: block;
-  margin-bottom: var(--space-xs);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--text-secondary);
-}
-
-.document-upload-form .form-control {
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  background: var(--surface);
-  border: 1px solid var(--neutral-200);
-  border-radius: var(--radius-lg);
-  color: var(--text-primary);
-  font-size: var(--text-base);
-  transition: border-color var(--transition-base);
-  box-sizing: border-box;
-}
-
-.document-upload-form .form-control:focus {
-  outline: none;
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.1);
-}
-
-/* File input — style the browser button to match brand */
-.document-upload-form input[type="file"].form-control {
-  padding: 0.375rem 0.75rem;
-  cursor: pointer;
-}
-
-.document-upload-form input[type="file"].form-control::file-selector-button {
-  padding: 0.25rem 0.75rem;
-  margin-right: 0.75rem;
-  background: var(--brand);
-  color: var(--brand-contrast);
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition: background var(--transition-base);
-}
-
-.document-upload-form input[type="file"].form-control::file-selector-button:hover {
-  background: var(--brand-600);
-}
-
-.document-upload-form .form-error {
-  margin: var(--space-xs) 0 0;
-  font-size: var(--text-sm);
-  color: var(--danger);
-}
-
-/* Document list */
-.document-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-/* document-item: surface bg, neutral-200 border, --radius-lg radius */
-.document-item {
+.documents-section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.documents-section-header h2 {
+  margin: 0;
+}
+
+/* Card grid — mirrors .animals-grid */
+.document-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+.document-card {
   background: var(--surface);
   border: 1px solid var(--neutral-200);
   border-radius: var(--radius-lg);
-  padding: var(--space-md) 1.25rem;
-  transition: box-shadow var(--transition-base), border-color var(--transition-base);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
   box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-base), border-color var(--transition-base);
 }
 
-.document-item:hover {
+.document-card:hover {
   box-shadow: var(--shadow-md);
   border-color: var(--brand);
 }
 
-.document-item__info {
-  flex: 1;
-  min-width: 0;
-}
-
-.document-item__title {
-  font-weight: var(--font-semibold);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-  margin-bottom: 0.125rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.document-item__description {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-  margin-bottom: 0.25rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.document-item__meta {
-  display: flex;
+.document-card__type-badge {
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
-}
-
-/* Dot separator between meta spans */
-.document-item__meta span + span::before {
-  content: "·";
-  margin: 0 0.375rem;
-  color: var(--neutral-300);
-}
-
-/* Action buttons — scoped so they don't bleed globally */
-.document-item__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
+  justify-content: center;
+  width: 40px;
+  height: 48px;
+  background: var(--neutral-100);
+  color: var(--brand);
+  border-radius: var(--radius-md);
+  font-size: 0.65rem;
+  font-weight: var(--font-bold);
+  letter-spacing: 0.04em;
+  margin-bottom: 0.15rem;
   flex-shrink: 0;
 }
 
-.document-item__actions .btn {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.375rem 0.75rem;
+[data-theme='dark'] .document-card__type-badge {
+  background: var(--neutral-800);
+}
+
+.document-card__title {
+  font-weight: var(--font-semibold);
+  font-size: var(--text-base);
+  color: var(--text-primary);
+  line-height: 1.25;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.document-card__description {
   font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.document-card__meta {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin-top: auto;
+  padding-top: 0.2rem;
+}
+
+/* Dot separator between meta spans */
+.document-card__meta span + span::before {
+  content: "·";
+  margin: 0 0.35rem;
+  color: var(--neutral-300);
+}
+
+.document-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--neutral-100);
+  margin-top: 0.25rem;
+}
+
+[data-theme='dark'] .document-card__actions {
+  border-top-color: var(--neutral-700);
+}
+
+.document-card__open-btn {
+  flex: 1;
+  text-align: center;
+  padding: 0.3rem 0;
+  background: var(--brand);
+  color: var(--brand-contrast);
   border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
   cursor: pointer;
-  white-space: nowrap;
-  transition: all var(--transition-base);
+  transition: background var(--transition-base);
   line-height: 1.4;
 }
 
-.document-item__actions .btn-primary {
-  background: var(--brand);
-  color: var(--brand-contrast);
-  /* Override GroupPage's global btn-primary lift/shadow — not appropriate at this size */
-  box-shadow: none;
-  transform: none;
-  font-size: var(--text-sm);
-}
-
-.document-item__actions .btn-primary:hover {
+.document-card__open-btn:hover {
   background: var(--brand-600);
-  transform: none;
-  box-shadow: none;
 }
 
-.document-item__actions .btn-secondary {
-  background: var(--surface);
-  color: var(--text-primary);
-  border: 1px solid var(--neutral-200);
-}
-
-.document-item__actions .btn-secondary:hover {
-  background: var(--neutral-100);
-  border-color: var(--neutral-300);
-}
-
-.document-item__actions .btn-danger {
-  background: var(--danger);
-  color: white;
-}
-
-.document-item__actions .btn-danger:hover {
-  background: var(--danger-600);
-}
-
-.document-item__actions .btn:disabled {
+.document-card__open-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-@media (max-width: 600px) {
-  .document-item {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.document-card__icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: var(--surface);
+  border: 1px solid var(--neutral-200);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base);
+  flex-shrink: 0;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1;
+}
 
-  .document-item__actions {
-    width: 100%;
-    justify-content: flex-end;
+.document-card__icon-btn:hover {
+  background: var(--neutral-100);
+  border-color: var(--neutral-300);
+}
+
+.document-card__icon-btn--danger {
+  background: var(--neutral-50);
+  border-color: var(--neutral-200);
+  color: var(--danger);
+}
+
+.document-card__icon-btn--danger:hover {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+[data-theme='dark'] .document-card__icon-btn {
+  background: var(--neutral-800);
+  border-color: var(--neutral-700);
+}
+
+[data-theme='dark'] .document-card__icon-btn:hover {
+  background: var(--neutral-700);
+  border-color: var(--neutral-600);
+}
+
+[data-theme='dark'] .document-card__icon-btn--danger {
+  background: var(--neutral-800);
+  border-color: var(--neutral-700);
+}
+
+[data-theme='dark'] .document-card__icon-btn--danger:hover {
+  background: rgba(220, 38, 38, 0.15);
+  border-color: rgba(220, 38, 38, 0.4);
+}
+
+.document-card__icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .document-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -69,6 +69,7 @@ const GroupPage: React.FC = () => {
   const [downloadingDocId, setDownloadingDocId] = useState<number | null>(null);
   const [openingDocId, setOpeningDocId] = useState<number | null>(null);
   const [docDeleteConfirm, setDocDeleteConfirm] = useState<{ show: boolean; doc: GroupDocument | null }>({ show: false, doc: null });
+  const [showUploadModal, setShowUploadModal] = useState(false);
   const docFileInputRef = useRef<HTMLInputElement>(null);
 
   // Skill tag state
@@ -1259,169 +1260,111 @@ const GroupPage: React.FC = () => {
           className="group-content"
         >
           <div className="documents-section">
-            <h2 className="section-title">Group Documents</h2>
-
-            {/* Upload form for group admins */}
-            {(membership?.is_group_admin || membership?.is_site_admin) && (
-              <div className="document-upload-form">
-                <h3>Upload Document</h3>
-                <div className="form-group">
-                  <label htmlFor="doc-title">Title *</label>
-                  <input
-                    id="doc-title"
-                    type="text"
-                    value={docUploadTitle}
-                    onChange={(e) => setDocUploadTitle(e.target.value)}
-                    placeholder="Document title"
-                    maxLength={200}
-                    className="form-control"
-                  />
-                  {docUploadTitle.length > 0 && docUploadTitle.length < 2 && (
-                    <p className="form-error">Title must be at least 2 characters.</p>
-                  )}
-                </div>
-                <div className="form-group">
-                  <label htmlFor="doc-description">Description</label>
-                  <textarea
-                    id="doc-description"
-                    value={docUploadDescription}
-                    onChange={(e) => setDocUploadDescription(e.target.value)}
-                    placeholder="Optional description"
-                    maxLength={500}
-                    rows={3}
-                    className="form-control"
-                  />
-                </div>
-                <div className="form-group">
-                  <label htmlFor="doc-file">File * (.pdf, .docx, .xlsx — DOCX/XLSX will be converted to PDF)</label>
-                  <input
-                    ref={docFileInputRef}
-                    id="doc-file"
-                    type="file"
-                    accept=".pdf,.docx,.xlsx"
-                    onChange={(e) => setDocUploadFile(e.target.files?.[0] ?? null)}
-                    className="form-control"
-                  />
-                  {(docUploadFile?.size ?? 0) > 20 * 1024 * 1024 && (
-                    <p className="form-error">File exceeds the 20 MB limit.</p>
-                  )}
-                </div>
+            <div className="documents-section-header">
+              <h2>Group Documents</h2>
+              {(membership?.is_group_admin || membership?.is_site_admin) && (
                 <button
                   type="button"
                   className="btn btn-primary"
-                  disabled={docUploading || docUploadTitle.length < 2 || !docUploadFile || (docUploadFile?.size ?? 0) > 20 * 1024 * 1024}
-                  onClick={async () => {
-                    if (!id || !docUploadFile) return;
-                    setDocUploading(true);
-                    try {
-                      const formData = new FormData();
-                      formData.append('title', docUploadTitle);
-                      formData.append('description', docUploadDescription);
-                      formData.append('file', docUploadFile);
-                      await groupDocumentsApi.upload(Number(id), formData);
-                      setDocUploadTitle('');
-                      setDocUploadDescription('');
-                      setDocUploadFile(null);
-                      // Reset file input
-                      if (docFileInputRef.current) docFileInputRef.current.value = '';
-                      await loadDocuments(Number(id));
-                      toast.showSuccess('Document uploaded successfully');
-                    } catch (err: unknown) {
-                      const axiosError = err as { response?: { data?: { error?: string } } };
-                      toast.showError(axiosError?.response?.data?.error || 'Failed to upload document');
-                    } finally {
-                      setDocUploading(false);
-                    }
-                  }}
+                  onClick={() => setShowUploadModal(true)}
                 >
-                  {docUploading ? 'Uploading...' : 'Upload Document'}
+                  + Upload Document
                 </button>
-              </div>
-            )}
+              )}
+            </div>
 
-            {/* Documents list */}
+            {/* Documents grid */}
             {documentsLoading && <SkeletonLoader />}
             {documentsError && <ErrorState message={documentsError} />}
             {!documentsLoading && !documentsError && documents.length === 0 && (
-              <EmptyState title="No documents" description="No documents have been uploaded yet." />
+              <EmptyState title="No documents yet" description="No documents have been uploaded for this group." />
             )}
             {!documentsLoading && !documentsError && documents.length > 0 && (
-              <ul className="document-list">
-                {documents.map((doc) => (
-                  <li key={doc.id} className="document-item">
-                    <div className="document-item__info">
-                      <div className="document-item__title">{doc.title}</div>
+              <div className="document-grid">
+                {documents.map((doc) => {
+                  const ext = doc.file_name.split('.').pop()?.toUpperCase() ?? 'FILE';
+                  const fileSize = doc.file_size >= 1024 * 1024
+                    ? `${(doc.file_size / (1024 * 1024)).toFixed(1)} MB`
+                    : `${(doc.file_size / 1024).toFixed(1)} KB`;
+                  const uploadDate = new Date(doc.created_at).toLocaleDateString();
+                  return (
+                    <div key={doc.id} className="document-card">
+                      <div className="document-card__type-badge" aria-hidden="true">{ext}</div>
+                      <div className="document-card__title">{doc.title}</div>
                       {doc.description && (
-                        <div className="document-item__description">{doc.description}</div>
+                        <div className="document-card__description">{doc.description}</div>
                       )}
-                      <div className="document-item__meta">
-                        <span>{doc.file_name}</span>
-                        <span>{doc.file_size >= 1024 * 1024 ? `${(doc.file_size / (1024 * 1024)).toFixed(1)} MB` : `${(doc.file_size / 1024).toFixed(1)} KB`}</span>
-                        <span>{new Date(doc.created_at).toLocaleDateString()}</span>
+                      <div className="document-card__meta">
+                        <span>{fileSize}</span>
+                        <span>{uploadDate}</span>
                       </div>
-                    </div>
-                    <div className="document-item__actions">
-                      <button
-                        type="button"
-                        className="btn btn-primary"
-                        disabled={openingDocId === doc.id}
-                        onClick={async () => {
-                          setOpeningDocId(doc.id);
-                          try {
-                            const res = await groupDocumentsApi.serve(doc.file_url);
-                            const url = URL.createObjectURL(res.data as Blob);
-                            // Use anchor click instead of window.open to avoid popup blockers
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.target = '_blank';
-                            a.rel = 'noopener noreferrer';
-                            a.click();
-                            setTimeout(() => URL.revokeObjectURL(url), 10000);
-                          } catch {
-                            toast.showError('Failed to open document');
-                          } finally {
-                            setOpeningDocId(null);
-                          }
-                        }}
-                      >
-                        {openingDocId === doc.id ? 'Opening...' : 'Open'}
-                      </button>
-                      <button
-                        type="button"
-                        className="btn btn-secondary"
-                        disabled={downloadingDocId === doc.id}
-                        onClick={async () => {
-                          setDownloadingDocId(doc.id);
-                          try {
-                            const res = await groupDocumentsApi.serve(doc.file_url);
-                            const url = URL.createObjectURL(res.data as Blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = doc.file_name;
-                            a.click();
-                            URL.revokeObjectURL(url);
-                          } catch {
-                            toast.showError('Failed to download document');
-                          } finally {
-                            setDownloadingDocId(null);
-                          }
-                        }}
-                      >
-                        {downloadingDocId === doc.id ? 'Downloading...' : 'Download'}
-                      </button>
-                      {(membership?.is_group_admin || membership?.is_site_admin) && (
+                      <div className="document-card__actions">
                         <button
                           type="button"
-                          className="btn btn-danger"
-                          onClick={() => setDocDeleteConfirm({ show: true, doc })}
+                          className="document-card__open-btn"
+                          disabled={openingDocId === doc.id}
+                          aria-label={`Open ${doc.title}`}
+                          onClick={async () => {
+                            setOpeningDocId(doc.id);
+                            try {
+                              const res = await groupDocumentsApi.serve(doc.file_url);
+                              const url = URL.createObjectURL(res.data as Blob);
+                              const a = document.createElement('a');
+                              a.href = url;
+                              a.target = '_blank';
+                              a.rel = 'noopener noreferrer';
+                              a.click();
+                              setTimeout(() => URL.revokeObjectURL(url), 10000);
+                            } catch {
+                              toast.showError('Failed to open document');
+                            } finally {
+                              setOpeningDocId(null);
+                            }
+                          }}
                         >
-                          Delete
+                          {openingDocId === doc.id ? 'Opening…' : 'Open'}
                         </button>
-                      )}
+                        <button
+                          type="button"
+                          className="document-card__icon-btn"
+                          disabled={downloadingDocId === doc.id}
+                          aria-label={`Download ${doc.title}`}
+                          title="Download"
+                          onClick={async () => {
+                            setDownloadingDocId(doc.id);
+                            try {
+                              const res = await groupDocumentsApi.serve(doc.file_url);
+                              const url = URL.createObjectURL(res.data as Blob);
+                              const a = document.createElement('a');
+                              a.href = url;
+                              a.download = doc.file_name;
+                              a.click();
+                              URL.revokeObjectURL(url);
+                            } catch {
+                              toast.showError('Failed to download document');
+                            } finally {
+                              setDownloadingDocId(null);
+                            }
+                          }}
+                        >
+                          ↓
+                        </button>
+                        {(membership?.is_group_admin || membership?.is_site_admin) && (
+                          <button
+                            type="button"
+                            className="document-card__icon-btn document-card__icon-btn--danger"
+                            aria-label={`Delete ${doc.title}`}
+                            title="Delete"
+                            onClick={() => setDocDeleteConfirm({ show: true, doc })}
+                          >
+                            🗑
+                          </button>
+                        )}
+                      </div>
                     </div>
-                  </li>
-                ))}
-              </ul>
+                  );
+                })}
+              </div>
             )}
           </div>
         </div>
@@ -1478,6 +1421,106 @@ const GroupPage: React.FC = () => {
         }}
         onCancel={() => setDeleteTagConfirm({ show: false, tag: null })}
       />
+
+      {/* Upload Document Modal */}
+      <Modal
+        isOpen={showUploadModal}
+        onClose={() => {
+          setShowUploadModal(false);
+          setDocUploadTitle('');
+          setDocUploadDescription('');
+          setDocUploadFile(null);
+          if (docFileInputRef.current) docFileInputRef.current.value = '';
+        }}
+        title="Upload Document"
+      >
+        <div className="form-group">
+          <label htmlFor="doc-title">Title *</label>
+          <input
+            id="doc-title"
+            type="text"
+            value={docUploadTitle}
+            onChange={(e) => setDocUploadTitle(e.target.value)}
+            placeholder="Document title"
+            maxLength={200}
+            className="form-control"
+          />
+          {docUploadTitle.length > 0 && docUploadTitle.length < 2 && (
+            <p className="form-error">Title must be at least 2 characters.</p>
+          )}
+        </div>
+        <div className="form-group">
+          <label htmlFor="doc-description">Description</label>
+          <textarea
+            id="doc-description"
+            value={docUploadDescription}
+            onChange={(e) => setDocUploadDescription(e.target.value)}
+            placeholder="Optional description"
+            maxLength={500}
+            rows={3}
+            className="form-control"
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="doc-file">File * (.pdf, .docx, .xlsx — DOCX/XLSX will be converted to PDF)</label>
+          <input
+            ref={docFileInputRef}
+            id="doc-file"
+            type="file"
+            accept=".pdf,.docx,.xlsx"
+            onChange={(e) => setDocUploadFile(e.target.files?.[0] ?? null)}
+            className="form-control"
+          />
+          {(docUploadFile?.size ?? 0) > 20 * 1024 * 1024 && (
+            <p className="form-error">File exceeds the 20 MB limit.</p>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: '0.75rem', marginTop: '0.5rem' }}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={docUploading || docUploadTitle.length < 2 || !docUploadFile || (docUploadFile?.size ?? 0) > 20 * 1024 * 1024}
+            onClick={async () => {
+              if (!id || !docUploadFile) return;
+              setDocUploading(true);
+              try {
+                const formData = new FormData();
+                formData.append('title', docUploadTitle);
+                formData.append('description', docUploadDescription);
+                formData.append('file', docUploadFile);
+                await groupDocumentsApi.upload(Number(id), formData);
+                setShowUploadModal(false);
+                setDocUploadTitle('');
+                setDocUploadDescription('');
+                setDocUploadFile(null);
+                if (docFileInputRef.current) docFileInputRef.current.value = '';
+                await loadDocuments(Number(id));
+                toast.showSuccess('Document uploaded successfully');
+              } catch (err: unknown) {
+                const axiosError = err as { response?: { data?: { error?: string } } };
+                toast.showError(axiosError?.response?.data?.error || 'Failed to upload document');
+              } finally {
+                setDocUploading(false);
+              }
+            }}
+          >
+            {docUploading ? 'Uploading...' : 'Upload Document'}
+          </button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => {
+              setShowUploadModal(false);
+              setDocUploadTitle('');
+              setDocUploadDescription('');
+              setDocUploadFile(null);
+              if (docFileInputRef.current) docFileInputRef.current.value = '';
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </Modal>
 
       <ConfirmDialog
         isOpen={docDeleteConfirm.show}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -72,6 +72,14 @@ const GroupPage: React.FC = () => {
   const [showUploadModal, setShowUploadModal] = useState(false);
   const docFileInputRef = useRef<HTMLInputElement>(null);
 
+  const closeUploadModal = useCallback(() => {
+    setShowUploadModal(false);
+    setDocUploadTitle('');
+    setDocUploadDescription('');
+    setDocUploadFile(null);
+    if (docFileInputRef.current) docFileInputRef.current.value = '';
+  }, []);
+
   // Skill tag state
   const [skillTags, setSkillTags] = useState<UserSkillTag[]>([]);
   const [editingMemberTags, setEditingMemberTags] = useState<number | null>(null); // userId being edited
@@ -1425,13 +1433,7 @@ const GroupPage: React.FC = () => {
       {/* Upload Document Modal */}
       <Modal
         isOpen={showUploadModal}
-        onClose={() => {
-          setShowUploadModal(false);
-          setDocUploadTitle('');
-          setDocUploadDescription('');
-          setDocUploadFile(null);
-          if (docFileInputRef.current) docFileInputRef.current.value = '';
-        }}
+        onClose={closeUploadModal}
         title="Upload Document"
       >
         <div className="form-group">
@@ -1489,11 +1491,7 @@ const GroupPage: React.FC = () => {
                 formData.append('description', docUploadDescription);
                 formData.append('file', docUploadFile);
                 await groupDocumentsApi.upload(Number(id), formData);
-                setShowUploadModal(false);
-                setDocUploadTitle('');
-                setDocUploadDescription('');
-                setDocUploadFile(null);
-                if (docFileInputRef.current) docFileInputRef.current.value = '';
+                closeUploadModal();
                 await loadDocuments(Number(id));
                 toast.showSuccess('Document uploaded successfully');
               } catch (err: unknown) {
@@ -1509,13 +1507,7 @@ const GroupPage: React.FC = () => {
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => {
-              setShowUploadModal(false);
-              setDocUploadTitle('');
-              setDocUploadDescription('');
-              setDocUploadFile(null);
-              if (docFileInputRef.current) docFileInputRef.current.value = '';
-            }}
+            onClick={closeUploadModal}
           >
             Cancel
           </button>

--- a/frontend/tests/group-documents-ux.spec.ts
+++ b/frontend/tests/group-documents-ux.spec.ts
@@ -116,16 +116,16 @@ test.describe('Group Documents UX', () => {
   test('clicking Upload Document opens the modal', async ({ page }) => {
     await navigateToDocuments(page);
     await page.getByRole('button', { name: /upload document/i }).click();
-    await expect(page.locator('.modal-overlay')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.modal-backdrop')).toBeVisible({ timeout: 5000 });
     await expect(page.getByRole('heading', { name: /upload document/i })).toBeVisible();
   });
 
   test('modal closes on Cancel', async ({ page }) => {
     await navigateToDocuments(page);
     await page.getByRole('button', { name: /upload document/i }).click();
-    await expect(page.locator('.modal-overlay')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.modal-backdrop')).toBeVisible({ timeout: 5000 });
     await page.getByRole('button', { name: /cancel/i }).click();
-    await expect(page.locator('.modal-overlay')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.modal-backdrop')).not.toBeVisible({ timeout: 5000 });
   });
 
   test('each document card has Open button and icon buttons', async ({ page, request }) => {

--- a/frontend/tests/group-documents-ux.spec.ts
+++ b/frontend/tests/group-documents-ux.spec.ts
@@ -1,0 +1,171 @@
+// frontend/tests/group-documents-ux.spec.ts
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { testUsers } from './helpers/auth';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Group Documents UX Tests
+ *
+ * Verifies the card-grid layout and modal upload introduced in the
+ * 2026-04-20 UX redesign. Tests run as a site admin (who is also a
+ * group admin) so upload/delete controls are visible.
+ */
+
+test.describe('Group Documents UX', () => {
+  let adminToken: string;
+  let groupId: number;
+  let uploadedDocId: number | null = null;
+  const tokenCachePath = path.join(os.tmpdir(), 'go-volunteer-media-e2e-admin-token.json');
+
+  const getToken = async (page: Page): Promise<string> => {
+    const token = await page.evaluate(() => localStorage.getItem('token'));
+    expect(token, 'Missing auth token').toBeTruthy();
+    return token as string;
+  };
+
+  const readCachedToken = (): string | null => {
+    try {
+      const raw = fs.readFileSync(tokenCachePath, 'utf8');
+      const parsed = JSON.parse(raw) as { token?: string };
+      return typeof parsed.token === 'string' ? parsed.token : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const writeCachedToken = (token: string) => {
+    fs.writeFileSync(tokenCachePath, JSON.stringify({ token }), 'utf8');
+  };
+
+  test.beforeAll(async ({ request }) => {
+    // Reuse cached token if still valid
+    const cached = readCachedToken();
+    if (cached) {
+      const resp = await request.get('/api/me', {
+        headers: { Authorization: `Bearer ${cached}` },
+      });
+      if (resp.ok()) {
+        adminToken = cached;
+      }
+    }
+
+    if (!adminToken) {
+      const resp = await request.post('/api/login', {
+        data: { username: testUsers.admin.username, password: testUsers.admin.password },
+      });
+      expect(resp.ok(), `Login failed: ${resp.status()}`).toBeTruthy();
+      const json = (await resp.json()) as { token: string };
+      adminToken = json.token;
+      writeCachedToken(adminToken);
+    }
+
+    // Resolve first group id
+    const groupsResp = await request.get('/api/groups', {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect(groupsResp.ok()).toBeTruthy();
+    const groups = (await groupsResp.json()) as { id: number }[];
+    expect(groups.length).toBeGreaterThan(0);
+    groupId = groups[0].id;
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((token) => {
+      localStorage.setItem('token', token);
+    }, adminToken);
+    await page.goto('/dashboard');
+    await expect(page.getByRole('button', { name: /^logout$/i })).toBeVisible({ timeout: 15000 });
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (uploadedDocId === null) return;
+    const docId = uploadedDocId;
+    uploadedDocId = null;
+    await request
+      .delete(`/api/groups/${groupId}/documents/${docId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      })
+      .catch(() => {});
+  });
+
+  const navigateToDocuments = async (page: Page) => {
+    await page.goto(`/groups/${groupId}?view=documents`);
+    await expect(page.locator('#documents-tab')).toBeVisible({ timeout: 10000 });
+    await page.click('#documents-tab');
+    await expect(page.locator('#documents-panel')).toBeVisible({ timeout: 10000 });
+  };
+
+  test('document list renders as card grid, not full-width list', async ({ page }) => {
+    await navigateToDocuments(page);
+    // Card grid should exist
+    await expect(page.locator('.document-grid')).toBeVisible({ timeout: 8000 });
+    // Old list should NOT exist
+    await expect(page.locator('.document-list')).not.toBeAttached();
+  });
+
+  test('upload form is not visible inline — only a button', async ({ page }) => {
+    await navigateToDocuments(page);
+    // Inline form must not be present
+    await expect(page.locator('.document-upload-form')).not.toBeAttached();
+    // Upload button must be visible to admins
+    await expect(page.getByRole('button', { name: /upload document/i })).toBeVisible({ timeout: 8000 });
+  });
+
+  test('clicking Upload Document opens the modal', async ({ page }) => {
+    await navigateToDocuments(page);
+    await page.getByRole('button', { name: /upload document/i }).click();
+    await expect(page.locator('.modal-overlay')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: /upload document/i })).toBeVisible();
+  });
+
+  test('modal closes on Cancel', async ({ page }) => {
+    await navigateToDocuments(page);
+    await page.getByRole('button', { name: /upload document/i }).click();
+    await expect(page.locator('.modal-overlay')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: /cancel/i }).click();
+    await expect(page.locator('.modal-overlay')).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('each document card has Open button and icon buttons', async ({ page, request }) => {
+    // Upload a document so there is at least one card to assert on
+    const pdfBuffer = Buffer.from('%PDF-1.4 test');
+    const uploadResp = await request.post(`/api/groups/${groupId}/documents`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      multipart: {
+        title: 'E2E Card Test Doc',
+        description: 'test',
+        file: { name: 'e2e-test.pdf', mimeType: 'application/pdf', buffer: pdfBuffer },
+      },
+    });
+    if (uploadResp.ok()) {
+      const json = (await uploadResp.json()) as { id: number };
+      uploadedDocId = json.id;
+    }
+
+    await navigateToDocuments(page);
+    const firstCard = page.locator('.document-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 8000 });
+
+    // Primary open button
+    await expect(firstCard.getByRole('button', { name: /open/i })).toBeVisible();
+    // Download icon button
+    await expect(firstCard.getByRole('button', { name: /download/i })).toBeVisible();
+    // Delete icon button (site admin sees this)
+    await expect(firstCard.getByRole('button', { name: /delete/i })).toBeVisible();
+  });
+
+  test('empty state shown when no documents exist and no list is rendered', async ({ page, request }) => {
+    // This test only makes sense if the group has no docs — skip if it does
+    const docsResp = await request.get(`/api/groups/${groupId}/documents`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const docs = (await docsResp.json()) as unknown[];
+    test.skip(docs.length > 0, 'Group has documents; skipping empty-state test');
+
+    await navigateToDocuments(page);
+    await expect(page.locator('.document-grid')).not.toBeAttached();
+    await expect(page.locator('.empty-state')).toBeVisible({ timeout: 8000 });
+  });
+});

--- a/frontend/tests/group-documents-ux.spec.ts
+++ b/frontend/tests/group-documents-ux.spec.ts
@@ -1,5 +1,5 @@
 // frontend/tests/group-documents-ux.spec.ts
-import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { testUsers } from './helpers/auth';
 import fs from 'fs';
 import path from 'path';
@@ -18,12 +18,6 @@ test.describe('Group Documents UX', () => {
   let groupId: number;
   let uploadedDocId: number | null = null;
   const tokenCachePath = path.join(os.tmpdir(), 'go-volunteer-media-e2e-admin-token.json');
-
-  const getToken = async (page: Page): Promise<string> => {
-    const token = await page.evaluate(() => localStorage.getItem('token'));
-    expect(token, 'Missing auth token').toBeTruthy();
-    return token as string;
-  };
 
   const readCachedToken = (): string | null => {
     try {
@@ -97,7 +91,22 @@ test.describe('Group Documents UX', () => {
     await expect(page.locator('#documents-panel')).toBeVisible({ timeout: 10000 });
   };
 
-  test('document list renders as card grid, not full-width list', async ({ page }) => {
+  test('document list renders as card grid, not full-width list', async ({ page, request }) => {
+    // Upload a document so the grid renders
+    const pdfBuffer = Buffer.from('%PDF-1.4 test');
+    const uploadResp = await request.post(`/api/groups/${groupId}/documents`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      multipart: {
+        title: 'E2E Grid Layout Test Doc',
+        description: 'grid test',
+        file: { name: 'grid-test.pdf', mimeType: 'application/pdf', buffer: pdfBuffer },
+      },
+    });
+    if (uploadResp.ok()) {
+      const json = (await uploadResp.json()) as { id: number };
+      uploadedDocId = json.id;
+    }
+
     await navigateToDocuments(page);
     // Card grid should exist
     await expect(page.locator('.document-grid')).toBeVisible({ timeout: 8000 });


### PR DESCRIPTION
## Summary

- Replaces the always-visible inline upload form with a modal triggered by an admin-only **＋ Upload Document** button, giving the document list the full page width
- Replaces the full-width `<ul>` list (where the Delete button was clipped) with a responsive card grid matching the existing animal cards pattern — file type badge, title, description, meta, and icon action buttons that never overflow
- Dark mode handled entirely via design tokens; explicit overrides added for danger icon button hover states and the actions border

## Test Plan

- [ ] Navigate to a group's Documents tab — confirm card grid renders instead of full-width list
- [ ] Confirm upload form is **not** visible inline (admin-gated ＋ Upload Document button only)
- [ ] Click **＋ Upload Document** → modal opens with title/description/file fields
- [ ] Cancel button and ✕ close both dismiss the modal and clear form state
- [ ] Upload a `.pdf`, `.docx`, or `.xlsx` file → modal closes, card appears in grid, success toast shown
- [ ] Open and Download icon buttons work on each card
- [ ] Delete icon button (admin only) triggers confirmation dialog and removes the card
- [ ] Enable dark mode — verify cards, badge, icon buttons, and danger hover all render correctly
- [ ] Resize to mobile (≤600px) — confirm grid collapses to single column
- [ ] Run `cd frontend && npx playwright test group-documents-ux` with the full stack running

🤖 Generated with [Claude Code](https://claude.com/claude-code)