### PR TITLE
fix: serve video thumbnails via ServeImage thumbnail_url lookup

### DIFF
--- a/internal/handlers/animal_upload.go
+++ b/internal/handlers/animal_upload.go
@@ -175,6 +175,20 @@ func ServeImage(db *gorm.DB, storageProvider storage.Provider) gin.HandlerFunc {
 				serveVideoBlob(c, storageProvider, animalVideo.BlobIdentifier, animalVideo.MimeType)
 				return
 			}
+			// Thumbnail blobs are stored under images/animals/ in Azure but have no
+			// AnimalImage row — look them up via the video's ThumbnailBlobID.
+			var thumbVideo models.AnimalVideo
+			if err3 := db.Where("thumbnail_url = ?", imageURL).First(&thumbVideo).Error; err3 == nil {
+				data, mimeType, err := storageProvider.GetImage(ctx, thumbVideo.ThumbnailBlobID)
+				if err != nil {
+					c.JSON(http.StatusNotFound, gin.H{"error": "Thumbnail not found in storage"})
+					return
+				}
+				c.Header("Cache-Control", "public, max-age=31536000")
+				c.Header("Content-Length", strconv.Itoa(len(data)))
+				c.Data(http.StatusOK, mimeType, data)
+				return
+			}
 			c.JSON(http.StatusNotFound, gin.H{"error": "Image not found"})
 			return
 		}

--- a/internal/handlers/animal_upload.go
+++ b/internal/handlers/animal_upload.go
@@ -178,7 +178,12 @@ func ServeImage(db *gorm.DB, storageProvider storage.Provider) gin.HandlerFunc {
 			// Thumbnail blobs are stored under images/animals/ in Azure but have no
 			// AnimalImage row — look them up via the video's ThumbnailBlobID.
 			var thumbVideo models.AnimalVideo
-			if err3 := db.Where("thumbnail_url = ?", imageURL).First(&thumbVideo).Error; err3 == nil {
+			thumbErr := db.Where("thumbnail_url = ?", imageURL).First(&thumbVideo).Error
+			if thumbErr != nil && !errors.Is(thumbErr, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve thumbnail"})
+				return
+			}
+			if thumbErr == nil {
 				if thumbVideo.ThumbnailBlobID == "" {
 					c.JSON(http.StatusNotFound, gin.H{"error": "Thumbnail blob not available"})
 					return

--- a/internal/handlers/animal_upload.go
+++ b/internal/handlers/animal_upload.go
@@ -179,12 +179,21 @@ func ServeImage(db *gorm.DB, storageProvider storage.Provider) gin.HandlerFunc {
 			// AnimalImage row — look them up via the video's ThumbnailBlobID.
 			var thumbVideo models.AnimalVideo
 			if err3 := db.Where("thumbnail_url = ?", imageURL).First(&thumbVideo).Error; err3 == nil {
+				if thumbVideo.ThumbnailBlobID == "" {
+					c.JSON(http.StatusNotFound, gin.H{"error": "Thumbnail blob not available"})
+					return
+				}
 				data, mimeType, err := storageProvider.GetImage(ctx, thumbVideo.ThumbnailBlobID)
 				if err != nil {
-					c.JSON(http.StatusNotFound, gin.H{"error": "Thumbnail not found in storage"})
+					if err == storage.ErrNotFound {
+						c.JSON(http.StatusNotFound, gin.H{"error": "Thumbnail not found in storage"})
+					} else {
+						c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve thumbnail"})
+					}
 					return
 				}
 				c.Header("Cache-Control", "public, max-age=31536000")
+				c.Header("Content-Type", mimeType)
 				c.Header("Content-Length", strconv.Itoa(len(data)))
 				c.Data(http.StatusOK, mimeType, data)
 				return

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -481,6 +482,101 @@ func TestUploadAnimalVideo_DBCreateFails_BothBlobsCleanedup(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, store.DeletedBlobs, "test-uuid-1.png", "thumbnail blob should be cleaned up on DB failure")
 	assert.Contains(t, store.DeletedBlobs, "test-uuid-2.png", "video blob should be cleaned up on DB failure")
+}
+
+func TestServeImage_ThumbnailFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("serves thumbnail blob via thumbnail_url lookup", func(t *testing.T) {
+		db := setupVideoTestDB(t)
+		imgData := []byte{0xFF, 0xD8, 0xFF} // fake JPEG bytes
+		store := &mockStorageProvider{GetImageData: imgData, GetImageMime: "image/jpeg"}
+
+		assert.NoError(t, db.Create(&models.AnimalVideo{
+			AnimalID:        1,
+			UserID:          1,
+			VideoURL:        "/api/videos/video-uuid",
+			ThumbnailURL:    "/api/images/thumb-uuid",
+			ThumbnailBlobID: "thumb-uuid.jpg",
+		}).Error)
+
+		r := gin.New()
+		r.GET("/api/images/:uuid", ServeImage(db, store))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/images/thumb-uuid", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "image/jpeg", w.Header().Get("Content-Type"))
+		assert.Equal(t, imgData, w.Body.Bytes())
+	})
+
+	t.Run("returns 404 when ThumbnailBlobID is empty", func(t *testing.T) {
+		db := setupVideoTestDB(t)
+		store := &mockStorageProvider{}
+
+		assert.NoError(t, db.Create(&models.AnimalVideo{
+			AnimalID:        1,
+			UserID:          1,
+			VideoURL:        "/api/videos/video-uuid2",
+			ThumbnailURL:    "/api/images/thumb-no-blob",
+			ThumbnailBlobID: "",
+		}).Error)
+
+		r := gin.New()
+		r.GET("/api/images/:uuid", ServeImage(db, store))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/images/thumb-no-blob", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 500 on non-ErrNotFound storage error", func(t *testing.T) {
+		db := setupVideoTestDB(t)
+		store := &mockStorageProvider{GetImageErr: fmt.Errorf("azure: connection refused")}
+
+		assert.NoError(t, db.Create(&models.AnimalVideo{
+			AnimalID:        1,
+			UserID:          1,
+			VideoURL:        "/api/videos/video-uuid3",
+			ThumbnailURL:    "/api/images/thumb-infra-err",
+			ThumbnailBlobID: "thumb-infra-err.jpg",
+		}).Error)
+
+		r := gin.New()
+		r.GET("/api/images/:uuid", ServeImage(db, store))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/images/thumb-infra-err", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("returns 404 when storage returns ErrNotFound", func(t *testing.T) {
+		db := setupVideoTestDB(t)
+		store := &mockStorageProvider{GetImageErr: storage.ErrNotFound}
+
+		assert.NoError(t, db.Create(&models.AnimalVideo{
+			AnimalID:        1,
+			UserID:          1,
+			VideoURL:        "/api/videos/video-uuid4",
+			ThumbnailURL:    "/api/images/thumb-missing",
+			ThumbnailBlobID: "thumb-missing.jpg",
+		}).Error)
+
+		r := gin.New()
+		r.GET("/api/images/:uuid", ServeImage(db, store))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/images/thumb-missing", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
 }
 
 func TestDeleteAnimalVideo(t *testing.T) {

--- a/internal/handlers/animal_video_test.go
+++ b/internal/handlers/animal_video_test.go
@@ -577,6 +577,23 @@ func TestServeImage_ThumbnailFallback(t *testing.T) {
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
+
+	t.Run("returns 500 when DB query itself fails", func(t *testing.T) {
+		db := setupVideoTestDB(t)
+		store := &mockStorageProvider{}
+
+		// Drop the table so the thumbnail_url query returns a DB error, not ErrRecordNotFound.
+		db.Exec("DROP TABLE animal_videos")
+
+		r := gin.New()
+		r.GET("/api/images/:uuid", ServeImage(db, store))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/images/thumb-db-err", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
 }
 
 func TestDeleteAnimalVideo(t *testing.T) {

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -155,6 +155,9 @@ type mockStorageProvider struct {
 	UploadImageErr        error
 	UploadImageCallErrors map[int]error // 1-based call index → error
 	UploadDocumentErr     error
+	GetImageData          []byte
+	GetImageMime          string
+	GetImageErr           error
 	LastMimeType          string
 	DeletedBlobs          []string
 	uploadCallCount       int
@@ -185,7 +188,10 @@ func (m *mockStorageProvider) UploadDocument(_ context.Context, _ []byte, _, _ s
 	return "/api/documents/test-uuid", "test-uuid", ".pdf", nil
 }
 func (m *mockStorageProvider) GetImage(_ context.Context, _ string) ([]byte, string, error) {
-	return nil, "", nil
+	if m.GetImageErr != nil {
+		return nil, "", m.GetImageErr
+	}
+	return m.GetImageData, m.GetImageMime, nil
 }
 func (m *mockStorageProvider) GetDocument(_ context.Context, _ string) ([]byte, string, error) {
 	return nil, "", nil

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -399,7 +399,7 @@ type AnimalVideo struct {
 	AnimalID        uint           `gorm:"not null;index:idx_animal_video_animal" json:"animal_id"`
 	UserID          uint           `gorm:"not null;index" json:"user_id"`
 	VideoURL        string         `gorm:"not null" json:"video_url"`
-	ThumbnailURL    string         `gorm:"not null" json:"thumbnail_url"`
+	ThumbnailURL    string         `gorm:"not null;index" json:"thumbnail_url"`
 	MimeType        string         `gorm:"default:'video/mp4'" json:"mime_type"`
 	Caption         string         `json:"caption"`
 	DurationSeconds int            `json:"duration_seconds"`


### PR DESCRIPTION
## Summary

- Video thumbnails were broken after upload — every `GET /api/images/<uuid>` for a thumbnail returned 404
- Root cause: thumbnail blobs are uploaded to Azure via `UploadImage` and their URL stored in `animal_videos.thumbnail_url`, but no `AnimalImage` row is created for them. `ServeImage` only queried `animal_images` (plus a legacy `video_url` fallback), so it never found the thumbnail
- Fix: adds a third fallback in `ServeImage` — queries `animal_videos.thumbnail_url`, then proxies the blob from Azure using `ThumbnailBlobID`

## Test plan

- [ ] Upload a video on an animal; confirm the thumbnail renders in the gallery immediately after upload
- [ ] Reload the page; confirm thumbnails persist (no second-load 404)
- [ ] Confirm existing animal images still load correctly (unaffected code path)
- [ ] Confirm video playback still works (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)