### PR TITLE
fix: replace ReadTimeout with ReadHeaderTimeout to allow large video uploads

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -445,16 +445,19 @@ func main() {
 		port = "8080"
 	}
 
-	// ReadTimeout and WriteTimeout apply to all routes. WriteTimeout is raised
-	// to 120 s to cover the 60 s LibreOffice conversion window; a reverse proxy
-	// or CDN in front of the server should enforce tighter per-route timeouts
-	// for lightweight endpoints.
+	// ReadHeaderTimeout protects against slow-header attacks without imposing a
+	// body-read deadline. ReadTimeout (which covers the entire request including
+	// the body) is intentionally omitted: a 200 MB video upload over a mobile
+	// connection can easily exceed any reasonable global limit, and the per-route
+	// MaxRequestBodySize middleware already bounds the payload size.
+	// WriteTimeout covers the response-write phase and is raised to 120 s for
+	// the LibreOffice conversion path.
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 120 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 30 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	// Start server in a goroutine


### PR DESCRIPTION
## Summary

- `ReadTimeout: 30s` applied to the **entire request including the body**, causing a timeout after ~30 seconds when uploading a large video (e.g. 38 MB MOV over a mobile connection)
- Replace with `ReadHeaderTimeout: 30s`, which only limits the header-read phase — protects against slow-header attacks while allowing large request bodies to be read without hitting a deadline
- The per-route `MaxRequestBodySize(210 MB)` middleware already bounds payload size, so removing the global body-read deadline is safe

## Root cause

`http.Server.ReadTimeout` measures from when the connection is accepted until the entire request body is read. For a 38 MB video on a typical mobile upload speed (5–10 Mbps), that's 30–60 seconds — reliably exceeding the 30 s limit. The server closed the connection and the frontend showed "Upload failed. Please try again."

`ReadHeaderTimeout` is the idiomatic Go fix for file-upload servers: it limits header reads (where slow attacks happen) without constraining body reads (where legitimate large uploads happen).

## Test plan

- [ ] Upload a video > 5 MB from a mobile device on dev
- [ ] Confirm the upload completes successfully (no "Upload failed" after 30 s)
- [ ] Confirm lightweight API requests still work normally
- [ ] Go build passes (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)