### PR TITLE
fix: eliminate QEMU emulation in Docker build (~42min → ~3min)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@
 *.swo
 
 # Frontend development
+node_modules
 frontend/node_modules
 frontend/.env.local
 frontend/.vite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Frontend build stage (optional - only runs if frontend source exists)
-FROM node:20-alpine AS frontend-builder
+# Use the builder's native platform so npm/vite run without QEMU emulation.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 
@@ -15,7 +16,9 @@ RUN if [ -f "package.json" ]; then \
     fi
 
 # Backend build stage
-FROM golang:1.24-alpine AS backend-builder
+# Use the builder's native platform so the Go toolchain runs without QEMU emulation.
+# CGO_ENABLED=0 with GOOS/GOARCH lets Go cross-compile natively to linux/amd64.
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS backend-builder
 
 # Install security updates and build dependencies
 RUN apk update && apk upgrade && \


### PR DESCRIPTION
## Summary

- Add `--platform=$BUILDPLATFORM` to both build stages so `npm ci`/`npm run build` and `go build` run natively on the host (Apple Silicon arm64) instead of under QEMU emulation
- Go cross-compiles to `linux/amd64` natively via `CGO_ENABLED=0` + `GOOS`/`GOARCH` — no emulation needed
- Add `node_modules` to `.dockerignore` to exclude the root-level node_modules from the build context (was causing a ~2min `COPY . .`)

## Before / After

| Step | Before | Expected after |
|------|--------|----------------|
| `npm ci && npm run build` | 1052s (17.5 min) | ~60–90s |
| `go build` | 1362s (22.7 min) | ~60–90s |
| `COPY . .` | 119s | ~5s |

## Test plan

- [ ] Run `./scripts/deploy-ghcr-az.sh` and confirm build completes in under 5 minutes
- [ ] Verify the deployed image starts and serves requests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)