### PR TITLE
fix: restore is_returned checkbox to animal edit form

### DIFF
--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -44,6 +44,7 @@ const AnimalForm: React.FC = () => {
     status: 'available',
     arrival_date: '',
     quarantine_start_date: '',
+    is_returned: false,
     protocol_document_url: '',
     protocol_document_name: '',
   });
@@ -717,6 +718,24 @@ const AnimalForm: React.FC = () => {
                 Date the animal entered the shelter. Used to calculate length of stay. Leave empty to use today's date.
               </p>
             </div>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="is_returned" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                id="is_returned"
+                type="checkbox"
+                checked={formData.is_returned}
+                onChange={(e) => setFormData({ ...formData, is_returned: e.target.checked })}
+                aria-describedby="is-returned-helper"
+              />
+              <span className="form-field__label" style={{ marginBottom: 0 }}>
+                Previously adopted &amp; returned to shelter
+              </span>
+            </label>
+            <p id="is-returned-helper" className="form-field__helper">
+              Check if this animal was previously adopted out and has since come back.
+            </p>
           </div>
 
           <div className="form-field">


### PR DESCRIPTION
## Summary

- PR #225 removed the `is_returned` checkbox from `AnimalForm` with the note it was "never surfaced in the UI"
- However, that same PR added a **Returned badge** to animal cards that displays when `is_returned=true`
- With the checkbox gone, there is no way to actually set `is_returned=true` — the badge can never appear

This PR restores the checkbox (with the accessibility attributes `id`, `htmlFor`, and `aria-describedby` that were already in place before #225).

## Test plan

- [ ] Open the edit page for an existing animal — "Previously adopted & returned to shelter" checkbox should be visible
- [ ] Check the box, save, and verify the **Returned** badge appears on the animal card in the group page
- [ ] Uncheck the box, save, and verify the badge disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)