### PR TITLE
fix: add media-src blob: to CSP to unblock video thumbnail capture

### DIFF
--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -538,6 +538,7 @@ func TestSecurityHeaders(t *testing.T) {
 			// Verify CSP contains key directives
 			expectedCSPDirectives := []string{
 				"default-src 'self'",
+				"media-src 'self' blob:",
 				"frame-src 'self' blob:",
 				"frame-ancestors 'none'",
 				"base-uri 'self'",

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -24,6 +24,7 @@ func SecurityHeaders() gin.HandlerFunc {
 			"script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
 			"style-src 'self' 'unsafe-inline'; " +
 			"img-src 'self' data: blob: https:; " +
+			"media-src 'self' blob:; " +
 			"font-src 'self' data:; " +
 			"frame-src 'self' blob:; " +
 			"connect-src 'self'; " +


### PR DESCRIPTION
## Root cause

`<video src="blob:...">` was blocked by the Content Security Policy. Without an explicit `media-src` directive, the browser falls back to `default-src 'self'`, which does not permit `blob:` URLs.

This caused `video.onerror` to fire immediately on every browser before any thumbnail capture logic could run, producing the "Couldn't generate a preview for this video" error. The iOS-specific fix in #213 was addressing the wrong layer — the blob URL was refused before iOS HEVC frame-decode behaviour was ever relevant.

`img-src` and `frame-src` already included `blob:` — `media-src` was simply never added when the video upload feature was introduced.

## Change

```go
// internal/middleware/security.go
"media-src 'self' blob:; "
```

One directive added. Test updated to assert its presence.

## Test plan

- [ ] Upload an iPhone MOV on iOS Safari — thumbnail generates and upload succeeds
- [ ] Upload an MP4 on desktop Chrome/Firefox — still works
- [ ] Upload on Android — still works
- [ ] Verify CSP test passes: `go test ./internal/middleware/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)