### PR TITLE
feat: pre-build LibreOffice base image to cut build time ~600s → ~60s

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -39,23 +39,46 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Versioned date tag — used in Dockerfile FROM (Renovate bumps this monthly)
+            type=raw,value={{date 'YYYY.MM'}}
+            # Also push latest as a convenience alias
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=go-volunteer-media-base
+            org.opencontainers.image.description=Pre-built base image with LibreOffice for go-volunteer-media
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
       - name: Build and push base image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.base
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
       - name: Summary
         env:
-          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           echo "## Base Image Built 📦" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${FULL_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${IMAGE_DIGEST}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The main app image will use this base on the next build." >> $GITHUB_STEP_SUMMARY
+          echo "**Tags pushed:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${IMAGE_TAGS}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Update \`Dockerfile\` FROM line to the new date tag, or let Renovate open the PR automatically." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,0 +1,61 @@
+name: Build Base Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile.base'
+      - '.github/workflows/build-base-image.yml'
+  schedule:
+    # Rebuild monthly to pick up OS/LibreOffice security updates
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-base
+
+jobs:
+  build:
+    name: Build and Push Base Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Summary
+        env:
+          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        run: |
+          echo "## Base Image Built 📦" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${FULL_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The main app image will use this base on the next build." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,13 +41,14 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Versioned date tag — used in Dockerfile FROM (Renovate bumps this monthly)
+            # Versioned date tag — referenced in Dockerfile FROM; update manually
+            # after each monthly base rebuild (or configure Renovate to do it).
             type=raw,value={{date 'YYYY.MM'}}
-            # Also push latest as a convenience alias
+            # Convenience alias — not used in Dockerfile FROM
             type=raw,value=latest
           labels: |
             org.opencontainers.image.title=go-volunteer-media-base
@@ -56,7 +57,7 @@ jobs:
 
       - name: Build and push base image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: .
           file: ./Dockerfile.base
@@ -81,4 +82,4 @@ jobs:
           echo "${IMAGE_TAGS}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Update \`Dockerfile\` FROM line to the new date tag, or let Renovate open the PR automatically." >> $GITHUB_STEP_SUMMARY
+          echo "Update the FROM tag in Dockerfile to the new date tag and open a PR." >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "
 # Final stage — use the pre-built base image so LibreOffice is not installed
 # on every build. Rebuild the base by running build-base-image.yml manually
 # or by editing Dockerfile.base (it also rebuilds monthly for security patches).
-FROM ghcr.io/networkengineer-cloud/go-volunteer-media-base:latest
-
-# Copy certificates and timezone data
-COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Tag format: YYYY.MM — Renovate bumps this automatically each month.
+FROM ghcr.io/networkengineer-cloud/go-volunteer-media-base:2026.06
 
 # Copy binary from backend builder
 COPY --from=backend-builder /app/api /api

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "
 # Final stage — use the pre-built base image so LibreOffice is not installed
 # on every build. Rebuild the base by running build-base-image.yml manually
 # or by editing Dockerfile.base (it also rebuilds monthly for security patches).
-# Tag format: YYYY.MM — Renovate bumps this automatically each month.
+# Tag format: YYYY.MM — update this after each monthly base rebuild
+# (see build-base-image.yml; configure Renovate to automate the bump).
 FROM ghcr.io/networkengineer-cloud/go-volunteer-media-base:2026.06
 
 # Copy binary from backend builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,22 +42,10 @@ COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "-static"' -o /app/api ./cmd/api
 
-# Final stage
-FROM debian:bookworm-slim
-
-# Install runtime dependencies.
-# libreoffice: converts DOCX/XLSX uploads to PDF at upload time.
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
-    libreoffice \
-    ca-certificates \
-    tzdata \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create non-root user (no home directory needed — HOME is set to /tmp below)
-RUN useradd -r -s /bin/false appuser
-
-# LibreOffice writes its user profile to HOME; /tmp is writable by all users.
-ENV HOME=/tmp
+# Final stage — use the pre-built base image so LibreOffice is not installed
+# on every build. Rebuild the base by running build-base-image.yml manually
+# or by editing Dockerfile.base (it also rebuilds monthly for security patches).
+FROM ghcr.io/networkengineer-cloud/go-volunteer-media-base:latest
 
 # Copy certificates and timezone data
 COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+# Install LibreOffice and runtime dependencies.
+# This layer is slow (~8 min) so it lives in a separate base image that is
+# rebuilt only when this file changes or on the monthly security schedule.
+# The main Dockerfile references the pre-built image so app builds stay fast.
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
+    libreoffice \
+    ca-certificates \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -r -s /bin/false appuser
+
+# LibreOffice writes its user profile to HOME; /tmp is writable by all users.
+ENV HOME=/tmp

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get inst
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -r -s /bin/false appuser
+RUN useradd --no-log-init -r -s /bin/false appuser
 
 # LibreOffice writes its user profile to HOME; /tmp is writable by all users.
 ENV HOME=/tmp


### PR DESCRIPTION
## Summary

- `apt-get install libreoffice` runs on every Docker build and takes ~10 minutes — LibreOffice itself is ~300 MB and the `debian:bookworm-slim` floating tag busts the BuildKit layer cache on most builds
- Moves LibreOffice into a separate pre-built base image (`ghcr.io/<repo>-base:latest`) that is only rebuilt when `Dockerfile.base` changes, on a monthly security schedule, or manually via `workflow_dispatch`
- The main `Dockerfile` final stage now does `FROM ghcr.io/.../go-volunteer-media-base:latest` — the app build itself becomes a ~60 second Go compile + npm build

## Files

| File | Change |
|------|--------|
| `Dockerfile.base` | New — installs LibreOffice, creates `appuser`, sets `HOME=/tmp` |
| `.github/workflows/build-base-image.yml` | New — builds and pushes the base image |
| `Dockerfile` | Final stage replaced with `FROM` the pre-built base |

## Bootstrap (one-time, do this before merging)

Because both workflows trigger on this merge, `build-image.yml` may fail the first time if the base image hasn't been pushed yet:

1. Merge this PR → `build-base-image.yml` starts building the base (~10 min)
2. If `build-image.yml` fails (can't pull base yet) — just re-run it manually once the base finishes
3. All subsequent builds: ~60 seconds

After bootstrap, the base image rebuilds automatically every month (or when `Dockerfile.base` is edited) and the app build stays fast.

## Test plan

- [ ] Merge and monitor `build-base-image.yml` — base image appears in GHCR packages
- [ ] Run `build-image.yml` (manually if needed) — completes in ~60s instead of ~600s
- [ ] Verify app starts correctly (container uses the pre-built base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)