### PR TITLE
feat: add video upload support for animals

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,66 @@
+# API Documentation
+
+All endpoints are prefixed with `/api` and require a valid JWT in the `Authorization: Bearer <token>` header unless noted.
+
+---
+
+## Animal Media
+
+### Get Animal Media
+
+```
+GET /api/groups/:id/animals/:animalId/media
+```
+
+Returns all images and videos for an animal. Requires group membership.
+
+**Response `200 OK`**
+```json
+{
+  "images": [{ "id": 1, "image_url": "...", "caption": "", "user": { "id": 1, "username": "..." }, ... }],
+  "videos": [{ "id": 1, "video_url": "...", "thumbnail_url": "...", "mime_type": "video/mp4", "user": { "id": 1, "username": "..." }, ... }]
+}
+```
+
+**Errors:** `403` not a group member · `404` animal not found
+
+---
+
+### Upload Animal Video
+
+```
+POST /api/groups/:id/animals/:animalId/videos
+Content-Type: multipart/form-data
+```
+
+Uploads a video and its thumbnail to Azure Blob Storage. Requires group membership and Azure storage configuration.
+
+**Form fields**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `video` | file | yes | MP4 or MOV, max 200 MB |
+| `thumbnail` | file | yes | JPEG/PNG image, client-generated |
+| `caption` | string | no | Max 500 characters |
+| `duration_seconds` | integer | no | 0–3600 |
+
+**Response `201 Created`** — the created `AnimalVideo` object with `user` preloaded.
+
+**Errors:** `400` missing/invalid field · `403` access denied · `404` animal not found · `413` video too large · `415` unsupported format · `503` Azure not configured
+
+---
+
+### Delete Animal Video
+
+```
+DELETE /api/groups/:id/animals/:animalId/videos/:videoId
+```
+
+Permanently deletes a video and its Azure blobs. Only the uploader or a site admin may delete.
+
+**Response `200 OK`**
+```json
+{ "message": "Video deleted successfully" }
+```
+
+**Errors:** `403` not owner or admin · `404` video or animal not found

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -302,7 +302,9 @@ func main() {
 
 			// Animal media and videos - all group members can view, upload videos, and delete videos
 			group.GET("/animals/:animalId/media", handlers.GetAnimalMedia(db))
-			group.POST("/animals/:animalId/videos", handlers.UploadAnimalVideo(db, storageProvider))
+			group.POST("/animals/:animalId/videos",
+				middleware.MaxRequestBodySize(210*1024*1024),
+				handlers.UploadAnimalVideo(db, storageProvider))
 			group.DELETE("/animals/:animalId/videos/:videoId", handlers.DeleteAnimalVideo(db, storageProvider))
 
 			// Animal comments - all group members can view, add, and edit own comments

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -300,6 +300,11 @@ func main() {
 			// Profile picture selection - available to all group members to help curate animal photos
 			group.PUT("/animals/:animalId/images/:imageId/set-profile", handlers.SetAnimalProfilePictureGroupScoped(db))
 
+			// Animal media and videos - all group members can view, upload videos, and delete videos
+			group.GET("/animals/:animalId/media", handlers.GetAnimalMedia(db))
+			group.POST("/animals/:animalId/videos", handlers.UploadAnimalVideo(db, storageProvider))
+			group.DELETE("/animals/:animalId/videos/:videoId", handlers.DeleteAnimalVideo(db, storageProvider))
+
 			// Animal comments - all group members can view, add, and edit own comments
 			group.GET("/animals/:animalId/comments", handlers.GetAnimalComments(db))
 			group.POST("/animals/:animalId/comments", handlers.CreateAnimalComment(db))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -258,7 +258,7 @@ export interface AnimalImage {
 
 export interface AnimalVideo {
   id: number;
-  animal_id: number | null;
+  animal_id: number;
   user_id: number;
   video_url: string;
   thumbnail_url: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -256,6 +256,25 @@ export interface AnimalImage {
   user?: User;
 }
 
+export interface AnimalVideo {
+  id: number;
+  animal_id: number | null;
+  user_id: number;
+  video_url: string;
+  thumbnail_url: string;
+  mime_type: string;
+  caption: string;
+  duration_seconds: number;
+  file_size: number;
+  created_at: string;
+  user?: User;
+}
+
+export interface AnimalMedia {
+  images: AnimalImage[];
+  videos: AnimalVideo[];
+}
+
 export interface AnimalComment {
   id: number;
   animal_id: number;
@@ -585,6 +604,28 @@ export const animalsApi = {
   },
   deleteImage: (groupId: number, animalId: number, imageId: number) =>
     api.delete('/groups/' + groupId + '/animals/' + animalId + '/images/' + imageId),
+  getMedia: (groupId: number, animalId: number) =>
+    api.get<AnimalMedia>('/groups/' + groupId + '/animals/' + animalId + '/media'),
+  uploadVideo: (
+    groupId: number,
+    animalId: number,
+    videoFile: File,
+    thumbnailBlob: Blob,
+    caption?: string,
+    durationSeconds?: number,
+  ) => {
+    const formData = new FormData();
+    formData.append('video', videoFile);
+    formData.append('thumbnail', new File([thumbnailBlob], 'thumbnail.jpg', { type: 'image/jpeg' }));
+    if (caption) formData.append('caption', caption);
+    formData.append('duration_seconds', String(durationSeconds ?? 0));
+    return api.post<AnimalVideo>(
+      '/groups/' + groupId + '/animals/' + animalId + '/videos',
+      formData,
+    );
+  },
+  deleteVideo: (groupId: number, animalId: number, videoId: number) =>
+    api.delete('/groups/' + groupId + '/animals/' + animalId + '/videos/' + videoId),
   getDeletedImages: (groupId: number) =>
     api.get<AnimalImage[]>('/admin/groups/' + groupId + '/deleted-images'),
   setProfilePicture: (groupId: number, animalId: number, imageId: number) =>

--- a/frontend/src/components/VideoUpload.tsx
+++ b/frontend/src/components/VideoUpload.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { animalsApi } from '../api/client';
+
+const MAX_VIDEO_SIZE = 200 * 1024 * 1024;
+const ALLOWED_TYPES = ['video/mp4', 'video/quicktime'];
+
+interface VideoUploadProps {
+  groupId: number;
+  animalId: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess, onCancel }) => {
+  const [videoFile, setVideoFile] = useState<File | null>(null);
+  const [caption, setCaption] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError('Only MP4 and MOV videos are supported.');
+      return;
+    }
+    if (file.size > MAX_VIDEO_SIZE) {
+      setError('This video is too large. Please use a clip under 200MB.');
+      return;
+    }
+    setError(null);
+    setVideoFile(file);
+  };
+
+  const extractThumbnail = (file: File): Promise<{ blob: Blob; duration: number }> =>
+    new Promise((resolve, reject) => {
+      const video = document.createElement('video');
+      video.preload = 'metadata';
+      video.muted = true;
+      const objectUrl = URL.createObjectURL(file);
+
+      video.onloadeddata = () => {
+        video.currentTime = 0;
+      };
+
+      video.onseeked = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          URL.revokeObjectURL(objectUrl);
+          reject(new Error('Canvas context unavailable'));
+          return;
+        }
+        ctx.drawImage(video, 0, 0);
+        canvas.toBlob(
+          (blob) => {
+            URL.revokeObjectURL(objectUrl);
+            if (!blob) {
+              reject(new Error('Failed to generate thumbnail'));
+              return;
+            }
+            resolve({ blob, duration: Math.round(video.duration) });
+          },
+          'image/jpeg',
+          0.85,
+        );
+      };
+
+      video.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error('Failed to load video'));
+      };
+
+      video.src = objectUrl;
+    });
+
+  const handleUpload = async () => {
+    if (!videoFile) return;
+    setUploading(true);
+    setError(null);
+
+    let thumbnailBlob: Blob;
+    let duration: number;
+    try {
+      ({ blob: thumbnailBlob, duration } = await extractThumbnail(videoFile));
+    } catch {
+      setError("Couldn't generate a preview for this video. Please try a different file.");
+      setUploading(false);
+      return;
+    }
+
+    try {
+      await animalsApi.uploadVideo(groupId, animalId, videoFile, thumbnailBlob, caption, duration);
+      onSuccess();
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(msg || 'Upload failed. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="video-upload">
+      <h3>Upload Video</h3>
+      <input
+        type="file"
+        accept="video/mp4,video/quicktime,.mp4,.mov"
+        onChange={handleFileSelect}
+        disabled={uploading}
+      />
+      {videoFile && (
+        <p className="file-selected">{videoFile.name} ({(videoFile.size / 1024 / 1024).toFixed(1)} MB)</p>
+      )}
+      <input
+        type="text"
+        placeholder="Caption (optional)"
+        value={caption}
+        onChange={(e) => setCaption(e.target.value)}
+        disabled={uploading}
+      />
+      {error && <p className="upload-error">{error}</p>}
+      <div className="upload-actions">
+        <button onClick={onCancel} disabled={uploading} className="btn-secondary">
+          Cancel
+        </button>
+        <button onClick={handleUpload} disabled={!videoFile || uploading} className="btn-primary">
+          {uploading ? 'Uploading…' : 'Upload Video'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default VideoUpload;

--- a/frontend/src/components/VideoUpload.tsx
+++ b/frontend/src/components/VideoUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { animalsApi } from '../api/client';
 
 const MAX_VIDEO_SIZE = 200 * 1024 * 1024;
@@ -17,6 +17,17 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
   const [caption, setCaption] = useState('');
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!preselectedFile) return;
+    if (!ALLOWED_TYPES.includes(preselectedFile.type)) {
+      setError('Only MP4 and MOV videos are supported.');
+      setVideoFile(null);
+    } else if (preselectedFile.size > MAX_VIDEO_SIZE) {
+      setError('This video is too large. Please use a clip under 200MB.');
+      setVideoFile(null);
+    }
+  }, [preselectedFile]);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -40,12 +51,7 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
       video.muted = true;
       const objectUrl = URL.createObjectURL(file);
 
-      video.onloadeddata = () => {
-        video.currentTime = 0;
-      };
-
-      video.onseeked = () => {
-        video.onseeked = null;
+      const capture = () => {
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;
@@ -68,6 +74,19 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
           'image/jpeg',
           0.85,
         );
+      };
+
+      video.onloadeddata = () => {
+        if (video.currentTime === 0) {
+          // Already at frame 0 — draw directly; seeking to 0 may not fire onseeked
+          capture();
+        } else {
+          video.onseeked = () => {
+            video.onseeked = null;
+            capture();
+          };
+          video.currentTime = 0;
+        }
       };
 
       video.onerror = () => {

--- a/frontend/src/components/VideoUpload.tsx
+++ b/frontend/src/components/VideoUpload.tsx
@@ -9,10 +9,11 @@ interface VideoUploadProps {
   animalId: number;
   onSuccess: () => void;
   onCancel: () => void;
+  preselectedFile?: File;
 }
 
-const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess, onCancel }) => {
-  const [videoFile, setVideoFile] = useState<File | null>(null);
+const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess, onCancel, preselectedFile }) => {
+  const [videoFile, setVideoFile] = useState<File | null>(preselectedFile ?? null);
   const [caption, setCaption] = useState('');
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,6 +45,7 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
       };
 
       video.onseeked = () => {
+        video.onseeked = null;
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;

--- a/frontend/src/pages/PhotoGallery.tsx
+++ b/frontend/src/pages/PhotoGallery.tsx
@@ -20,6 +20,7 @@ const PhotoGallery: React.FC = () => {
   const [videos, setVideos] = useState<AnimalVideo[]>([]);
   const [selectedVideo, setSelectedVideo] = useState<AnimalVideo | null>(null);
   const [showVideoUpload, setShowVideoUpload] = useState(false);
+  const [pendingVideoFile, setPendingVideoFile] = useState<File | null>(null);
   const [deletedImages, setDeletedImages] = useState<AnimalImage[]>([]);
   const [showDeleted, setShowDeleted] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -282,6 +283,7 @@ const PhotoGallery: React.FC = () => {
                 if (!file) return;
                 e.target.value = '';
                 if (file.type.startsWith('video/')) {
+                  setPendingVideoFile(file);
                   setShowVideoUpload(true);
                 } else {
                   setEditingImageUrl(URL.createObjectURL(file));
@@ -502,12 +504,14 @@ const PhotoGallery: React.FC = () => {
               <VideoUpload
                 groupId={Number(groupId)}
                 animalId={Number(id)}
+                preselectedFile={pendingVideoFile ?? undefined}
                 onSuccess={() => {
                   setShowVideoUpload(false);
+                  setPendingVideoFile(null);
                   showToast('Video uploaded successfully', 'success');
                   loadData(Number(groupId), Number(id));
                 }}
-                onCancel={() => setShowVideoUpload(false)}
+                onCancel={() => { setShowVideoUpload(false); setPendingVideoFile(null); }}
               />
             </div>
           </div>

--- a/frontend/src/pages/PhotoGallery.tsx
+++ b/frontend/src/pages/PhotoGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { animalsApi } from '../api/client';
 import type { Animal, AnimalImage, AnimalVideo } from '../api/client';
@@ -21,6 +21,7 @@ const PhotoGallery: React.FC = () => {
   const [selectedVideo, setSelectedVideo] = useState<AnimalVideo | null>(null);
   const [showVideoUpload, setShowVideoUpload] = useState(false);
   const [pendingVideoFile, setPendingVideoFile] = useState<File | null>(null);
+  const mediaInputRef = useRef<HTMLInputElement>(null);
   const [deletedImages, setDeletedImages] = useState<AnimalImage[]>([]);
   const [showDeleted, setShowDeleted] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -274,7 +275,7 @@ const PhotoGallery: React.FC = () => {
               {videos.length === 1 ? 'video' : 'videos'}
             </p>
             <input
-              id="media-upload-input"
+              ref={mediaInputRef}
               type="file"
               accept="image/*,video/mp4,video/quicktime,.mov"
               style={{ display: 'none' }}
@@ -291,7 +292,7 @@ const PhotoGallery: React.FC = () => {
                 }
               }}
             />
-            <button className="btn-primary" onClick={() => document.getElementById('media-upload-input')?.click()}>
+            <button className="btn-primary" onClick={() => mediaInputRef.current?.click()}>
               + Upload Media
             </button>
           </div>
@@ -337,7 +338,7 @@ const PhotoGallery: React.FC = () => {
         {images.length === 0 && videos.length === 0 ? (
           <div className="no-photos">
             <p>No media has been shared for {animal.name} yet.</p>
-            <button className="btn-primary" onClick={() => document.getElementById('media-upload-input')?.click()}>
+            <button className="btn-primary" onClick={() => mediaInputRef.current?.click()}>
               Upload First Media
             </button>
           </div>
@@ -470,7 +471,6 @@ const PhotoGallery: React.FC = () => {
                 <video
                   src={selectedVideo.video_url}
                   controls
-                  autoPlay
                   style={{ maxWidth: '100%', maxHeight: '80vh' }}
                 />
                 <div className="lightbox-info">

--- a/frontend/src/pages/PhotoGallery.tsx
+++ b/frontend/src/pages/PhotoGallery.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { animalsApi } from '../api/client';
-import type { Animal, AnimalImage } from '../api/client';
+import type { Animal, AnimalImage, AnimalVideo } from '../api/client';
+import VideoUpload from '../components/VideoUpload';
 import type { AxiosResponse } from 'axios';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
@@ -16,6 +17,9 @@ const PhotoGallery: React.FC = () => {
   const { showToast } = useToast();
   const [animal, setAnimal] = useState<Animal | null>(null);
   const [images, setImages] = useState<AnimalImage[]>([]);
+  const [videos, setVideos] = useState<AnimalVideo[]>([]);
+  const [selectedVideo, setSelectedVideo] = useState<AnimalVideo | null>(null);
+  const [showVideoUpload, setShowVideoUpload] = useState(false);
   const [deletedImages, setDeletedImages] = useState<AnimalImage[]>([]);
   const [showDeleted, setShowDeleted] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -37,7 +41,7 @@ const PhotoGallery: React.FC = () => {
     try {
       const promises = [
         animalsApi.getById(gId, animalId),
-        animalsApi.getImages(gId, animalId),
+        animalsApi.getMedia(gId, animalId),
       ];
 
       if (isAdmin) {
@@ -45,14 +49,15 @@ const PhotoGallery: React.FC = () => {
       }
 
       const results = await Promise.all(promises);
-      const [animalRes, imagesRes, deletedRes] = results as [
+      const [animalRes, mediaRes, deletedRes] = results as [
         AxiosResponse<Animal>,
-        AxiosResponse<AnimalImage[]>,
+        AxiosResponse<{ images: AnimalImage[]; videos: AnimalVideo[] }>,
         AxiosResponse<{ data?: AnimalImage[] }> | undefined,
       ];
 
       setAnimal(animalRes.data);
-      setImages(imagesRes.data);
+      setImages(mediaRes.data.images);
+      setVideos(mediaRes.data.videos);
 
       if (isAdmin && deletedRes) {
         setDeletedImages(deletedRes.data.data || (deletedRes.data as unknown as AnimalImage[]));
@@ -85,6 +90,24 @@ const PhotoGallery: React.FC = () => {
         } catch (error) {
           console.error('Failed to delete image:', error);
           showToast('Failed to delete photo', 'error');
+        }
+      },
+    );
+  };
+
+  const handleDeleteVideo = (videoId: number) => {
+    if (!groupId || !id) return;
+    openConfirmDialog(
+      'Delete Video',
+      'Are you sure you want to delete this video?',
+      async () => {
+        try {
+          await animalsApi.deleteVideo(Number(groupId), Number(id), videoId);
+          showToast('Video deleted successfully', 'success');
+          setSelectedVideo(null);
+          await loadData(Number(groupId), Number(id));
+        } catch {
+          showToast('Failed to delete video', 'error');
         }
       },
     );
@@ -246,10 +269,28 @@ const PhotoGallery: React.FC = () => {
           <h1>{animal.name}'s Photos</h1>
           <div className="gallery-header-actions">
             <p className="photo-count">
-              {images.length} {images.length === 1 ? 'photo' : 'photos'}
+              {images.length} {images.length === 1 ? 'photo' : 'photos'}, {videos.length}{' '}
+              {videos.length === 1 ? 'video' : 'videos'}
             </p>
-            <button className="btn-primary" onClick={() => setShowUploadModal(true)}>
-              + Upload Photo
+            <input
+              id="media-upload-input"
+              type="file"
+              accept="image/*,video/mp4,video/quicktime,.mov"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                e.target.value = '';
+                if (file.type.startsWith('video/')) {
+                  setShowVideoUpload(true);
+                } else {
+                  setEditingImageUrl(URL.createObjectURL(file));
+                  setShowImageEditor(true);
+                }
+              }}
+            />
+            <button className="btn-primary" onClick={() => document.getElementById('media-upload-input')?.click()}>
+              + Upload Media
             </button>
           </div>
         </div>
@@ -291,18 +332,18 @@ const PhotoGallery: React.FC = () => {
           </div>
         )}
 
-        {images.length === 0 ? (
+        {images.length === 0 && videos.length === 0 ? (
           <div className="no-photos">
-            <p>No photos have been shared for {animal.name} yet.</p>
-            <button className="btn-primary" onClick={() => setShowUploadModal(true)}>
-              Upload First Photo
+            <p>No media has been shared for {animal.name} yet.</p>
+            <button className="btn-primary" onClick={() => document.getElementById('media-upload-input')?.click()}>
+              Upload First Media
             </button>
           </div>
         ) : (
           <div className="photos-grid">
             {images.map((image, index) => (
               <div
-                key={image.id}
+                key={`img-${image.id}`}
                 className="photo-card"
                 onClick={() => openLightbox(index)}
               >
@@ -312,13 +353,26 @@ const PhotoGallery: React.FC = () => {
                 <img src={image.image_url} alt={image.caption || `Photo ${index + 1}`} />
                 <div className="photo-info">
                   <span className="photo-author">{image.user?.username}</span>
-                  <span className="photo-date">
-                    {new Date(image.created_at).toLocaleDateString()}
-                  </span>
+                  <span className="photo-date">{new Date(image.created_at).toLocaleDateString()}</span>
                 </div>
-                {image.caption && (
-                  <div className="photo-caption">{image.caption}</div>
-                )}
+                {image.caption && <div className="photo-caption">{image.caption}</div>}
+              </div>
+            ))}
+            {videos.map((video) => (
+              <div
+                key={`vid-${video.id}`}
+                className="photo-card video-card"
+                onClick={() => setSelectedVideo(video)}
+              >
+                <div className="video-thumbnail-wrapper">
+                  <img src={video.thumbnail_url} alt={video.caption || 'Video thumbnail'} />
+                  <div className="play-overlay">▶</div>
+                </div>
+                <div className="photo-info">
+                  <span className="photo-author">{video.user?.username}</span>
+                  <span className="photo-date">{new Date(video.created_at).toLocaleDateString()}</span>
+                </div>
+                {video.caption && <div className="photo-caption">{video.caption}</div>}
               </div>
             ))}
           </div>
@@ -401,6 +455,60 @@ const PhotoGallery: React.FC = () => {
               >
                 ›
               </button>
+            </div>
+          </div>
+        )}
+
+        {/* Video player modal */}
+        {selectedVideo && (
+          <div className="lightbox" onClick={() => setSelectedVideo(null)}>
+            <div className="lightbox-content" onClick={(e) => e.stopPropagation()}>
+              <button className="lightbox-close" onClick={() => setSelectedVideo(null)}>✕</button>
+              <div className="lightbox-image-container">
+                <video
+                  src={selectedVideo.video_url}
+                  controls
+                  autoPlay
+                  style={{ maxWidth: '100%', maxHeight: '80vh' }}
+                />
+                <div className="lightbox-info">
+                  {selectedVideo.caption && (
+                    <p className="lightbox-caption">{selectedVideo.caption}</p>
+                  )}
+                  <div className="lightbox-meta">
+                    <span>By {selectedVideo.user?.username}</span>
+                    <span>{new Date(selectedVideo.created_at).toLocaleDateString()}</span>
+                  </div>
+                  <div className="lightbox-actions">
+                    {(isAdmin || selectedVideo.user?.id === user?.id) && (
+                      <button
+                        className="btn-danger"
+                        onClick={() => handleDeleteVideo(selectedVideo.id)}
+                      >
+                        Delete Video
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Video upload modal */}
+        {showVideoUpload && groupId && id && (
+          <div className="modal-overlay">
+            <div className="modal-content">
+              <VideoUpload
+                groupId={Number(groupId)}
+                animalId={Number(id)}
+                onSuccess={() => {
+                  setShowVideoUpload(false);
+                  showToast('Video uploaded successfully', 'success');
+                  loadData(Number(groupId), Number(id));
+                }}
+                onCancel={() => setShowVideoUpload(false)}
+              />
             </div>
           </div>
         )}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -165,6 +165,7 @@ func RunMigrations(db *gorm.DB) error {
 		&models.AnimalTag{},
 		&models.UserSkillTag{},
 		&models.AnimalImage{},
+		&models.AnimalVideo{},
 		&models.AnimalNameHistory{},
 		&models.GroupDocument{},
 	)

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -196,6 +196,12 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 
 		if err := db.Create(&animalVideo).Error; err != nil {
 			logger.Error("Failed to save video to database", err)
+			if delErr := storageProvider.DeleteImage(ctx, videoBlobID+videoBlobExt); delErr != nil {
+				logger.Error("Failed to clean up video blob after DB failure", delErr)
+			}
+			if delErr := storageProvider.DeleteImage(ctx, thumbBlobID+thumbExt); delErr != nil {
+				logger.Error("Failed to clean up thumbnail blob after DB failure", delErr)
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save video"})
 			return
 		}

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
+)
+
+type mediaResponse struct {
+	Images []models.AnimalImage `json:"images"`
+	Videos []models.AnimalVideo `json:"videos"`
+}
+
+// GetAnimalMedia returns all images and videos for an animal.
+// GET /api/groups/:id/animals/:animalId/media
+func GetAnimalMedia(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		logger := middleware.GetLogger(c)
+		groupID := c.Param("id")
+		animalID := c.Param("animalId")
+		userIDUint, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userIDUint, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		var animal models.Animal
+		if err := db.Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
+			return
+		}
+
+		var images []models.AnimalImage
+		if err := db.
+			Select("id, created_at, updated_at, animal_id, user_id, image_url, caption, is_profile_picture, width, height, file_size").
+			Where("animal_id = ?", animalID).
+			Order("is_profile_picture DESC, created_at DESC").
+			Find(&images).Error; err != nil {
+			logger.Error("Failed to fetch animal images", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch media"})
+			return
+		}
+
+		var videos []models.AnimalVideo
+		if err := db.Preload("User").
+			Where("animal_id = ?", animalID).
+			Order("created_at DESC").
+			Find(&videos).Error; err != nil {
+			logger.Error("Failed to fetch animal videos", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch media"})
+			return
+		}
+
+		c.JSON(http.StatusOK, mediaResponse{Images: images, Videos: videos})
+	}
+}

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -213,3 +213,65 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		c.JSON(http.StatusOK, animalVideo)
 	}
 }
+
+// DeleteAnimalVideo deletes a video and its Azure blobs. Only the uploader or a site admin may delete.
+// DELETE /api/groups/:id/animals/:animalId/videos/:videoId
+func DeleteAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		logger := middleware.GetLogger(c)
+		groupID := c.Param("id")
+		animalID := c.Param("animalId")
+		videoID := c.Param("videoId")
+		userIDUint, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userIDUint, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		var video models.AnimalVideo
+		if err := db.Where("id = ?", videoID).First(&video).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Video not found"})
+			return
+		}
+
+		if video.AnimalID == nil || strconv.FormatUint(uint64(*video.AnimalID), 10) != animalID {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Video not found"})
+			return
+		}
+
+		isAdminBool, _ := isAdmin.(bool)
+		if video.UserID != userIDUint && !isAdminBool {
+			c.JSON(http.StatusForbidden, gin.H{"error": "You can only delete your own videos"})
+			return
+		}
+
+		if video.BlobIdentifier != "" {
+			if err := storageProvider.DeleteImage(ctx, video.BlobIdentifier); err != nil {
+				logger.WithFields(map[string]interface{}{"error": err.Error(), "blob": video.BlobIdentifier}).
+					Warn("Failed to delete video blob")
+			}
+		}
+
+		if video.ThumbnailBlobID != "" {
+			if err := storageProvider.DeleteImage(ctx, video.ThumbnailBlobID); err != nil {
+				logger.WithFields(map[string]interface{}{"error": err.Error(), "blob": video.ThumbnailBlobID}).
+					Warn("Failed to delete thumbnail blob")
+			}
+		}
+
+		if err := db.Delete(&video).Error; err != nil {
+			logger.Error("Failed to delete video from database", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete video"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Video deleted successfully"})
+	}
+}

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -171,7 +171,12 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		}
 
 		videoExt := strings.ToLower(filepath.Ext(videoFile.Filename))
-		videoMimeType := upload.AllowedVideoTypes[videoExt][0]
+		mimeTypes, ok := upload.AllowedVideoTypes[videoExt]
+		if !ok || len(mimeTypes) == 0 {
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "Only MP4 and MOV videos are supported."})
+			return
+		}
+		videoMimeType := mimeTypes[0]
 
 		videoURL, videoBlobID, videoBlobExt, err := storageProvider.UploadImage(ctx, videoData, videoMimeType, map[string]string{"caption": caption})
 		if err != nil {

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -103,6 +103,18 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			return
 		}
 
+		caption := c.PostForm("caption")
+		if len(caption) > 500 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "caption must be 500 characters or fewer"})
+			return
+		}
+
+		durationSeconds, _ := strconv.Atoi(c.PostForm("duration_seconds"))
+		if durationSeconds < 0 || durationSeconds > 3600 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration must be between 0 and 3600 seconds"})
+			return
+		}
+
 		videoFile, err := c.FormFile("video")
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "No video file uploaded"})
@@ -151,18 +163,8 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			return
 		}
 
-		caption := c.PostForm("caption")
-		if len(caption) > 500 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "caption must be 500 characters or fewer"})
-			return
-		}
-
-		durationSeconds, _ := strconv.Atoi(c.PostForm("duration_seconds"))
-		if durationSeconds < 0 || durationSeconds > 3600 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "duration must be between 0 and 3600 seconds"})
-			return
-		}
-
+		// The thumbnail is client-supplied and is not verified to be a frame from
+		// the uploaded video. This is intentional for the volunteer portal use-case.
 		thumbURL, thumbBlobID, thumbExt, err := storageProvider.UploadImage(ctx, thumbData, "image/jpeg", map[string]string{"caption": caption})
 		if err != nil {
 			logger.Error("Failed to upload thumbnail", err)
@@ -178,6 +180,8 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		}
 		videoMimeType := mimeTypes[0]
 
+		// UploadImage is intentionally reused for video blobs; the provider stores
+		// any content type without image-specific processing.
 		videoURL, videoBlobID, videoBlobExt, err := storageProvider.UploadImage(ctx, videoData, videoMimeType, map[string]string{"caption": caption})
 		if err != nil {
 			logger.Error("Failed to upload video, cleaning up thumbnail", err)
@@ -266,7 +270,9 @@ func DeleteAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			return
 		}
 
-		if err := db.Delete(&video).Error; err != nil {
+		// Hard-delete: blobs are permanently removed below, so a soft-delete
+		// row would point to missing blobs if ever recovered.
+		if err := db.Unscoped().Delete(&video).Error; err != nil {
 			logger.Error("Failed to delete video from database", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete video"})
 			return

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -47,7 +47,7 @@ func GetAnimalMedia(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		var images []models.AnimalImage
-		if err := db.
+		if err := db.Preload("User").
 			Select("id, created_at, updated_at, animal_id, user_id, image_url, caption, is_profile_picture, width, height, file_size").
 			Where("animal_id = ?", animalID).
 			Order("is_profile_picture DESC, created_at DESC").
@@ -88,7 +88,7 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		isAdmin, _ := c.Get("is_admin")
 
 		if storageProvider.Name() != storage.ProviderAzure {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Video upload is not available right now. Please contact support."})
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Video upload is not available right now. Please contact support."})
 			return
 		}
 
@@ -191,7 +191,6 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			FileSize:        videoFile.Size,
 			BlobIdentifier:  videoBlobID + videoBlobExt,
 			ThumbnailBlobID: thumbBlobID + thumbExt,
-			BlobExtension:   videoBlobExt,
 		}
 
 		if err := db.Create(&animalVideo).Error; err != nil {
@@ -241,13 +240,14 @@ func DeleteAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			return
 		}
 
-		var video models.AnimalVideo
-		if err := db.Where("id = ?", videoID).First(&video).Error; err != nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Video not found"})
+		var animal models.Animal
+		if err := db.Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
 			return
 		}
 
-		if video.AnimalID == nil || strconv.FormatUint(uint64(*video.AnimalID), 10) != animalID {
+		var video models.AnimalVideo
+		if err := db.Where("id = ? AND animal_id = ?", videoID, animal.ID).First(&video).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Video not found"})
 			return
 		}
@@ -255,6 +255,12 @@ func DeleteAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		isAdminBool, _ := isAdmin.(bool)
 		if video.UserID != userIDUint && !isAdminBool {
 			c.JSON(http.StatusForbidden, gin.H{"error": "You can only delete your own videos"})
+			return
+		}
+
+		if err := db.Delete(&video).Error; err != nil {
+			logger.Error("Failed to delete video from database", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete video"})
 			return
 		}
 
@@ -270,12 +276,6 @@ func DeleteAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 				logger.WithFields(map[string]interface{}{"error": err.Error(), "blob": video.ThumbnailBlobID}).
 					Warn("Failed to delete thumbnail blob")
 			}
-		}
-
-		if err := db.Delete(&video).Error; err != nil {
-			logger.Error("Failed to delete video from database", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete video"})
-			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{"message": "Video deleted successfully"})

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -87,13 +87,13 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		}
 		isAdmin, _ := c.Get("is_admin")
 
-		if storageProvider.Name() != storage.ProviderAzure {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Video upload is not available right now. Please contact support."})
+		if !checkGroupAccess(db, userIDUint, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
 			return
 		}
 
-		if !checkGroupAccess(db, userIDUint, isAdmin, groupID) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		if storageProvider.Name() != storage.ProviderAzure {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Video upload is not available right now. Please contact support."})
 			return
 		}
 
@@ -152,7 +152,16 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		}
 
 		caption := c.PostForm("caption")
+		if len(caption) > 500 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "caption must be 500 characters or fewer"})
+			return
+		}
+
 		durationSeconds, _ := strconv.Atoi(c.PostForm("duration_seconds"))
+		if durationSeconds < 0 || durationSeconds > 3600 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration must be between 0 and 3600 seconds"})
+			return
+		}
 
 		thumbURL, thumbBlobID, thumbExt, err := storageProvider.UploadImage(ctx, thumbData, "image/jpeg", map[string]string{"caption": caption})
 		if err != nil {
@@ -162,10 +171,7 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 		}
 
 		videoExt := strings.ToLower(filepath.Ext(videoFile.Filename))
-		videoMimeType := "video/mp4"
-		if videoExt == ".mov" {
-			videoMimeType = "video/quicktime"
-		}
+		videoMimeType := upload.AllowedVideoTypes[videoExt][0]
 
 		videoURL, videoBlobID, videoBlobExt, err := storageProvider.UploadImage(ctx, videoData, videoMimeType, map[string]string{"caption": caption})
 		if err != nil {

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -177,11 +177,8 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			return
 		}
 
-		animalIDUint, _ := strconv.ParseUint(animalID, 10, 32)
-		animalIDVal := uint(animalIDUint)
-
 		animalVideo := models.AnimalVideo{
-			AnimalID:        &animalIDVal,
+			AnimalID:        animal.ID,
 			UserID:          userIDUint,
 			VideoURL:        videoURL,
 			ThumbnailURL:    thumbURL,
@@ -215,7 +212,7 @@ func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.Handle
 			"size":      videoFile.Size,
 		}).Info("Video uploaded and stored")
 
-		c.JSON(http.StatusOK, animalVideo)
+		c.JSON(http.StatusCreated, animalVideo)
 	}
 }
 

--- a/internal/handlers/animal_video.go
+++ b/internal/handlers/animal_video.go
@@ -1,11 +1,18 @@
 package handlers
 
 import (
+	"errors"
+	"io"
 	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/storage"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/upload"
 	"gorm.io/gorm"
 )
 
@@ -61,5 +68,148 @@ func GetAnimalMedia(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, mediaResponse{Images: images, Videos: videos})
+	}
+}
+
+// UploadAnimalVideo handles video uploads to the animal gallery.
+// Azure Blob Storage is required — videos are never stored in PostgreSQL.
+// POST /api/groups/:id/animals/:animalId/videos
+func UploadAnimalVideo(db *gorm.DB, storageProvider storage.Provider) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		logger := middleware.GetLogger(c)
+		groupID := c.Param("id")
+		animalID := c.Param("animalId")
+		userIDUint, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+		isAdmin, _ := c.Get("is_admin")
+
+		if storageProvider.Name() != storage.ProviderAzure {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Video upload is not available right now. Please contact support."})
+			return
+		}
+
+		if !checkGroupAccess(db, userIDUint, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		var animal models.Animal
+		if err := db.Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
+			return
+		}
+
+		videoFile, err := c.FormFile("video")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No video file uploaded"})
+			return
+		}
+		if err := upload.ValidateVideoUpload(videoFile, upload.MaxVideoSize); err != nil {
+			if errors.Is(err, upload.ErrFileTooLarge) {
+				c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "This video is too large. Please use a clip under 200MB."})
+			} else {
+				c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "Only MP4 and MOV videos are supported."})
+			}
+			return
+		}
+
+		thumbnailFile, err := c.FormFile("thumbnail")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No thumbnail file uploaded"})
+			return
+		}
+		if err := upload.ValidateImageUpload(thumbnailFile, upload.MaxImageSize); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid thumbnail image"})
+			return
+		}
+
+		videoSrc, err := videoFile.Open()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process video"})
+			return
+		}
+		defer videoSrc.Close()
+		videoData, err := io.ReadAll(videoSrc)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process video"})
+			return
+		}
+
+		thumbSrc, err := thumbnailFile.Open()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process thumbnail"})
+			return
+		}
+		defer thumbSrc.Close()
+		thumbData, err := io.ReadAll(thumbSrc)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process thumbnail"})
+			return
+		}
+
+		caption := c.PostForm("caption")
+		durationSeconds, _ := strconv.Atoi(c.PostForm("duration_seconds"))
+
+		thumbURL, thumbBlobID, thumbExt, err := storageProvider.UploadImage(ctx, thumbData, "image/jpeg", map[string]string{"caption": caption})
+		if err != nil {
+			logger.Error("Failed to upload thumbnail", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Upload failed. Please try again."})
+			return
+		}
+
+		videoExt := strings.ToLower(filepath.Ext(videoFile.Filename))
+		videoMimeType := "video/mp4"
+		if videoExt == ".mov" {
+			videoMimeType = "video/quicktime"
+		}
+
+		videoURL, videoBlobID, videoBlobExt, err := storageProvider.UploadImage(ctx, videoData, videoMimeType, map[string]string{"caption": caption})
+		if err != nil {
+			logger.Error("Failed to upload video, cleaning up thumbnail", err)
+			if delErr := storageProvider.DeleteImage(ctx, thumbBlobID+thumbExt); delErr != nil {
+				logger.Error("Failed to clean up thumbnail after video upload failure", delErr)
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Upload failed. Please try again."})
+			return
+		}
+
+		animalIDUint, _ := strconv.ParseUint(animalID, 10, 32)
+		animalIDVal := uint(animalIDUint)
+
+		animalVideo := models.AnimalVideo{
+			AnimalID:        &animalIDVal,
+			UserID:          userIDUint,
+			VideoURL:        videoURL,
+			ThumbnailURL:    thumbURL,
+			MimeType:        videoMimeType,
+			Caption:         caption,
+			DurationSeconds: durationSeconds,
+			FileSize:        videoFile.Size,
+			BlobIdentifier:  videoBlobID + videoBlobExt,
+			ThumbnailBlobID: thumbBlobID + thumbExt,
+			BlobExtension:   videoBlobExt,
+		}
+
+		if err := db.Create(&animalVideo).Error; err != nil {
+			logger.Error("Failed to save video to database", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save video"})
+			return
+		}
+
+		if err := db.Preload("User").First(&animalVideo, animalVideo.ID).Error; err != nil {
+			logger.Error("Failed to preload user for video response", err)
+		}
+
+		logger.WithFields(map[string]interface{}{
+			"video_id":  animalVideo.ID,
+			"animal_id": animalID,
+			"size":      videoFile.Size,
+		}).Info("Video uploaded and stored")
+
+		c.JSON(http.StatusOK, animalVideo)
 	}
 }

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -86,6 +86,48 @@ func itoa(n uint) string {
 	return fmt.Sprintf("%d", n)
 }
 
+func TestGetAnimalMedia_ImagesIncludeUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+
+	group := models.Group{Name: "Dogs2", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "uploader", Email: "up@test.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Buddy", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	animalIDRef := animal.ID
+	assert.NoError(t, db.Create(&models.AnimalImage{
+		AnimalID: &animalIDRef,
+		UserID:   user.ID,
+		ImageURL: "/images/buddy.jpg",
+	}).Error)
+
+	r := gin.New()
+	r.GET("/groups/:id/animals/:animalId/media", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, GetAnimalMedia(db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/groups/"+itoa(group.ID)+"/animals/"+itoa(animal.ID)+"/media", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Images []models.AnimalImage `json:"images"`
+		Videos []models.AnimalVideo `json:"videos"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Len(t, body.Images, 1)
+	assert.NotZero(t, body.Images[0].User.ID, "image should include preloaded User")
+	assert.Equal(t, user.ID, body.Images[0].User.ID)
+}
+
 func TestUploadAnimalVideo_AzureRequired(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := setupVideoTestDB(t)
@@ -110,7 +152,7 @@ func TestUploadAnimalVideo_AzureRequired(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 	assert.Contains(t, w.Body.String(), "Video upload is not available right now")
 }
 
@@ -171,6 +213,69 @@ func TestDeleteAnimalVideo(t *testing.T) {
 
 	videoBlob := "video-blob-id.mp4"
 	thumbBlob := "thumb-blob-id.png"
+
+	t.Run("cross-group delete rejected when animal belongs to different group", func(t *testing.T) {
+		group2 := models.Group{Name: "Cats", Description: "x"}
+		assert.NoError(t, db.Create(&group2).Error)
+		animalGroup2 := models.Animal{Name: "Luna", Species: "Cat", GroupID: group2.ID, Status: "available"}
+		assert.NoError(t, db.Create(&animalGroup2).Error)
+
+		animalIDRef := animalGroup2.ID
+		video := models.AnimalVideo{
+			AnimalID:        &animalIDRef,
+			UserID:          owner.ID,
+			VideoURL:        "/video.mp4",
+			ThumbnailURL:    "/thumb.jpg",
+			BlobIdentifier:  "cross-group-video.mp4",
+			ThumbnailBlobID: "cross-group-thumb.png",
+		}
+		assert.NoError(t, db.Create(&video).Error)
+
+		store := &mockStorageProvider{ProviderName: "azure"}
+		r := gin.New()
+		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
+			c.Set("user_id", owner.ID)
+			c.Set("is_admin", false)
+		}, DeleteAnimalVideo(db, store))
+
+		path := "/groups/" + itoa(group.ID) + "/animals/" + itoa(animalGroup2.ID) + "/videos/" + itoa(video.ID)
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Empty(t, store.DeletedBlobs, "no blobs should be deleted when animal is in a different group")
+	})
+
+	t.Run("site admin can delete video without being the uploader", func(t *testing.T) {
+		admin := models.User{Username: "admin", Email: "admin@t.com", Password: "x", IsAdmin: true}
+		assert.NoError(t, db.Create(&admin).Error)
+
+		animalIDRef := animal.ID
+		video := models.AnimalVideo{
+			AnimalID:        &animalIDRef,
+			UserID:          owner.ID,
+			VideoURL:        "/video.mp4",
+			ThumbnailURL:    "/thumb.jpg",
+			BlobIdentifier:  videoBlob,
+			ThumbnailBlobID: thumbBlob,
+		}
+		assert.NoError(t, db.Create(&video).Error)
+
+		store := &mockStorageProvider{ProviderName: "azure"}
+		r := gin.New()
+		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
+			c.Set("user_id", admin.ID)
+			c.Set("is_admin", true)
+		}, DeleteAnimalVideo(db, store))
+
+		path := "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos/" + itoa(video.ID)
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, store.DeletedBlobs, videoBlob)
+		assert.Contains(t, store.DeletedBlobs, thumbBlob)
+	})
 
 	t.Run("non-owner is forbidden", func(t *testing.T) {
 		store := &mockStorageProvider{ProviderName: "azure"}

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -89,6 +89,32 @@ func itoa(n uint) string {
 	return fmt.Sprintf("%d", n)
 }
 
+func TestGetAnimalMedia_NonMemberIsForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	stranger := models.User{Username: "stranger", Email: "stranger@test.com", Password: "x"}
+	assert.NoError(t, db.Create(&stranger).Error)
+	// stranger is deliberately NOT added to the group
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.GET("/groups/:id/animals/:animalId/media", func(c *gin.Context) {
+		c.Set("user_id", stranger.ID)
+		c.Set("is_admin", false)
+	}, GetAnimalMedia(db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/groups/"+itoa(group.ID)+"/animals/"+itoa(animal.ID)+"/media", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestGetAnimalMedia_ImagesIncludeUser(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := setupVideoTestDB(t)

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -85,3 +85,71 @@ func TestGetAnimalMedia(t *testing.T) {
 func itoa(n uint) string {
 	return fmt.Sprintf("%d", n)
 }
+
+func TestUploadAnimalVideo_AzureRequired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{} // Name() returns "mock", not "azure"
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoMultipartRequest(t, minimalMP4, minimalJPEG)
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Video upload is not available right now")
+}
+
+func TestUploadAnimalVideo_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoMultipartRequest(t, minimalMP4, minimalJPEG)
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var video models.AnimalVideo
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &video))
+	assert.NotZero(t, video.ID)
+	assert.Equal(t, "Test caption", video.Caption)
+	assert.Equal(t, 15, video.DurationSeconds)
+
+	// Verify DB record
+	var dbVideo models.AnimalVideo
+	assert.NoError(t, db.First(&dbVideo, video.ID).Error)
+	assert.Equal(t, *dbVideo.AnimalID, animal.ID)
+	assert.NotZero(t, video.User.ID, "response should include the preloaded User")
+	assert.Equal(t, user.ID, video.User.ID)
+}

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -153,3 +153,71 @@ func TestUploadAnimalVideo_Success(t *testing.T) {
 	assert.NotZero(t, video.User.ID, "response should include the preloaded User")
 	assert.Equal(t, user.ID, video.User.ID)
 }
+
+func TestDeleteAnimalVideo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	owner := models.User{Username: "owner", Email: "owner@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&owner).Error)
+	assert.NoError(t, db.Model(&owner).Association("Groups").Append(&group))
+	other := models.User{Username: "other", Email: "other@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&other).Error)
+	assert.NoError(t, db.Model(&other).Association("Groups").Append(&group))
+
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+	animalIDRef := animal.ID
+
+	videoBlob := "video-blob-id.mp4"
+	thumbBlob := "thumb-blob-id.png"
+	video := models.AnimalVideo{
+		AnimalID:        &animalIDRef,
+		UserID:          owner.ID,
+		VideoURL:        "/video.mp4",
+		ThumbnailURL:    "/thumb.jpg",
+		BlobIdentifier:  videoBlob,
+		ThumbnailBlobID: thumbBlob,
+	}
+	assert.NoError(t, db.Create(&video).Error)
+
+	t.Run("non-owner is forbidden", func(t *testing.T) {
+		r := gin.New()
+		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
+			c.Set("user_id", other.ID)
+			c.Set("is_admin", false)
+		}, DeleteAnimalVideo(db, store))
+
+		path := "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos/" + itoa(video.ID)
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("owner can delete and blobs are cleaned up", func(t *testing.T) {
+		r := gin.New()
+		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
+			c.Set("user_id", owner.ID)
+			c.Set("is_admin", false)
+		}, DeleteAnimalVideo(db, store))
+
+		path := "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos/" + itoa(video.ID)
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Both blobs must be queued for deletion
+		assert.Contains(t, store.DeletedBlobs, videoBlob)
+		assert.Contains(t, store.DeletedBlobs, thumbBlob)
+
+		// Record should be soft-deleted
+		var count int64
+		db.Model(&models.AnimalVideo{}).Where("id = ?", video.ID).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+}

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -53,7 +53,7 @@ func TestGetAnimalMedia(t *testing.T) {
 		ImageURL: "/images/test.jpg",
 	}).Error)
 	assert.NoError(t, db.Create(&models.AnimalVideo{
-		AnimalID:     &animalIDRef,
+		AnimalID:     animalIDRef,
 		UserID:       user.ID,
 		VideoURL:     "/videos/test.mp4",
 		ThumbnailURL: "/images/thumb.jpg",
@@ -180,7 +180,7 @@ func TestUploadAnimalVideo_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusCreated, w.Code)
 
 	var video models.AnimalVideo
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &video))
@@ -191,9 +191,74 @@ func TestUploadAnimalVideo_Success(t *testing.T) {
 	// Verify DB record
 	var dbVideo models.AnimalVideo
 	assert.NoError(t, db.First(&dbVideo, video.ID).Error)
-	assert.Equal(t, *dbVideo.AnimalID, animal.ID)
+	assert.Equal(t, dbVideo.AnimalID, animal.ID)
 	assert.NotZero(t, video.User.ID, "response should include the preloaded User")
 	assert.Equal(t, user.ID, video.User.ID)
+}
+
+func TestUploadAnimalVideo_VideoUploadFails_ThumbnailCleanedup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	// Call 1 (thumbnail) succeeds; call 2 (video) fails.
+	store := &mockStorageProvider{
+		ProviderName:          "azure",
+		UploadImageCallErrors: map[int]error{2: fmt.Errorf("azure: container unavailable")},
+	}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoMultipartRequest(t, minimalMP4, minimalJPEG)
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, store.DeletedBlobs, "test-uuid-1.png", "thumbnail blob should be cleaned up after video upload failure")
+	assert.Len(t, store.DeletedBlobs, 1, "only the thumbnail should be deleted")
+}
+
+func TestUploadAnimalVideo_DBCreateFails_BothBlobsCleanedup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	// Drop the video table so db.Create fails while earlier queries still work.
+	db.Exec("DROP TABLE animal_videos")
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoMultipartRequest(t, minimalMP4, minimalJPEG)
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, store.DeletedBlobs, "test-uuid-1.png", "thumbnail blob should be cleaned up on DB failure")
+	assert.Contains(t, store.DeletedBlobs, "test-uuid-2.png", "video blob should be cleaned up on DB failure")
 }
 
 func TestDeleteAnimalVideo(t *testing.T) {
@@ -222,7 +287,7 @@ func TestDeleteAnimalVideo(t *testing.T) {
 
 		animalIDRef := animalGroup2.ID
 		video := models.AnimalVideo{
-			AnimalID:        &animalIDRef,
+			AnimalID:        animalIDRef,
 			UserID:          owner.ID,
 			VideoURL:        "/video.mp4",
 			ThumbnailURL:    "/thumb.jpg",
@@ -252,7 +317,7 @@ func TestDeleteAnimalVideo(t *testing.T) {
 
 		animalIDRef := animal.ID
 		video := models.AnimalVideo{
-			AnimalID:        &animalIDRef,
+			AnimalID:        animalIDRef,
 			UserID:          owner.ID,
 			VideoURL:        "/video.mp4",
 			ThumbnailURL:    "/thumb.jpg",
@@ -281,7 +346,7 @@ func TestDeleteAnimalVideo(t *testing.T) {
 		store := &mockStorageProvider{ProviderName: "azure"}
 		animalIDRef := animal.ID
 		video := models.AnimalVideo{
-			AnimalID:        &animalIDRef,
+			AnimalID:        animalIDRef,
 			UserID:          owner.ID,
 			VideoURL:        "/video.mp4",
 			ThumbnailURL:    "/thumb.jpg",
@@ -308,7 +373,7 @@ func TestDeleteAnimalVideo(t *testing.T) {
 		store := &mockStorageProvider{ProviderName: "azure"}
 		animalIDRef := animal.ID
 		video := models.AnimalVideo{
-			AnimalID:        &animalIDRef,
+			AnimalID:        animalIDRef,
 			UserID:          owner.ID,
 			VideoURL:        "/video.mp4",
 			ThumbnailURL:    "/thumb.jpg",

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -194,6 +197,180 @@ func TestUploadAnimalVideo_Success(t *testing.T) {
 	assert.Equal(t, dbVideo.AnimalID, animal.ID)
 	assert.NotZero(t, video.User.ID, "response should include the preloaded User")
 	assert.Equal(t, user.ID, video.User.ID)
+}
+
+// createVideoRequestWithFields builds a multipart POST with explicit caption, duration, and filename.
+func createVideoRequestWithFields(t *testing.T, videoContent, thumbContent []byte, filename, caption, duration string) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	vp, err := writer.CreateFormFile("video", filename)
+	if err != nil {
+		t.Fatalf("failed to create video form file: %v", err)
+	}
+	if _, err := vp.Write(videoContent); err != nil {
+		t.Fatalf("failed to write video content: %v", err)
+	}
+
+	tp, err := writer.CreateFormFile("thumbnail", "thumb.jpg")
+	if err != nil {
+		t.Fatalf("failed to create thumbnail form file: %v", err)
+	}
+	if _, err := tp.Write(thumbContent); err != nil {
+		t.Fatalf("failed to write thumbnail content: %v", err)
+	}
+
+	_ = writer.WriteField("caption", caption)
+	_ = writer.WriteField("duration_seconds", duration)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/test", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func TestUploadAnimalVideo_NonMemberGetsForbiddenNotStorageError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{} // Name() returns "mock", not "azure"
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "stranger", Email: "s@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	// user is deliberately NOT added to group
+
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoMultipartRequest(t, minimalMP4, minimalJPEG)
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "access check must run before storage check so non-members don't learn about Azure configuration")
+}
+
+func TestUploadAnimalVideo_MovFile_StoresMimeTypeAsQuicktime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoRequestWithFields(t, minimalMP4, minimalJPEG, "clip.mov", "", "5")
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var video models.AnimalVideo
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &video))
+	assert.Equal(t, "video/quicktime", video.MimeType)
+}
+
+func TestUploadAnimalVideo_NegativeDuration_ReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoRequestWithFields(t, minimalMP4, minimalJPEG, "clip.mp4", "hello", "-1")
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "duration")
+}
+
+func TestUploadAnimalVideo_DurationTooLarge_ReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	req := createVideoRequestWithFields(t, minimalMP4, minimalJPEG, "clip.mp4", "", "3601")
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "duration")
+}
+
+func TestUploadAnimalVideo_CaptionTooLong_ReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+	store := &mockStorageProvider{ProviderName: "azure"}
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "v@t.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	r := gin.New()
+	r.POST("/groups/:id/animals/:animalId/videos", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, UploadAnimalVideo(db, store))
+
+	longCaption := strings.Repeat("x", 501)
+	req := createVideoRequestWithFields(t, minimalMP4, minimalJPEG, "clip.mp4", longCaption, "10")
+	req.URL.Path = "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "caption")
 }
 
 func TestUploadAnimalVideo_VideoUploadFails_ThumbnailCleanedup(t *testing.T) {

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -157,7 +157,6 @@ func TestUploadAnimalVideo_Success(t *testing.T) {
 func TestDeleteAnimalVideo(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := setupVideoTestDB(t)
-	store := &mockStorageProvider{ProviderName: "azure"}
 
 	group := models.Group{Name: "Dogs", Description: "x"}
 	assert.NoError(t, db.Create(&group).Error)
@@ -167,24 +166,25 @@ func TestDeleteAnimalVideo(t *testing.T) {
 	other := models.User{Username: "other", Email: "other@t.com", Password: "x"}
 	assert.NoError(t, db.Create(&other).Error)
 	assert.NoError(t, db.Model(&other).Association("Groups").Append(&group))
-
 	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
 	assert.NoError(t, db.Create(&animal).Error)
-	animalIDRef := animal.ID
 
 	videoBlob := "video-blob-id.mp4"
 	thumbBlob := "thumb-blob-id.png"
-	video := models.AnimalVideo{
-		AnimalID:        &animalIDRef,
-		UserID:          owner.ID,
-		VideoURL:        "/video.mp4",
-		ThumbnailURL:    "/thumb.jpg",
-		BlobIdentifier:  videoBlob,
-		ThumbnailBlobID: thumbBlob,
-	}
-	assert.NoError(t, db.Create(&video).Error)
 
 	t.Run("non-owner is forbidden", func(t *testing.T) {
+		store := &mockStorageProvider{ProviderName: "azure"}
+		animalIDRef := animal.ID
+		video := models.AnimalVideo{
+			AnimalID:        &animalIDRef,
+			UserID:          owner.ID,
+			VideoURL:        "/video.mp4",
+			ThumbnailURL:    "/thumb.jpg",
+			BlobIdentifier:  videoBlob,
+			ThumbnailBlobID: thumbBlob,
+		}
+		assert.NoError(t, db.Create(&video).Error)
+
 		r := gin.New()
 		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
 			c.Set("user_id", other.ID)
@@ -196,9 +196,22 @@ func TestDeleteAnimalVideo(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, store.DeletedBlobs, "no blobs should be deleted on forbidden request")
 	})
 
 	t.Run("owner can delete and blobs are cleaned up", func(t *testing.T) {
+		store := &mockStorageProvider{ProviderName: "azure"}
+		animalIDRef := animal.ID
+		video := models.AnimalVideo{
+			AnimalID:        &animalIDRef,
+			UserID:          owner.ID,
+			VideoURL:        "/video.mp4",
+			ThumbnailURL:    "/thumb.jpg",
+			BlobIdentifier:  videoBlob,
+			ThumbnailBlobID: thumbBlob,
+		}
+		assert.NoError(t, db.Create(&video).Error)
+
 		r := gin.New()
 		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
 			c.Set("user_id", owner.ID)
@@ -211,11 +224,9 @@ func TestDeleteAnimalVideo(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		// Both blobs must be queued for deletion
 		assert.Contains(t, store.DeletedBlobs, videoBlob)
 		assert.Contains(t, store.DeletedBlobs, thumbBlob)
 
-		// Record should be soft-deleted
 		var count int64
 		db.Model(&models.AnimalVideo{}).Where("id = ?", video.ID).Count(&count)
 		assert.Equal(t, int64(0), count)

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupVideoTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	assert.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.Animal{},
+		&models.AnimalImage{},
+		&models.AnimalVideo{},
+	))
+	return db
+}
+
+func TestGetAnimalMedia(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+
+	group := models.Group{Name: "Dogs", Description: "Dog group"}
+	assert.NoError(t, db.Create(&group).Error)
+
+	user := models.User{Username: "vol", Email: "vol@test.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+
+	animal := models.Animal{Name: "Rex", Species: "Dog", GroupID: group.ID, Status: "available"}
+	assert.NoError(t, db.Create(&animal).Error)
+
+	// Seed one image and one video
+	animalIDRef := animal.ID
+	assert.NoError(t, db.Create(&models.AnimalImage{
+		AnimalID: &animalIDRef,
+		UserID:   user.ID,
+		ImageURL: "/images/test.jpg",
+	}).Error)
+	assert.NoError(t, db.Create(&models.AnimalVideo{
+		AnimalID:     &animalIDRef,
+		UserID:       user.ID,
+		VideoURL:     "/videos/test.mp4",
+		ThumbnailURL: "/images/thumb.jpg",
+	}).Error)
+
+	r := gin.New()
+	r.GET("/groups/:id/animals/:animalId/media", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, GetAnimalMedia(db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/groups/"+itoa(group.ID)+"/animals/"+itoa(animal.ID)+"/media", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Images []models.AnimalImage `json:"images"`
+		Videos []models.AnimalVideo `json:"videos"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Len(t, body.Images, 1)
+	assert.Len(t, body.Videos, 1)
+}
+
+// itoa converts uint to string for URL building in tests.
+func itoa(n uint) string {
+	return fmt.Sprintf("%d", n)
+}

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -84,9 +84,28 @@ func TestGetAnimalMedia(t *testing.T) {
 	assert.Len(t, body.Videos, 1)
 }
 
-// itoa converts uint to string for URL building in tests.
-func itoa(n uint) string {
-	return fmt.Sprintf("%d", n)
+func TestGetAnimalMedia_UnknownAnimalReturns404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupVideoTestDB(t)
+
+	group := models.Group{Name: "Dogs", Description: "x"}
+	assert.NoError(t, db.Create(&group).Error)
+	user := models.User{Username: "vol", Email: "vol@test.com", Password: "x"}
+	assert.NoError(t, db.Create(&user).Error)
+	assert.NoError(t, db.Model(&user).Association("Groups").Append(&group))
+
+	r := gin.New()
+	r.GET("/groups/:id/animals/:animalId/media", func(c *gin.Context) {
+		c.Set("user_id", user.ID)
+		c.Set("is_admin", false)
+	}, GetAnimalMedia(db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/groups/"+itoa(group.ID)+"/animals/99999/media", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestGetAnimalMedia_NonMemberIsForbidden(t *testing.T) {
@@ -481,6 +500,37 @@ func TestDeleteAnimalVideo(t *testing.T) {
 
 	videoBlob := "video-blob-id.mp4"
 	thumbBlob := "thumb-blob-id.png"
+
+	t.Run("non-member is forbidden", func(t *testing.T) {
+		stranger := models.User{Username: "stranger", Email: "stranger@t.com", Password: "x"}
+		assert.NoError(t, db.Create(&stranger).Error)
+		// stranger is deliberately NOT added to group
+
+		store := &mockStorageProvider{ProviderName: "azure"}
+		animalIDRef := animal.ID
+		video := models.AnimalVideo{
+			AnimalID:        animalIDRef,
+			UserID:          owner.ID,
+			VideoURL:        "/video.mp4",
+			ThumbnailURL:    "/thumb.jpg",
+			BlobIdentifier:  videoBlob,
+			ThumbnailBlobID: thumbBlob,
+		}
+		assert.NoError(t, db.Create(&video).Error)
+
+		r := gin.New()
+		r.DELETE("/groups/:id/animals/:animalId/videos/:videoId", func(c *gin.Context) {
+			c.Set("user_id", stranger.ID)
+			c.Set("is_admin", false)
+		}, DeleteAnimalVideo(db, store))
+
+		path := "/groups/" + itoa(group.ID) + "/animals/" + itoa(animal.ID) + "/videos/" + itoa(video.ID)
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, store.DeletedBlobs)
+	})
 
 	t.Run("cross-group delete rejected when animal belongs to different group", func(t *testing.T) {
 		group2 := models.Group{Name: "Cats", Description: "x"}

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -198,6 +198,11 @@ func (m *mockStorageProvider) DeleteDocument(_ context.Context, _ string) error 
 func (m *mockStorageProvider) GetImageURL(_ string) string                      { return "" }
 func (m *mockStorageProvider) GetDocumentURL(_ string) string                   { return "" }
 
+// itoa converts a uint to its decimal string representation for URL construction in tests.
+func itoa(n uint) string {
+	return fmt.Sprintf("%d", n)
+}
+
 // createImageMultipartRequest builds a multipart/form-data POST request containing one image file.
 func createImageMultipartRequest(t *testing.T, fieldName, filename string, content []byte) *http.Request {
 	t.Helper()

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -145,14 +146,18 @@ func (m *mockConverter) ToPDF(_ context.Context, _ []byte, _ string) ([]byte, er
 
 // mockStorageProvider is a test double for storage.Provider.
 // Set ProviderName to control what Name() returns (default: "mock").
-// Set UploadImageErr or UploadDocumentErr to simulate failures.
+// Set UploadImageErr to fail every call, or UploadImageCallErrors to fail specific
+// calls by 1-based index. Each successful call returns a unique identifier
+// ("test-uuid-N") so tests can assert which blobs were cleaned up.
 // DeletedBlobs records every identifier passed to DeleteImage.
 type mockStorageProvider struct {
-	ProviderName      string
-	UploadImageErr    error
-	UploadDocumentErr error
-	LastMimeType      string
-	DeletedBlobs      []string
+	ProviderName          string
+	UploadImageErr        error
+	UploadImageCallErrors map[int]error // 1-based call index → error
+	UploadDocumentErr     error
+	LastMimeType          string
+	DeletedBlobs          []string
+	uploadCallCount       int
 }
 
 func (m *mockStorageProvider) Name() string {
@@ -162,11 +167,16 @@ func (m *mockStorageProvider) Name() string {
 	return "mock"
 }
 func (m *mockStorageProvider) UploadImage(_ context.Context, _ []byte, mimeType string, _ map[string]string) (string, string, string, error) {
+	m.uploadCallCount++
 	m.LastMimeType = mimeType
+	if err, ok := m.UploadImageCallErrors[m.uploadCallCount]; ok {
+		return "", "", "", err
+	}
 	if m.UploadImageErr != nil {
 		return "", "", "", m.UploadImageErr
 	}
-	return "/api/images/test-uuid", "test-uuid", ".png", nil
+	id := fmt.Sprintf("test-uuid-%d", m.uploadCallCount)
+	return "/api/images/" + id, id, ".png", nil
 }
 func (m *mockStorageProvider) UploadDocument(_ context.Context, _ []byte, _, _ string) (string, string, string, error) {
 	if m.UploadDocumentErr != nil {

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -144,14 +144,23 @@ func (m *mockConverter) ToPDF(_ context.Context, _ []byte, _ string) ([]byte, er
 }
 
 // mockStorageProvider is a test double for storage.Provider.
-// Set UploadImageErr or UploadDocumentErr to simulate storage failures.
+// Set ProviderName to control what Name() returns (default: "mock").
+// Set UploadImageErr or UploadDocumentErr to simulate failures.
+// DeletedBlobs records every identifier passed to DeleteImage.
 type mockStorageProvider struct {
+	ProviderName      string
 	UploadImageErr    error
 	UploadDocumentErr error
 	LastMimeType      string
+	DeletedBlobs      []string
 }
 
-func (m *mockStorageProvider) Name() string { return "mock" }
+func (m *mockStorageProvider) Name() string {
+	if m.ProviderName != "" {
+		return m.ProviderName
+	}
+	return "mock"
+}
 func (m *mockStorageProvider) UploadImage(_ context.Context, _ []byte, mimeType string, _ map[string]string) (string, string, string, error) {
 	m.LastMimeType = mimeType
 	if m.UploadImageErr != nil {
@@ -171,7 +180,10 @@ func (m *mockStorageProvider) GetImage(_ context.Context, _ string) ([]byte, str
 func (m *mockStorageProvider) GetDocument(_ context.Context, _ string) ([]byte, string, error) {
 	return nil, "", nil
 }
-func (m *mockStorageProvider) DeleteImage(_ context.Context, _ string) error    { return nil }
+func (m *mockStorageProvider) DeleteImage(_ context.Context, identifier string) error {
+	m.DeletedBlobs = append(m.DeletedBlobs, identifier)
+	return nil
+}
 func (m *mockStorageProvider) DeleteDocument(_ context.Context, _ string) error { return nil }
 func (m *mockStorageProvider) GetImageURL(_ string) string                      { return "" }
 func (m *mockStorageProvider) GetDocumentURL(_ string) string                   { return "" }
@@ -189,6 +201,49 @@ func createImageMultipartRequest(t *testing.T, fieldName, filename string, conte
 		t.Fatalf("Failed to write file content: %v", err)
 	}
 	writer.Close()
+	req := httptest.NewRequest(http.MethodPost, "/test", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// minimalMP4 passes isVideoContent — "ftyp" box type at bytes 4-7.
+var minimalMP4 = func() []byte {
+	b := make([]byte, 20)
+	copy(b[4:8], []byte("ftyp"))
+	copy(b[8:12], []byte("isom"))
+	return b
+}()
+
+// minimalJPEG is a valid JPEG header that passes ValidateImageUpload.
+var minimalJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46}
+
+// createVideoMultipartRequest builds a multipart POST with "video", "thumbnail",
+// "caption", and "duration_seconds" fields.
+func createVideoMultipartRequest(t *testing.T, videoContent, thumbContent []byte) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	videoPart, err := writer.CreateFormFile("video", "clip.mp4")
+	if err != nil {
+		t.Fatalf("failed to create video form file: %v", err)
+	}
+	if _, err := videoPart.Write(videoContent); err != nil {
+		t.Fatalf("failed to write video content: %v", err)
+	}
+
+	thumbPart, err := writer.CreateFormFile("thumbnail", "thumb.jpg")
+	if err != nil {
+		t.Fatalf("failed to create thumbnail form file: %v", err)
+	}
+	if _, err := thumbPart.Write(thumbContent); err != nil {
+		t.Fatalf("failed to write thumbnail content: %v", err)
+	}
+
+	_ = writer.WriteField("caption", "Test caption")
+	_ = writer.WriteField("duration_seconds", "15")
+	writer.Close()
+
 	req := httptest.NewRequest(http.MethodPost, "/test", body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -396,7 +396,7 @@ type AnimalVideo struct {
 	CreatedAt       time.Time      `json:"created_at"`
 	UpdatedAt       time.Time      `json:"updated_at"`
 	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
-	AnimalID        *uint          `gorm:"index:idx_animal_video_animal" json:"animal_id"`
+	AnimalID        uint           `gorm:"not null;index:idx_animal_video_animal" json:"animal_id"`
 	UserID          uint           `gorm:"not null;index" json:"user_id"`
 	VideoURL        string         `gorm:"not null" json:"video_url"`
 	ThumbnailURL    string         `gorm:"not null" json:"thumbnail_url"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -406,7 +406,6 @@ type AnimalVideo struct {
 	FileSize        int64          `json:"file_size"`
 	BlobIdentifier  string         `json:"-"` // UUID+ext of video blob in Azure
 	ThumbnailBlobID string         `json:"-"` // UUID+ext of thumbnail blob in Azure
-	BlobExtension   string         `json:"-"` // e.g. ".mp4"
 	User            User           `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -390,6 +390,26 @@ type AnimalImage struct {
 	Animal           Animal         `gorm:"foreignKey:AnimalID" json:"animal,omitempty"`
 }
 
+// AnimalVideo represents a video uploaded for an animal
+type AnimalVideo struct {
+	ID              uint           `gorm:"primaryKey" json:"id"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
+	AnimalID        *uint          `gorm:"index:idx_animal_video_animal" json:"animal_id"`
+	UserID          uint           `gorm:"not null;index" json:"user_id"`
+	VideoURL        string         `gorm:"not null" json:"video_url"`
+	ThumbnailURL    string         `gorm:"not null" json:"thumbnail_url"`
+	MimeType        string         `gorm:"default:'video/mp4'" json:"mime_type"`
+	Caption         string         `json:"caption"`
+	DurationSeconds int            `json:"duration_seconds"`
+	FileSize        int64          `json:"file_size"`
+	BlobIdentifier  string         `json:"-"` // UUID+ext of video blob in Azure
+	ThumbnailBlobID string         `json:"-"` // UUID+ext of thumbnail blob in Azure
+	BlobExtension   string         `json:"-"` // e.g. ".mp4"
+	User            User           `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
 // AnimalNameHistory tracks name changes for an animal
 type AnimalNameHistory struct {
 	ID        uint      `gorm:"primaryKey" json:"id"`

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -300,7 +300,8 @@ func isVideoContent(data []byte) bool {
 	}
 	boxType := data[4:8]
 	for _, valid := range [][]byte{
-		[]byte("ftyp"), []byte("moov"), []byte("wide"), []byte("mdat"), []byte("free"),
+		[]byte("ftyp"),
+		[]byte("moov"), // legacy QuickTime files without ftyp box
 	} {
 		if bytes.Equal(boxType, valid) {
 			return true

--- a/internal/upload/validation.go
+++ b/internal/upload/validation.go
@@ -20,6 +20,9 @@ const (
 
 	// MaxDocumentSize is the maximum allowed document upload size (20MB)
 	MaxDocumentSize = 20 * 1024 * 1024 // 20 MB
+
+	// MaxVideoSize is the maximum allowed video upload size (200MB)
+	MaxVideoSize = 200 * 1024 * 1024 // 200 MB
 )
 
 var (
@@ -50,6 +53,12 @@ var AllowedDocumentTypes = map[string][]string{
 	".pdf":  {"application/pdf"},
 	".docx": {"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
 	".xlsx": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+}
+
+// AllowedVideoTypes maps file extensions to their MIME types for video uploads
+var AllowedVideoTypes = map[string][]string{
+	".mp4": {"video/mp4"},
+	".mov": {"video/quicktime"},
 }
 
 // ValidateImageUpload validates an uploaded image file
@@ -247,4 +256,55 @@ func MimeTypeFromFilename(filename string) string {
 		return types[0]
 	}
 	return "application/octet-stream"
+}
+
+// ValidateVideoUpload validates an uploaded video file (size, extension, magic bytes).
+// Videos must be MP4 or MOV and fit within maxSize bytes.
+func ValidateVideoUpload(file *multipart.FileHeader, maxSize int64) error {
+	if file.Size > maxSize {
+		return fmt.Errorf("%w: file size is %d bytes, maximum is %d bytes",
+			ErrFileTooLarge, file.Size, maxSize)
+	}
+
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	if _, ok := AllowedVideoTypes[ext]; !ok {
+		return fmt.Errorf("%w: extension %s is not allowed (only .mp4 and .mov are supported)",
+			ErrInvalidFileType, ext)
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer src.Close()
+
+	buf := make([]byte, 12)
+	n, err := src.Read(buf)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	if !isVideoContent(buf[:n]) {
+		return fmt.Errorf("%w: file does not appear to be a valid MP4 or MOV video",
+			ErrInvalidFileType)
+	}
+
+	return nil
+}
+
+// isVideoContent checks the ISO Base Media File Format box type at bytes 4-7.
+// Both MP4 and MOV are built on this format.
+func isVideoContent(data []byte) bool {
+	if len(data) < 8 {
+		return false
+	}
+	boxType := data[4:8]
+	for _, valid := range [][]byte{
+		[]byte("ftyp"), []byte("moov"), []byte("wide"), []byte("mdat"), []byte("free"),
+	} {
+		if bytes.Equal(boxType, valid) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/upload/validation_video_test.go
+++ b/internal/upload/validation_video_test.go
@@ -63,6 +63,14 @@ func TestValidateVideoUpload(t *testing.T) {
 			wantErr:     ErrInvalidFileType,
 			errContains: "does not appear to be a valid",
 		},
+		{
+			name:        "empty content",
+			fileSize:    4,
+			filename:    "clip.mp4",
+			content:     []byte{0x00, 0x00, 0x00, 0x04},
+			wantErr:     ErrInvalidFileType,
+			errContains: "does not appear to be a valid",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/upload/validation_video_test.go
+++ b/internal/upload/validation_video_test.go
@@ -1,0 +1,109 @@
+package upload
+
+import (
+	"bytes"
+	"errors"
+	"mime/multipart"
+	"strings"
+	"testing"
+)
+
+func TestValidateVideoUpload(t *testing.T) {
+	// MP4: 4-byte size, "ftyp" at bytes 4-7, brand "isom" at 8-11
+	minimalMP4 := make([]byte, 20)
+	copy(minimalMP4[4:8], []byte("ftyp"))
+	copy(minimalMP4[8:12], []byte("isom"))
+
+	// MOV: "ftyp" at bytes 4-7, brand "qt  " at 8-11
+	minimalMOV := make([]byte, 20)
+	copy(minimalMOV[4:8], []byte("ftyp"))
+	copy(minimalMOV[8:12], []byte("qt  "))
+
+	tests := []struct {
+		name        string
+		fileSize    int64
+		filename    string
+		content     []byte
+		wantErr     error
+		errContains string
+	}{
+		{
+			name:     "valid MP4",
+			fileSize: 10 * 1024 * 1024,
+			filename: "clip.mp4",
+			content:  minimalMP4,
+		},
+		{
+			name:     "valid MOV",
+			fileSize: 10 * 1024 * 1024,
+			filename: "clip.mov",
+			content:  minimalMOV,
+		},
+		{
+			name:        "file too large",
+			fileSize:    201 * 1024 * 1024,
+			filename:    "big.mp4",
+			content:     minimalMP4,
+			wantErr:     ErrFileTooLarge,
+			errContains: "file size exceeds maximum limit",
+		},
+		{
+			name:        "unsupported extension",
+			fileSize:    1024,
+			filename:    "clip.avi",
+			content:     minimalMP4,
+			wantErr:     ErrInvalidFileType,
+			errContains: "extension .avi is not allowed",
+		},
+		{
+			name:        "wrong magic bytes",
+			fileSize:    1024,
+			filename:    "clip.mp4",
+			content:     []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x00, 0x00, 0x00}, // JPEG bytes
+			wantErr:     ErrInvalidFileType,
+			errContains: "does not appear to be a valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &bytes.Buffer{}
+			writer := multipart.NewWriter(body)
+			part, err := writer.CreateFormFile("video", tt.filename)
+			if err != nil {
+				t.Fatalf("failed to create form file: %v", err)
+			}
+			if _, err := part.Write(tt.content); err != nil {
+				t.Fatalf("failed to write content: %v", err)
+			}
+			writer.Close()
+
+			reader := multipart.NewReader(body, writer.Boundary())
+			form, err := reader.ReadForm(32 << 20)
+			if err != nil {
+				t.Fatalf("failed to read form: %v", err)
+			}
+			defer form.RemoveAll()
+
+			files := form.File["video"]
+			if len(files) == 0 {
+				t.Fatal("no files in form")
+			}
+			fh := files[0]
+			fh.Size = tt.fileSize
+
+			err = ValidateVideoUpload(fh, MaxVideoSize)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("got %v, want %v", err, tt.wantErr)
+				}
+				if tt.errContains != "" && (err == nil || !strings.Contains(err.Error(), tt.errContains)) {
+					t.Errorf("error %q does not contain %q", err, tt.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `AnimalVideo` model backed by a new `animal_videos` table with Azure Blob Storage (no PostgreSQL fallback)
- New `GET /api/groups/:id/animals/:animalId/media` endpoint returns images and videos in a unified response
- New `POST` and `DELETE` video endpoints with Azure-only enforcement, validation (MP4/MOV, 200MB limit), thumbnail upload, and blob cleanup on failure
- `VideoUpload` React component handles client-side first-frame thumbnail extraction before uploading
- `PhotoGallery` updated to show a mixed image/video grid; videos show thumbnail with play overlay and open in a modal player

## Test Plan

- [ ] Backend: `go test ./internal/upload/... ./internal/handlers/...` — all new tests pass (6 validation, 5 handler tests across GetAnimalMedia, UploadAnimalVideo, DeleteAnimalVideo)
- [ ] TypeScript: `npx tsc --noEmit` in `frontend/` — no errors
- [ ] Binary: `go build ./cmd/api/...` — clean build
- [ ] Manual: Upload a short `.mp4` or `.mov` from an iPhone/Android via the gallery — verify thumbnail appears, modal plays video, delete removes it
- [ ] Verify Azure storage is configured (`STORAGE_PROVIDER=azure`) — video upload returns a clear error if not

> **Note:** `TestCreateGroup/accepts_valid_GroupMe_bot_id` is a pre-existing failure unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)