### PR TITLE
fix: start video thumbnail extraction on file select, not upload click

### DIFF
--- a/frontend/src/components/VideoUpload.tsx
+++ b/frontend/src/components/VideoUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { animalsApi } from '../api/client';
 
 const MAX_VIDEO_SIZE = 200 * 1024 * 1024;
@@ -17,6 +17,10 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
   const [caption, setCaption] = useState('');
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Thumbnail extraction starts as soon as a file is selected so it runs
+  // in the background while the user types a caption. By upload time it's
+  // usually already resolved and only the network transfer remains.
+  const thumbnailPromiseRef = useRef<Promise<{ blob: Blob; duration: number }> | null>(null);
 
   useEffect(() => {
     if (!preselectedFile) return;
@@ -26,6 +30,8 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
     } else if (preselectedFile.size > MAX_VIDEO_SIZE) {
       setError('This video is too large. Please use a clip under 200MB.');
       setVideoFile(null);
+    } else {
+      thumbnailPromiseRef.current = extractThumbnail(preselectedFile);
     }
   }, [preselectedFile]);
 
@@ -42,6 +48,7 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
     }
     setError(null);
     setVideoFile(file);
+    thumbnailPromiseRef.current = extractThumbnail(file);
   };
 
   const extractThumbnail = (file: File): Promise<{ blob: Blob; duration: number }> =>
@@ -137,7 +144,7 @@ const VideoUpload: React.FC<VideoUploadProps> = ({ groupId, animalId, onSuccess,
     let thumbnailBlob: Blob;
     let duration: number;
     try {
-      ({ blob: thumbnailBlob, duration } = await extractThumbnail(videoFile));
+      ({ blob: thumbnailBlob, duration } = await (thumbnailPromiseRef.current ?? extractThumbnail(videoFile)));
     } catch {
       setError("Couldn't generate a preview for this video. Please try a different file.");
       setUploading(false);


### PR DESCRIPTION
## Summary

- Uploading a video had two noticeable wait periods: one for thumbnail extraction (video decode + canvas capture) and one for the network upload
- Both ran sequentially under the same spinner, making it feel like two separate upload phases
- Fix: call `extractThumbnail` immediately when a file is selected and store the Promise in a ref. By the time the user clicks Upload — after optionally typing a caption — the thumbnail is already resolved and only the network transfer remains

## Test plan

- [ ] Select a video file; immediately click Upload — thumbnail extraction and upload should both complete in one uninterrupted wait
- [ ] Select a video file, wait a few seconds, then click Upload — upload should start almost immediately (thumbnail already resolved)
- [ ] Select an invalid/corrupted video — error message should still appear on Upload click
- [ ] Test with `preselectedFile` prop (drag-and-drop path) — same eager extraction should apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)