### PR TITLE
feat: show photo and video counts on animal cards

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -208,6 +208,8 @@ export interface Animal {
   last_status_change?: string;
   return_count: number;
   is_returned: boolean;
+  image_count?: number;
+  video_count?: number;
   protocol_document_url?: string;
   protocol_document_name?: string;
   protocol_document_type?: string;

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1661,9 +1661,9 @@
 }
 
 .media-pill.no-media {
-  background: rgba(0, 0, 0, 0.03);
-  border: 1px solid #e5e7eb;
-  color: #c9cdd4;
+  background: var(--neutral-100);
+  border: 1px solid var(--border);
+  color: var(--text-tertiary);
   cursor: default;
   pointer-events: none;
 }

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -1629,3 +1629,41 @@
     grid-template-columns: 1fr;
   }
 }
+
+.media-indicator {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 0.65rem;
+}
+
+.media-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.22rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.media-pill.has-media {
+  background: rgba(0, 163, 173, 0.09);
+  border: 1px solid rgba(0, 163, 173, 0.3);
+  color: var(--brand);
+}
+
+.media-pill.has-media:hover {
+  background: rgba(0, 163, 173, 0.16);
+}
+
+.media-pill.no-media {
+  background: rgba(0, 0, 0, 0.03);
+  border: 1px solid #e5e7eb;
+  color: #c9cdd4;
+  cursor: default;
+  pointer-events: none;
+}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1038,6 +1038,7 @@ const GroupPage: React.FC = () => {
                             })()}
                           </p>
                         )}
+                        {/* Both pills link to /photos — PhotoGallery renders images and videos on the same page */}
                         <div className="media-indicator">
                           {(animal.image_count ?? 0) > 0 ? (
                             <Link

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1039,28 +1039,36 @@ const GroupPage: React.FC = () => {
                           </p>
                         )}
                         <div className="media-indicator">
-                          <Link
-                            to={`/groups/${id}/animals/${animal.id}/photos`}
-                            className={`media-pill ${(animal.image_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
-                            onClick={(e) => e.stopPropagation()}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
-                            }}
-                            aria-label={`${animal.image_count ?? 0} photos`}
-                          >
-                            📷 {animal.image_count ?? 0}
-                          </Link>
-                          <Link
-                            to={`/groups/${id}/animals/${animal.id}/photos`}
-                            className={`media-pill ${(animal.video_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
-                            onClick={(e) => e.stopPropagation()}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
-                            }}
-                            aria-label={`${animal.video_count ?? 0} videos`}
-                          >
-                            🎥 {animal.video_count ?? 0}
-                          </Link>
+                          {(animal.image_count ?? 0) > 0 ? (
+                            <Link
+                              to={`/groups/${id}/animals/${animal.id}/photos`}
+                              className="media-pill has-media"
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                              }}
+                              aria-label={`${animal.image_count} photos`}
+                            >
+                              📷 {animal.image_count}
+                            </Link>
+                          ) : (
+                            <span className="media-pill no-media" aria-label="0 photos">📷 0</span>
+                          )}
+                          {(animal.video_count ?? 0) > 0 ? (
+                            <Link
+                              to={`/groups/${id}/animals/${animal.id}/photos`}
+                              className="media-pill has-media"
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                              }}
+                              aria-label={`${animal.video_count} videos`}
+                            >
+                              🎥 {animal.video_count}
+                            </Link>
+                          ) : (
+                            <span className="media-pill no-media" aria-label="0 videos">🎥 0</span>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -958,7 +958,7 @@ const GroupPage: React.FC = () => {
                       aria-label={`View ${animal.name}`}
                       onClick={() => navigate(`/groups/${id}/animals/${animal.id}/view`)}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
+                        if (e.key === 'Enter') {
                           e.preventDefault();
                           navigate(`/groups/${id}/animals/${animal.id}/view`);
                         }
@@ -1045,7 +1045,7 @@ const GroupPage: React.FC = () => {
                               className="media-pill has-media"
                               onClick={(e) => e.stopPropagation()}
                               onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                                if (e.key === 'Enter') e.stopPropagation();
                               }}
                               aria-label={`${animal.image_count} photos`}
                             >
@@ -1060,7 +1060,7 @@ const GroupPage: React.FC = () => {
                               className="media-pill has-media"
                               onClick={(e) => e.stopPropagation()}
                               onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                                if (e.key === 'Enter') e.stopPropagation();
                               }}
                               aria-label={`${animal.video_count} videos`}
                             >

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -950,10 +950,18 @@ const GroupPage: React.FC = () => {
                   const { years: cardAgeYears, months: cardAgeMonths } = calculateAge(animal.estimated_birth_date, animal.age);
                   
                   return (
-                    <Link
+                    <div
                       key={animal.id}
-                      to={`/groups/${id}/animals/${animal.id}/view`}
                       className="animal-card"
+                      role="link"
+                      tabIndex={0}
+                      onClick={() => navigate(`/groups/${id}/animals/${animal.id}/view`)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          navigate(`/groups/${id}/animals/${animal.id}/view`);
+                        }
+                      }}
                     >
                       {animal.image_url && (
                         <img
@@ -1029,8 +1037,26 @@ const GroupPage: React.FC = () => {
                             })()}
                           </p>
                         )}
+                        <div className="media-indicator">
+                          <Link
+                            to={`/groups/${id}/animals/${animal.id}/photos`}
+                            className={`media-pill ${(animal.image_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label={`${animal.image_count ?? 0} photos`}
+                          >
+                            📷 {animal.image_count ?? 0}
+                          </Link>
+                          <Link
+                            to={`/groups/${id}/animals/${animal.id}/photos`}
+                            className={`media-pill ${(animal.video_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label={`${animal.video_count ?? 0} videos`}
+                          >
+                            🎥 {animal.video_count ?? 0}
+                          </Link>
+                        </div>
                       </div>
-                    </Link>
+                    </div>
                   );
                 })}
               </div>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -955,6 +955,7 @@ const GroupPage: React.FC = () => {
                       className="animal-card"
                       role="link"
                       tabIndex={0}
+                      aria-label={`View ${animal.name}`}
                       onClick={() => navigate(`/groups/${id}/animals/${animal.id}/view`)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
@@ -1042,6 +1043,9 @@ const GroupPage: React.FC = () => {
                             to={`/groups/${id}/animals/${animal.id}/photos`}
                             className={`media-pill ${(animal.image_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
                             onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                            }}
                             aria-label={`${animal.image_count ?? 0} photos`}
                           >
                             📷 {animal.image_count ?? 0}
@@ -1050,6 +1054,9 @@ const GroupPage: React.FC = () => {
                             to={`/groups/${id}/animals/${animal.id}/photos`}
                             className={`media-pill ${(animal.video_count ?? 0) > 0 ? 'has-media' : 'no-media'}`}
                             onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                            }}
                             aria-label={`${animal.video_count ?? 0} videos`}
                           >
                             🎥 {animal.video_count ?? 0}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -88,14 +89,15 @@ func GetAnimals(db *gorm.DB) gin.HandlerFunc {
 		}
 		var counts []countRow
 		if len(ids) > 0 {
-			// Best-effort: if the media tables don't exist yet (e.g. in minimal test
-			// environments), counts simply remain zero rather than surfacing a 500.
-			db.WithContext(ctx).Raw(`
+			// Best-effort: counts remain zero on error so the list still renders.
+			if result := db.WithContext(ctx).Raw(`
 				SELECT a.id AS animal_id,
 					(SELECT COUNT(*) FROM animal_images WHERE animal_id = a.id) AS image_count,
 					(SELECT COUNT(*) FROM animal_videos WHERE animal_id = a.id) AS video_count
 				FROM animals a
-				WHERE a.id IN ?`, ids).Scan(&counts)
+				WHERE a.id IN ?`, ids).Scan(&counts); result.Error != nil {
+				log.Printf("GetAnimals: failed to fetch media counts: %v", result.Error)
+			}
 		}
 		countMap := make(map[uint]countRow, len(counts))
 		for _, cr := range counts {

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -92,10 +92,13 @@ func GetAnimals(db *gorm.DB) gin.HandlerFunc {
 			// Best-effort: counts remain zero on error so the list still renders.
 			if result := db.WithContext(ctx).Raw(`
 				SELECT a.id AS animal_id,
-					(SELECT COUNT(*) FROM animal_images WHERE animal_id = a.id) AS image_count,
-					(SELECT COUNT(*) FROM animal_videos WHERE animal_id = a.id) AS video_count
+					COUNT(DISTINCT ai.id) AS image_count,
+					COUNT(DISTINCT av.id) AS video_count
 				FROM animals a
-				WHERE a.id IN ?`, ids).Scan(&counts); result.Error != nil {
+				LEFT JOIN animal_images ai ON ai.animal_id = a.id
+				LEFT JOIN animal_videos av ON av.animal_id = a.id
+				WHERE a.id IN ?
+				GROUP BY a.id`, ids).Scan(&counts); result.Error != nil {
 				log.Printf("GetAnimals: failed to fetch media counts: %v", result.Error)
 			}
 		}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -23,6 +23,13 @@ func escapeSQLWildcards(input string) string {
 	return result
 }
 
+// animalWithCounts extends Animal with photo/video counts for the list endpoint.
+type animalWithCounts struct {
+	models.Animal
+	ImageCount int `json:"image_count"`
+	VideoCount int `json:"video_count"`
+}
+
 // GetAnimals returns all animals in a group with optional filtering
 func GetAnimals(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -63,10 +70,45 @@ func GetAnimals(db *gorm.DB) gin.HandlerFunc {
 			query = query.Where("LOWER(name) LIKE ?", "%"+escaped+"%")
 		}
 
-		var animals []models.Animal
-		if err := query.Preload("Tags").Find(&animals).Error; err != nil {
+		var baseAnimals []models.Animal
+		if err := query.Preload("Tags").Find(&baseAnimals).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch animals"})
 			return
+		}
+
+		// Collect IDs for count subquery
+		type countRow struct {
+			AnimalID   uint `gorm:"column:animal_id"`
+			ImageCount int  `gorm:"column:image_count"`
+			VideoCount int  `gorm:"column:video_count"`
+		}
+		ids := make([]uint, len(baseAnimals))
+		for i, a := range baseAnimals {
+			ids[i] = a.ID
+		}
+		var counts []countRow
+		if len(ids) > 0 {
+			// Best-effort: if the media tables don't exist yet (e.g. in minimal test
+			// environments), counts simply remain zero rather than surfacing a 500.
+			db.WithContext(ctx).Raw(`
+				SELECT a.id AS animal_id,
+					(SELECT COUNT(*) FROM animal_images WHERE animal_id = a.id) AS image_count,
+					(SELECT COUNT(*) FROM animal_videos WHERE animal_id = a.id) AS video_count
+				FROM animals a
+				WHERE a.id IN ?`, ids).Scan(&counts)
+		}
+		countMap := make(map[uint]countRow, len(counts))
+		for _, cr := range counts {
+			countMap[cr.AnimalID] = cr
+		}
+
+		animals := make([]animalWithCounts, len(baseAnimals))
+		for i, a := range baseAnimals {
+			animals[i] = animalWithCounts{
+				Animal:     a,
+				ImageCount: countMap[a.ID].ImageCount,
+				VideoCount: countMap[a.ID].VideoCount,
+			}
 		}
 
 		c.JSON(http.StatusOK, animals)

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -24,8 +24,25 @@ func setupAnimalTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
 
+	// SQLite in-memory databases are per-connection; pin to one to share state.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
 	// Run migrations
-	err = db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}, &models.Animal{}, &models.AnimalTag{}, &models.AnimalNameHistory{})
+	err = db.AutoMigrate(
+		&models.User{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.Animal{},
+		&models.AnimalTag{},
+		&models.AnimalNameHistory{},
+		&models.AnimalImage{},
+		&models.AnimalVideo{},
+	)
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)
 	}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 // animalListItem is the minimal shape of a GetAnimals response entry used across tests.
@@ -122,12 +120,7 @@ func TestGetAnimals_StatusFilter(t *testing.T) {
 				return
 			}
 
-			var animals []struct {
-				ID         uint   `json:"id"`
-				Name       string `json:"name"`
-				ImageCount *int   `json:"image_count"`
-				VideoCount *int   `json:"video_count"`
-			}
+			var animals []animalListItem
 			if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 				t.Fatalf("Failed to unmarshal response: %v", err)
 			}
@@ -191,12 +184,7 @@ func TestGetAnimals_NameSearch(t *testing.T) {
 				return
 			}
 
-			var animals []struct {
-				ID         uint   `json:"id"`
-				Name       string `json:"name"`
-				ImageCount *int   `json:"image_count"`
-				VideoCount *int   `json:"video_count"`
-			}
+			var animals []animalListItem
 			if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 				t.Fatalf("Failed to unmarshal response: %v", err)
 			}
@@ -1544,28 +1532,7 @@ func TestUpdateAnimal_IsReturned(t *testing.T) {
 
 // TestGetAnimals_IncludesMediaCounts verifies that GetAnimals returns image_count and video_count for each animal
 func TestGetAnimals_IncludesMediaCounts(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("failed to open db: %v", err)
-	}
-	sqlDB, err2 := db.DB()
-	if err2 != nil {
-		t.Fatalf("failed to get sql.DB: %v", err2)
-	}
-	sqlDB.SetMaxOpenConns(1)
-	sqlDB.SetMaxIdleConns(1)
-	if err := db.AutoMigrate(
-		&models.User{},
-		&models.Group{},
-		&models.UserGroup{},
-		&models.Animal{},
-		&models.AnimalTag{},
-		&models.AnimalImage{},
-		&models.AnimalVideo{},
-	); err != nil {
-		t.Fatalf("failed to migrate: %v", err)
-	}
-
+	db := setupAnimalTestDB(t)
 	user, group := createAnimalTestUser(t, db, "counter", "counter@example.com", false)
 
 	// One animal with 2 images and 1 video

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -35,7 +35,12 @@ func TestGetAnimals_Success(t *testing.T) {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var animals []models.Animal
+	var animals []struct {
+		ID         uint   `json:"id"`
+		Name       string `json:"name"`
+		ImageCount *int   `json:"image_count"`
+		VideoCount *int   `json:"video_count"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
@@ -114,7 +119,12 @@ func TestGetAnimals_StatusFilter(t *testing.T) {
 				return
 			}
 
-			var animals []models.Animal
+			var animals []struct {
+				ID         uint   `json:"id"`
+				Name       string `json:"name"`
+				ImageCount *int   `json:"image_count"`
+				VideoCount *int   `json:"video_count"`
+			}
 			if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 				t.Fatalf("Failed to unmarshal response: %v", err)
 			}
@@ -178,7 +188,12 @@ func TestGetAnimals_NameSearch(t *testing.T) {
 				return
 			}
 
-			var animals []models.Animal
+			var animals []struct {
+				ID         uint   `json:"id"`
+				Name       string `json:"name"`
+				ImageCount *int   `json:"image_count"`
+				VideoCount *int   `json:"video_count"`
+			}
 			if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 				t.Fatalf("Failed to unmarshal response: %v", err)
 			}
@@ -233,7 +248,12 @@ func TestGetAnimals_AdminAccess(t *testing.T) {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var animals []models.Animal
+	var animals []struct {
+		ID         uint   `json:"id"`
+		Name       string `json:"name"`
+		ImageCount *int   `json:"image_count"`
+		VideoCount *int   `json:"video_count"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
@@ -1530,6 +1550,12 @@ func TestGetAnimals_IncludesMediaCounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
+	sqlDB, err2 := db.DB()
+	if err2 != nil {
+		t.Fatalf("failed to get sql.DB: %v", err2)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 	if err := db.AutoMigrate(
 		&models.User{},
 		&models.Group{},

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -15,6 +15,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// animalListItem is the minimal shape of a GetAnimals response entry used across tests.
+type animalListItem struct {
+	ID         uint   `json:"id"`
+	Name       string `json:"name"`
+	ImageCount *int   `json:"image_count"`
+	VideoCount *int   `json:"video_count"`
+}
+
 // TestGetAnimals_Success tests successful retrieval of animals
 func TestGetAnimals_Success(t *testing.T) {
 	db := setupAnimalTestDB(t)
@@ -35,12 +43,7 @@ func TestGetAnimals_Success(t *testing.T) {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var animals []struct {
-		ID         uint   `json:"id"`
-		Name       string `json:"name"`
-		ImageCount *int   `json:"image_count"`
-		VideoCount *int   `json:"video_count"`
-	}
+	var animals []animalListItem
 	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
@@ -248,12 +251,7 @@ func TestGetAnimals_AdminAccess(t *testing.T) {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var animals []struct {
-		ID         uint   `json:"id"`
-		Name       string `json:"name"`
-		ImageCount *int   `json:"image_count"`
-		VideoCount *int   `json:"video_count"`
-	}
+	var animals []animalListItem
 	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
@@ -1590,11 +1588,7 @@ func TestGetAnimals_IncludesMediaCounts(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var animals []struct {
-		ID         uint `json:"id"`
-		ImageCount int  `json:"image_count"`
-		VideoCount int  `json:"video_count"`
-	}
+	var animals []animalListItem
 	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -1602,27 +1596,40 @@ func TestGetAnimals_IncludesMediaCounts(t *testing.T) {
 		t.Fatalf("expected 2 animals, got %d", len(animals))
 	}
 
-	// Find Biscuit's entry
-	var richCounts struct{ ImageCount, VideoCount int }
+	// Find Biscuit's entry and dereference counts (nil pointer = field absent = bug)
+	var imageCount, videoCount int
 	for _, a := range animals {
 		if a.ID == rich.ID {
-			richCounts.ImageCount = a.ImageCount
-			richCounts.VideoCount = a.VideoCount
+			if a.ImageCount == nil {
+				t.Fatal("image_count field missing from response")
+			}
+			if a.VideoCount == nil {
+				t.Fatal("video_count field missing from response")
+			}
+			imageCount = *a.ImageCount
+			videoCount = *a.VideoCount
 		}
 	}
 
-	if richCounts.ImageCount != 2 {
-		t.Errorf("expected image_count 2 for Biscuit, got %d", richCounts.ImageCount)
+	if imageCount != 2 {
+		t.Errorf("expected image_count 2 for Biscuit, got %d", imageCount)
 	}
-	if richCounts.VideoCount != 1 {
-		t.Errorf("expected video_count 1 for Biscuit, got %d", richCounts.VideoCount)
+	if videoCount != 1 {
+		t.Errorf("expected video_count 1 for Biscuit, got %d", videoCount)
 	}
 
-	// Mochi has no media — verify the fields exist with zero values
+	// Mochi has no media — verify the fields exist and are zero
 	for _, a := range animals {
 		if a.ID != rich.ID {
-			if a.ImageCount != 0 || a.VideoCount != 0 {
-				t.Errorf("expected zero counts for Mochi, got images=%d videos=%d", a.ImageCount, a.VideoCount)
+			ic, vc := 0, 0
+			if a.ImageCount != nil {
+				ic = *a.ImageCount
+			}
+			if a.VideoCount != nil {
+				vc = *a.VideoCount
+			}
+			if ic != 0 || vc != 0 {
+				t.Errorf("expected zero counts for Mochi, got images=%d videos=%d", ic, vc)
 			}
 		}
 	}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // TestGetAnimals_Success tests successful retrieval of animals
@@ -1519,6 +1521,84 @@ func TestUpdateAnimal_IsReturned(t *testing.T) {
 				t.Errorf("Expected is_returned %v, got %v", tt.wantValue, updatedAnimal.IsReturned)
 			}
 		})
+	}
+}
+
+// TestGetAnimals_IncludesMediaCounts verifies that GetAnimals returns image_count and video_count for each animal
+func TestGetAnimals_IncludesMediaCounts(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.User{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.Animal{},
+		&models.AnimalTag{},
+		&models.AnimalImage{},
+		&models.AnimalVideo{},
+	); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	user, group := createAnimalTestUser(t, db, "counter", "counter@example.com", false)
+
+	// One animal with 2 images and 1 video
+	rich := createTestAnimal(t, db, group.ID, "Biscuit", "Dog")
+	animalIDRef := rich.ID
+	db.Create(&models.AnimalImage{AnimalID: &animalIDRef, UserID: user.ID, ImageURL: "/img/1.jpg"})
+	db.Create(&models.AnimalImage{AnimalID: &animalIDRef, UserID: user.ID, ImageURL: "/img/2.jpg"})
+	db.Create(&models.AnimalVideo{AnimalID: animalIDRef, UserID: user.ID, VideoURL: "/vid/1.mp4", ThumbnailURL: "/img/t.jpg"})
+
+	// One animal with no media
+	createTestAnimal(t, db, group.ID, "Mochi", "Cat")
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/groups/%d/animals?status=all", group.ID), nil)
+
+	GetAnimals(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var animals []struct {
+		ID         uint `json:"id"`
+		ImageCount int  `json:"image_count"`
+		VideoCount int  `json:"video_count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(animals) != 2 {
+		t.Fatalf("expected 2 animals, got %d", len(animals))
+	}
+
+	// Find Biscuit's entry
+	var richCounts struct{ ImageCount, VideoCount int }
+	for _, a := range animals {
+		if a.ID == rich.ID {
+			richCounts.ImageCount = a.ImageCount
+			richCounts.VideoCount = a.VideoCount
+		}
+	}
+
+	if richCounts.ImageCount != 2 {
+		t.Errorf("expected image_count 2 for Biscuit, got %d", richCounts.ImageCount)
+	}
+	if richCounts.VideoCount != 1 {
+		t.Errorf("expected video_count 1 for Biscuit, got %d", richCounts.VideoCount)
+	}
+
+	// Mochi has no media — verify the fields exist with zero values
+	for _, a := range animals {
+		if a.ID != rich.ID {
+			if a.ImageCount != 0 || a.VideoCount != 0 {
+				t.Errorf("expected zero counts for Mochi, got images=%d videos=%d", a.ImageCount, a.VideoCount)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `GetAnimals` backend endpoint to include `image_count` and `video_count` per animal via a single bulk COUNT query (no N+1)
- Adds `image_count?` and `video_count?` to the TypeScript `Animal` interface
- Refactors animal cards from `<Link>` to keyboard-accessible `<div role="link">` to allow nested gallery links
- Adds teal pills (📷 N · 🎥 N) at the bottom of each card — colored when media exists, grayed out when empty — each linking directly to the animal's photo gallery

## Test Plan

- [ ] Group Animals tab: every card shows 📷 and 🎥 pills at the bottom
- [ ] Animals with media: pills are teal and clickable → navigate to gallery
- [ ] Animals with no media: pills are grayed out and non-interactive
- [ ] Clicking anywhere else on the card → navigates to animal detail page
- [ ] Keyboard: Tab to card, Enter → detail page; Tab to teal pill, Enter → gallery
- [ ] `TestGetAnimals_IncludesMediaCounts` passes (verifies counts in API response)
- [ ] All 287 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)