### PR TITLE
feat: Add third-party approval tracking for bite quarantine animals

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -204,6 +204,8 @@ export interface Animal {
   arrival_date?: string;
   foster_start_date?: string;
   quarantine_start_date?: string;
+  quarantine_approval_status?: string; // "" | "requested" | "granted"
+  quarantine_approval_date?: string;
   archived_date?: string;
   last_status_change?: string;
   is_returned: boolean;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -204,7 +204,7 @@ export interface Animal {
   arrival_date?: string;
   foster_start_date?: string;
   quarantine_start_date?: string;
-  quarantine_approval_status?: string; // "" | "requested" | "granted"
+  quarantine_approval_status?: '' | 'requested' | 'granted';
   quarantine_approval_date?: string;
   archived_date?: string;
   last_status_change?: string;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -354,6 +354,11 @@ a:focus-visible {
   color: #16a34a;
 }
 
+[data-theme='dark'] .quarantine-approval-none {
+  background: rgba(156, 163, 175, 0.15);
+  color: var(--neutral-400);
+}
+
 [data-theme='dark'] .quarantine-approval-requested {
   background: rgba(234, 179, 8, 0.25);
   color: #fbbf24;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -329,3 +329,37 @@ a:focus-visible {
   h2 { font-size: 1.875rem; }
   h3 { font-size: 1.5rem; }
 }
+
+/* ── Quarantine Approval Badge (shared across GroupPage, BulkEdit, AnimalDetail) ── */
+.quarantine-approval-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.quarantine-approval-none {
+  background: rgba(156, 163, 175, 0.2);
+  color: var(--neutral-500);
+}
+
+.quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.2);
+  color: #b45309;
+}
+
+.quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+}
+
+[data-theme='dark'] .quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fbbf24;
+}
+
+[data-theme='dark'] .quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -1078,39 +1078,6 @@
   margin-top: 0.5rem;
 }
 
-.quarantine-approval-badge {
-  display: inline-block;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.quarantine-approval-none {
-  background: rgba(156, 163, 175, 0.2);
-  color: var(--neutral-500);
-}
-
-.quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.2);
-  color: #b45309;
-}
-
-.quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.2);
-  color: #16a34a;
-}
-
-[data-theme='dark'] .quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.25);
-  color: #fbbf24;
-}
-
-[data-theme='dark'] .quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.25);
-  color: #4ade80;
-}
-
 [data-theme='dark'] .quarantine-info {
   background: rgba(239, 68, 68, 0.2);
   border-color: var(--danger);

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -1074,6 +1074,43 @@
   margin: 0.25rem 0;
 }
 
+.quarantine-approval-status {
+  margin-top: 0.5rem;
+}
+
+.quarantine-approval-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.quarantine-approval-none {
+  background: rgba(156, 163, 175, 0.2);
+  color: var(--neutral-500);
+}
+
+.quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.2);
+  color: #b45309;
+}
+
+.quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+}
+
+[data-theme='dark'] .quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fbbf24;
+}
+
+[data-theme='dark'] .quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
 [data-theme='dark'] .quarantine-info {
   background: rgba(239, 68, 68, 0.2);
   border-color: var(--danger);

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -475,14 +475,13 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
-                  {animal.quarantine_approval_status && (
+                  {animal.quarantine_approval_status ? (
                     <p className="quarantine-approval-status">
                       <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}>
                         {animal.quarantine_approval_status === 'requested' ? '🕐 Approval Requested' : '✅ Approved — Cleared to Work'}
                       </span>
                     </p>
-                  )}
-                  {!animal.quarantine_approval_status && (
+                  ) : (
                     <p className="quarantine-approval-status">
                       <span className="quarantine-approval-badge quarantine-approval-none">
                         No Approval Requested

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -484,7 +484,7 @@ const AnimalDetailPage: React.FC = () => {
                   ) : (
                     <p className="quarantine-approval-status">
                       <span className="quarantine-approval-badge quarantine-approval-none">
-                        Not Requested
+                        ⬜ Not Requested
                       </span>
                     </p>
                   )}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -484,7 +484,7 @@ const AnimalDetailPage: React.FC = () => {
                   ) : (
                     <p className="quarantine-approval-status">
                       <span className="quarantine-approval-badge quarantine-approval-none">
-                        No Approval Requested
+                        Not Requested
                       </span>
                     </p>
                   )}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,14 +477,18 @@ const AnimalDetailPage: React.FC = () => {
                   </p>
                   {animal.quarantine_approval_status ? (
                     <p className="quarantine-approval-status">
-                      <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
-                        {animal.quarantine_approval_status === 'requested' ? '🕐 Approval Requested' : '✅ Approved — Cleared to Work'}
+                      <span
+                        className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}
+                        aria-label={animal.quarantine_approval_status === 'requested' ? 'Approval Requested — Awaiting Response' : 'Approved — Cleared to Work'}
+                      >
+                        <span aria-hidden="true">{animal.quarantine_approval_status === 'requested' ? '🕐' : '✅'}</span>
+                        {' '}{animal.quarantine_approval_status === 'requested' ? 'Approval Requested' : 'Approved — Cleared to Work'}
                       </span>
                     </p>
                   ) : (
                     <p className="quarantine-approval-status">
-                      <span className="quarantine-approval-badge quarantine-approval-none">
-                        ⬜ Not Requested
+                      <span className="quarantine-approval-badge quarantine-approval-none" aria-label="No approval requested">
+                        <span aria-hidden="true">⬜</span>{' '}Not Requested
                       </span>
                     </p>
                   )}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -475,6 +475,20 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
+                  {animal.quarantine_approval_status && (
+                    <p className="quarantine-approval-status">
+                      <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}>
+                        {animal.quarantine_approval_status === 'requested' ? '🕐 Approval Requested' : '✅ Approved — Cleared to Work'}
+                      </span>
+                    </p>
+                  )}
+                  {!animal.quarantine_approval_status && (
+                    <p className="quarantine-approval-status">
+                      <span className="quarantine-approval-badge quarantine-approval-none">
+                        No Approval Requested
+                      </span>
+                    </p>
+                  )}
                 </div>
               )}
               {animal.description && (

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,7 +477,7 @@ const AnimalDetailPage: React.FC = () => {
                   </p>
                   {animal.quarantine_approval_status ? (
                     <p className="quarantine-approval-status">
-                      <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}>
+                      <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
                         {animal.quarantine_approval_status === 'requested' ? '🕐 Approval Requested' : '✅ Approved — Cleared to Work'}
                       </span>
                     </p>

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -44,6 +44,7 @@ const AnimalForm: React.FC = () => {
     status: 'available',
     arrival_date: '',
     quarantine_start_date: '',
+    quarantine_approval_status: '',
     is_returned: false,
     protocol_document_url: '',
     protocol_document_name: '',
@@ -112,6 +113,7 @@ const AnimalForm: React.FC = () => {
         trainer_notes: animal.trainer_notes || '',
         arrival_date: animal.arrival_date ? animal.arrival_date.split('T')[0] : '',
         quarantine_start_date: animal.quarantine_start_date ? animal.quarantine_start_date.split('T')[0] : '',
+        quarantine_approval_status: animal.quarantine_approval_status || '',
         protocol_document_url: animal.protocol_document_url || '',
         protocol_document_name: animal.protocol_document_name || '',
       });
@@ -701,7 +703,30 @@ const AnimalForm: React.FC = () => {
               </select>
               <p className="form-field__helper">Current status of the animal</p>
             </div>
+          </div>
 
+          {formData.status === 'bite_quarantine' && (
+            <div className="form-field">
+              <label htmlFor="quarantine_approval_status" className="form-field__label">
+                Third-Party Approval
+              </label>
+              <select
+                id="quarantine_approval_status"
+                value={formData.quarantine_approval_status}
+                onChange={(e) => setFormData({ ...formData, quarantine_approval_status: e.target.value })}
+                className="form-field__input"
+              >
+                <option value="">Not Requested</option>
+                <option value="requested">Requested — Awaiting Response</option>
+                <option value="granted">Granted — Cleared to Work</option>
+              </select>
+              <p className="form-field__helper">
+                Track whether third-party permission has been requested or granted to resume working with this animal.
+              </p>
+            </div>
+          )}
+
+          <div className="form-row">
             <div className="form-field">
               <label htmlFor="arrival_date" className="form-field__label">
                 Date in Shelter

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -423,6 +423,12 @@ const AnimalForm: React.FC = () => {
         estimated_birth_date: finalBirthDate || undefined,
         age: birthYears,
         quarantine_start_date: formData.quarantine_start_date || undefined,
+        // Only include quarantine_approval_status when in bite_quarantine so non-quarantine saves
+        // don't accidentally send "" and trigger the "not provided" vs "clear" ambiguity.
+        // The backend uses *string: nil = not provided (no change), "" = explicit clear.
+        quarantine_approval_status: formData.status === 'bite_quarantine'
+          ? formData.quarantine_approval_status
+          : undefined,
       };
       
       if (id && groupId) {

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -719,7 +719,7 @@ const AnimalForm: React.FC = () => {
               <select
                 id="quarantine_approval_status"
                 value={formData.quarantine_approval_status}
-                onChange={(e) => setFormData({ ...formData, quarantine_approval_status: e.target.value })}
+                onChange={(e) => setFormData({ ...formData, quarantine_approval_status: e.target.value as '' | 'requested' | 'granted' })}
                 className="form-field__input"
               >
                 <option value="">Not Requested</option>

--- a/frontend/src/pages/BulkEditAnimalsPage.css
+++ b/frontend/src/pages/BulkEditAnimalsPage.css
@@ -589,6 +589,39 @@
   font-weight: 600;
 }
 
+.quarantine-approval-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.quarantine-approval-none {
+  background: rgba(156, 163, 175, 0.2);
+  color: var(--neutral-500);
+}
+
+.quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.2);
+  color: #b45309;
+}
+
+.quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+}
+
+[data-theme='dark'] .quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fbbf24;
+}
+
+[data-theme='dark'] .quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
 .info-select {
   padding: 0.5rem 0.625rem;
   border: 1px solid var(--border);

--- a/frontend/src/pages/BulkEditAnimalsPage.css
+++ b/frontend/src/pages/BulkEditAnimalsPage.css
@@ -589,39 +589,6 @@
   font-weight: 600;
 }
 
-.quarantine-approval-badge {
-  display: inline-block;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.quarantine-approval-none {
-  background: rgba(156, 163, 175, 0.2);
-  color: var(--neutral-500);
-}
-
-.quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.2);
-  color: #b45309;
-}
-
-.quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.2);
-  color: #16a34a;
-}
-
-[data-theme='dark'] .quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.25);
-  color: #fbbf24;
-}
-
-[data-theme='dark'] .quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.25);
-  color: #4ade80;
-}
-
 .info-select {
   padding: 0.5rem 0.625rem;
   border: 1px solid var(--border);

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -712,12 +712,25 @@ const BulkEditAnimalsPage: React.FC = () => {
                           <div className="info-item full-width">
                             <div className="info-label">Approval</div>
                             <div className="info-value">
-                              <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
-                                {animal.quarantine_approval_status === 'granted'
-                                  ? '✅ Approved'
-                                  : animal.quarantine_approval_status === 'requested'
-                                  ? '🕐 Pending'
-                                  : '⬜ Not Requested'}
+                              <span
+                                className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
+                                aria-label={
+                                  animal.quarantine_approval_status === 'granted' ? 'Approved' :
+                                  animal.quarantine_approval_status === 'requested' ? 'Approval Pending' :
+                                  'No approval requested'
+                                }
+                              >
+                                <span aria-hidden="true">{
+                                  animal.quarantine_approval_status === 'granted' ? '✅' :
+                                  animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
+                                }</span>
+                                {' '}{
+                                  animal.quarantine_approval_status === 'granted'
+                                    ? 'Approved'
+                                    : animal.quarantine_approval_status === 'requested'
+                                    ? 'Pending'
+                                    : 'Not Requested'
+                                }
                               </span>
                             </div>
                           </div>

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -709,6 +709,18 @@ const BulkEditAnimalsPage: React.FC = () => {
                               {calculateQuarantineEndDate(animal.quarantine_start_date)}
                             </div>
                           </div>
+                          <div className="info-item full-width">
+                            <div className="info-label">Approval</div>
+                            <div className="info-value">
+                              <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
+                                {animal.quarantine_approval_status === 'granted'
+                                  ? '✅ Approved'
+                                  : animal.quarantine_approval_status === 'requested'
+                                  ? '🕐 Pending'
+                                  : '⬜ Not Requested'}
+                              </span>
+                            </div>
+                          </div>
                         </>
                       )}
                     </div>

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -611,39 +611,6 @@
   margin-top: 0.35rem;
 }
 
-.quarantine-approval-badge {
-  display: inline-block;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.quarantine-approval-none {
-  background: rgba(156, 163, 175, 0.2);
-  color: var(--neutral-500);
-}
-
-.quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.2);
-  color: #b45309;
-}
-
-.quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.2);
-  color: #16a34a;
-}
-
-[data-theme='dark'] .quarantine-approval-requested {
-  background: rgba(234, 179, 8, 0.25);
-  color: #fbbf24;
-}
-
-[data-theme='dark'] .quarantine-approval-granted {
-  background: rgba(34, 197, 94, 0.25);
-  color: #4ade80;
-}
-
 /* Animal Tags */
 .animal-tags {
   display: flex;

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -607,6 +607,43 @@
   background: rgba(239, 68, 68, 0.15);
 }
 
+.quarantine-approval-inline {
+  margin-top: 0.35rem;
+}
+
+.quarantine-approval-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.quarantine-approval-none {
+  background: rgba(156, 163, 175, 0.2);
+  color: var(--neutral-500);
+}
+
+.quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.2);
+  color: #b45309;
+}
+
+.quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+}
+
+[data-theme='dark'] .quarantine-approval-requested {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fbbf24;
+}
+
+[data-theme='dark'] .quarantine-approval-granted {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
 /* Animal Tags */
 .animal-tags {
   display: flex;

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1045,7 +1045,7 @@ const GroupPage: React.FC = () => {
                                 ? '✅ Approved'
                                 : animal.quarantine_approval_status === 'requested'
                                 ? '🕐 Approval Pending'
-                                : '⬜ No Approval'}
+                                : '⬜ Not Requested'}
                             </span>
                           </p>
                         )}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1040,12 +1040,25 @@ const GroupPage: React.FC = () => {
                         )}
                         {animal.status === 'bite_quarantine' && (
                           <p className="quarantine-approval-inline">
-                            <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
-                              {animal.quarantine_approval_status === 'granted'
-                                ? '✅ Approved'
-                                : animal.quarantine_approval_status === 'requested'
-                                ? '🕐 Approval Pending'
-                                : '⬜ Not Requested'}
+                            <span
+                              className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
+                              aria-label={
+                                animal.quarantine_approval_status === 'granted' ? 'Approved' :
+                                animal.quarantine_approval_status === 'requested' ? 'Approval Pending' :
+                                'No approval requested'
+                              }
+                            >
+                              <span aria-hidden="true">{
+                                animal.quarantine_approval_status === 'granted' ? '✅' :
+                                animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
+                              }</span>
+                              {' '}{
+                                animal.quarantine_approval_status === 'granted'
+                                  ? 'Approved'
+                                  : animal.quarantine_approval_status === 'requested'
+                                  ? 'Approval Pending'
+                                  : 'Not Requested'
+                              }
                             </span>
                           </p>
                         )}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1038,6 +1038,17 @@ const GroupPage: React.FC = () => {
                             })()}
                           </p>
                         )}
+                        {animal.status === 'bite_quarantine' && (
+                          <p className="quarantine-approval-inline">
+                            <span className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}>
+                              {animal.quarantine_approval_status === 'granted'
+                                ? '✅ Approved'
+                                : animal.quarantine_approval_status === 'requested'
+                                ? '🕐 Approval Pending'
+                                : '⬜ No Approval'}
+                            </span>
+                          </p>
+                        )}
                         {/* Both pills link to /photos — PhotoGallery renders images and videos on the same page */}
                         <div className="media-indicator">
                           {(animal.image_count ?? 0) > 0 ? (

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -99,11 +99,9 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["foster_start_date"] = nil
 				updates["archived_date"] = nil
 			case "archived":
-				// Clear approval fields when archiving a quarantined animal
-				if animal.Status == "bite_quarantine" {
-					updates["quarantine_approval_status"] = ""
-					updates["quarantine_approval_date"] = nil
-				}
+				// Always clear approval fields on archive (defensive: approval is only meaningful during quarantine)
+				updates["quarantine_approval_status"] = ""
+				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = now
 			}
 		} else if animal.Status == "bite_quarantine" {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -69,10 +69,14 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			case "available":
 				updates["foster_start_date"] = nil
 				updates["quarantine_start_date"] = nil
+				updates["quarantine_approval_status"] = ""
+				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
 			case "foster":
 				updates["foster_start_date"] = now
 				updates["quarantine_start_date"] = nil
+				updates["quarantine_approval_status"] = ""
+				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
 			case "bite_quarantine":
 				// Use provided quarantine start date if available, otherwise use current time
@@ -81,11 +85,20 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				} else {
 					updates["quarantine_start_date"] = now
 				}
+				if req.QuarantineApprovalStatus != "" {
+					updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+					updates["quarantine_approval_date"] = now
+				}
 				updates["foster_start_date"] = nil
 				updates["archived_date"] = nil
 			case "archived":
 				updates["archived_date"] = now
 			}
+		} else if req.QuarantineApprovalStatus != "" && (req.Status == "bite_quarantine" || animal.Status == "bite_quarantine") {
+			// Update approval status without changing main status
+			now := time.Now()
+			updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+			updates["quarantine_approval_date"] = now
 		}
 		if req.GroupID != 0 {
 			updates["group_id"] = req.GroupID

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -96,6 +96,11 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["foster_start_date"] = nil
 				updates["archived_date"] = nil
 			case "archived":
+				// Clear approval fields when archiving a quarantined animal
+				if animal.Status == "bite_quarantine" {
+					updates["quarantine_approval_status"] = ""
+					updates["quarantine_approval_date"] = nil
+				}
 				updates["archived_date"] = now
 			}
 		} else if animal.Status == "bite_quarantine" {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -62,9 +62,9 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 		if req.ImageURL != "" {
 			updates["image_url"] = req.ImageURL
 		}
+		now := time.Now()
 		if req.Status != "" && req.Status != animal.Status {
 			// Track status change
-			now := time.Now()
 			updates["status"] = req.Status
 			updates["last_status_change"] = now
 
@@ -98,12 +98,16 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			case "archived":
 				updates["archived_date"] = now
 			}
-		} else if req.Status == "bite_quarantine" || animal.Status == "bite_quarantine" {
+		} else if animal.Status == "bite_quarantine" {
 			// Update approval status (allow clearing to "") without changing main status
 			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
-				now := time.Now()
-				updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
-				updates["quarantine_approval_date"] = now
+				if req.QuarantineApprovalStatus == "" {
+					updates["quarantine_approval_status"] = ""
+					updates["quarantine_approval_date"] = nil
+				} else {
+					updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+					updates["quarantine_approval_date"] = now
+				}
 			}
 		}
 		if req.GroupID != 0 {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -23,6 +23,10 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
 			return
 		}
+		if !isValidApprovalStatus(req.QuarantineApprovalStatus) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid quarantine_approval_status: must be '', 'requested', or 'granted'"})
+			return
+		}
 
 		var animal models.Animal
 		if err := db.Preload("Tags").First(&animal, animalID).Error; err != nil {
@@ -94,11 +98,13 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			case "archived":
 				updates["archived_date"] = now
 			}
-		} else if req.QuarantineApprovalStatus != "" && (req.Status == "bite_quarantine" || animal.Status == "bite_quarantine") {
-			// Update approval status without changing main status
-			now := time.Now()
-			updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
-			updates["quarantine_approval_date"] = now
+		} else if req.Status == "bite_quarantine" || animal.Status == "bite_quarantine" {
+			// Update approval status (allow clearing to "") without changing main status
+			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
+				now := time.Now()
+				updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+				updates["quarantine_approval_date"] = now
+			}
 		}
 		if req.GroupID != 0 {
 			updates["group_id"] = req.GroupID

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -89,8 +89,8 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				} else {
 					updates["quarantine_start_date"] = now
 				}
-				if req.QuarantineApprovalStatus != "" {
-					updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+				if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
+					updates["quarantine_approval_status"] = *req.QuarantineApprovalStatus
 					updates["quarantine_approval_date"] = now
 				}
 				updates["foster_start_date"] = nil
@@ -99,13 +99,13 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["archived_date"] = now
 			}
 		} else if animal.Status == "bite_quarantine" {
-			// Update approval status (allow clearing to "") without changing main status
-			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
-				if req.QuarantineApprovalStatus == "" {
+			// Update approval status only when explicitly provided (nil = not sent = no change)
+			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
+				if *req.QuarantineApprovalStatus == "" {
 					updates["quarantine_approval_status"] = ""
 					updates["quarantine_approval_date"] = nil
 				} else {
-					updates["quarantine_approval_status"] = req.QuarantineApprovalStatus
+					updates["quarantine_approval_status"] = *req.QuarantineApprovalStatus
 					updates["quarantine_approval_date"] = now
 				}
 			}

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -115,13 +115,13 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 					updates["quarantine_approval_date"] = now
 				}
 			}
+			// Update quarantine start date independently — both fields can change in one request
+			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+				updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
+			}
 		}
 		if req.GroupID != 0 {
 			updates["group_id"] = req.GroupID
-		}
-		// Update quarantine start date if provided and status is quarantine
-		if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil && (req.Status == "bite_quarantine" || animal.Status == "bite_quarantine") {
-			updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
 		}
 
 		if len(updates) == 0 {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -89,6 +89,9 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				} else {
 					updates["quarantine_start_date"] = now
 				}
+				// Always start clean, then apply provided value if any
+				updates["quarantine_approval_status"] = ""
+				updates["quarantine_approval_date"] = nil
 				if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
 					updates["quarantine_approval_status"] = *req.QuarantineApprovalStatus
 					updates["quarantine_approval_date"] = now

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -432,3 +432,78 @@ func TestGetAllAnimals_OrderedByGroupAndName(t *testing.T) {
 		t.Errorf("Expected third animal to be 'Zebra', got '%s'", animals[2].Name)
 	}
 }
+
+// --- Quarantine approval status admin tests ---
+
+// TestUpdateAnimalAdmin_ApprovalStatusSet verifies admin path sets approval status and stamps the date.
+func TestUpdateAnimalAdmin_ApprovalStatusSet(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminapproval1", "adminapproval1@example.com", true)
+
+	animal := createTestAnimal(t, db, group.ID, "Gus", "Dog")
+	animal.Status = "bite_quarantine"
+	db.Save(animal)
+
+	newStatus := "granted"
+	req := AnimalRequest{
+		Name:                     "Gus",
+		Status:                   "bite_quarantine",
+		QuarantineApprovalStatus: &newStatus,
+	}
+	body, _ := json.Marshal(req)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimalAdmin(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "granted" {
+		t.Errorf("Expected approval_status 'granted', got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate == nil {
+		t.Error("Expected approval_date to be set, got nil")
+	}
+}
+
+// TestUpdateAnimalAdmin_ApprovalClearedOnTransitionToAvailable verifies admin path clears approval on exit.
+func TestUpdateAnimalAdmin_ApprovalClearedOnTransitionToAvailable(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminapproval2", "adminapproval2@example.com", true)
+
+	animal := createTestAnimal(t, db, group.ID, "Hank", "Cat")
+	animal.Status = "bite_quarantine"
+	animal.QuarantineApprovalStatus = "requested"
+	db.Save(animal)
+
+	req := AnimalRequest{
+		Name:   "Hank",
+		Status: "available",
+	}
+	body, _ := json.Marshal(req)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimalAdmin(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "" {
+		t.Errorf("Expected approval_status '', got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate != nil {
+		t.Error("Expected approval_date to be nil after leaving quarantine, got non-nil")
+	}
+}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -215,6 +215,11 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 			} else {
 				animal.QuarantineStartDate = &now
 			}
+			// Set third-party approval status if provided
+			if req.QuarantineApprovalStatus != "" {
+				animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+				animal.QuarantineApprovalDate = &now
+			}
 		case "archived":
 			animal.ArchivedDate = &now
 		}
@@ -312,13 +317,17 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				if oldStatus == "archived" {
 					animal.ArrivalDate = &now
 				}
-				// Clear specific status dates
+				// Clear specific status dates and approval when leaving quarantine
 				animal.FosterStartDate = nil
 				animal.QuarantineStartDate = nil
+				animal.QuarantineApprovalStatus = ""
+				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
 			case "foster":
 				animal.FosterStartDate = &now
 				animal.QuarantineStartDate = nil
+				animal.QuarantineApprovalStatus = ""
+				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
 			case "bite_quarantine":
 				// Use provided quarantine start date if available, otherwise use current time
@@ -327,13 +336,24 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				} else {
 					animal.QuarantineStartDate = &now
 				}
+				// Set approval status if provided
+				if req.QuarantineApprovalStatus != "" {
+					animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+					animal.QuarantineApprovalDate = &now
+				}
 				animal.FosterStartDate = nil
 				animal.ArchivedDate = nil
 			case "archived":
 				animal.ArchivedDate = &now
 			}
 			animal.Status = newStatus
-		} else if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil && animal.Status == "bite_quarantine" {
+		} else if animal.Status == "bite_quarantine" && req.QuarantineApprovalStatus != "" {
+			// Update approval status without changing main status
+			approvalNow := time.Now()
+			animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+			animal.QuarantineApprovalDate = &approvalNow
+		}
+		if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil && animal.Status == "bite_quarantine" {
 			// Update quarantine start date if provided and animal is already in quarantine status
 			// This handles the case where only the date is being updated without status change
 			animal.QuarantineStartDate = req.QuarantineStartDate.Time

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -220,8 +220,8 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineStartDate = &now
 			}
 			// Set third-party approval status if provided
-			if req.QuarantineApprovalStatus != "" {
-				animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
+				animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 				animal.QuarantineApprovalDate = &now
 			}
 		case "archived":
@@ -314,8 +314,8 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 		// Track status changes
 		oldStatus := animal.Status
 		newStatus := req.Status
+		now := time.Now()
 		if newStatus != "" && newStatus != oldStatus {
-			now := time.Now()
 			animal.LastStatusChange = &now
 
 			// Update status-specific dates
@@ -345,8 +345,8 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 					animal.QuarantineStartDate = &now
 				}
 				// Set approval status if provided
-				if req.QuarantineApprovalStatus != "" {
-					animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+				if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
+					animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 					animal.QuarantineApprovalDate = &now
 				}
 				animal.FosterStartDate = nil
@@ -356,15 +356,14 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 			}
 			animal.Status = newStatus
 		} else if animal.Status == "bite_quarantine" {
-			// Update approval status (can also be cleared to "") when status is unchanged
-			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
-				if req.QuarantineApprovalStatus == "" {
+			// Update approval status only when explicitly provided (nil = not sent = no change)
+			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
+				if *req.QuarantineApprovalStatus == "" {
 					animal.QuarantineApprovalStatus = ""
 					animal.QuarantineApprovalDate = nil
 				} else {
-					approvalNow := time.Now()
-					animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
-					animal.QuarantineApprovalDate = &approvalNow
+					animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
+					animal.QuarantineApprovalDate = &now
 				}
 			}
 			// Update quarantine start date independently — both fields can change in one request

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -356,13 +356,19 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 			}
 			animal.Status = newStatus
 		} else if animal.Status == "bite_quarantine" {
-			// Update approval status (can also be cleared to "") or quarantine start date
+			// Update approval status (can also be cleared to "") when status is unchanged
 			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
-				approvalNow := time.Now()
-				animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
-				animal.QuarantineApprovalDate = &approvalNow
-			} else if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
-				// Update quarantine start date if provided and status is unchanged
+				if req.QuarantineApprovalStatus == "" {
+					animal.QuarantineApprovalStatus = ""
+					animal.QuarantineApprovalDate = nil
+				} else {
+					approvalNow := time.Now()
+					animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+					animal.QuarantineApprovalDate = &approvalNow
+				}
+			}
+			// Update quarantine start date independently — both fields can change in one request
+			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
 			}
 		}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -352,6 +352,11 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.FosterStartDate = nil
 				animal.ArchivedDate = nil
 			case "archived":
+				// Clear approval fields when archiving a quarantined animal
+				if oldStatus == "bite_quarantine" {
+					animal.QuarantineApprovalStatus = ""
+					animal.QuarantineApprovalDate = nil
+				}
 				animal.ArchivedDate = &now
 			}
 			animal.Status = newStatus

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -361,7 +361,7 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				approvalNow := time.Now()
 				animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
 				animal.QuarantineApprovalDate = &approvalNow
-	} else if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+			} else if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				// Update quarantine start date if provided and status is unchanged
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
 			}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -164,6 +164,10 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
 			return
 		}
+		if !isValidApprovalStatus(req.QuarantineApprovalStatus) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid quarantine_approval_status: must be '', 'requested', or 'granted'"})
+			return
+		}
 
 		gid, err := strconv.ParseUint(groupID, 10, 32)
 		if err != nil {
@@ -275,6 +279,10 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
 			return
 		}
+		if !isValidApprovalStatus(req.QuarantineApprovalStatus) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid quarantine_approval_status: must be '', 'requested', or 'granted'"})
+			return
+		}
 
 		var animal models.Animal
 		if err := db.WithContext(ctx).Preload("Tags").Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
@@ -347,16 +355,16 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.ArchivedDate = &now
 			}
 			animal.Status = newStatus
-		} else if animal.Status == "bite_quarantine" && req.QuarantineApprovalStatus != "" {
-			// Update approval status without changing main status
-			approvalNow := time.Now()
-			animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
-			animal.QuarantineApprovalDate = &approvalNow
-		}
-		if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil && animal.Status == "bite_quarantine" {
-			// Update quarantine start date if provided and animal is already in quarantine status
-			// This handles the case where only the date is being updated without status change
-			animal.QuarantineStartDate = req.QuarantineStartDate.Time
+		} else if animal.Status == "bite_quarantine" {
+			// Update approval status (can also be cleared to "") or quarantine start date
+			if req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
+				approvalNow := time.Now()
+				animal.QuarantineApprovalStatus = req.QuarantineApprovalStatus
+				animal.QuarantineApprovalDate = &approvalNow
+	} else if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+				// Update quarantine start date if provided and status is unchanged
+				animal.QuarantineStartDate = req.QuarantineStartDate.Time
+			}
 		}
 
 		if req.IsReturned != nil {

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -344,7 +344,9 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				} else {
 					animal.QuarantineStartDate = &now
 				}
-				// Set approval status if provided
+				// Always start clean, then apply provided value if any
+				animal.QuarantineApprovalStatus = ""
+				animal.QuarantineApprovalDate = nil
 				if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
 					animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 					animal.QuarantineApprovalDate = &now

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -354,11 +354,9 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.FosterStartDate = nil
 				animal.ArchivedDate = nil
 			case "archived":
-				// Clear approval fields when archiving a quarantined animal
-				if oldStatus == "bite_quarantine" {
-					animal.QuarantineApprovalStatus = ""
-					animal.QuarantineApprovalDate = nil
-				}
+				// Always clear approval fields on archive (defensive: approval is only meaningful during quarantine)
+				animal.QuarantineApprovalStatus = ""
+				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = &now
 			}
 			animal.Status = newStatus

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -81,7 +81,7 @@ type AnimalRequest struct {
 	GroupID                  uint         `json:"group_id,omitempty"`
 	ArrivalDate              NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
 	QuarantineStartDate      NullableTime `json:"quarantine_start_date,omitempty"`
-	QuarantineApprovalStatus string       `json:"quarantine_approval_status,omitempty"` // "" | "requested" | "granted"
+	QuarantineApprovalStatus *string      `json:"quarantine_approval_status,omitempty"` // nil = not provided; "" | "requested" | "granted" when set
 	IsReturned               *bool        `json:"is_returned,omitempty"`                // Pointer to distinguish null from false
 }
 
@@ -93,9 +93,12 @@ type DuplicateNameInfo struct {
 	HasDuplicates bool            `json:"has_duplicates"`
 }
 
-// isValidApprovalStatus returns true for the three allowed quarantine approval values.
-func isValidApprovalStatus(s string) bool {
-	return s == "" || s == "requested" || s == "granted"
+// isValidApprovalStatus returns true when s is nil (not provided) or one of the three allowed values.
+func isValidApprovalStatus(s *string) bool {
+	if s == nil {
+		return true
+	}
+	return *s == "" || *s == "requested" || *s == "granted"
 }
 
 // checkGroupAccess verifies if the user has access to a specific group

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -69,20 +69,20 @@ func (nt NullableTime) MarshalJSON() ([]byte, error) {
 
 // AnimalRequest represents the request structure for creating/updating animals
 type AnimalRequest struct {
-	Name                string       `json:"name" binding:"required"`
-	Species             string       `json:"species"`
-	Breed               string       `json:"breed"`
-	Age                 int          `json:"age"`
-	EstimatedBirthDate  NullableTime `json:"estimated_birth_date,omitempty"` // Estimated date of birth for real-time age
-	Description         string       `json:"description"`
-	TrainerNotes        string       `json:"trainer_notes"`
-	ImageURL            string       `json:"image_url,omitempty"`
+	Name                     string       `json:"name" binding:"required"`
+	Species                  string       `json:"species"`
+	Breed                    string       `json:"breed"`
+	Age                      int          `json:"age"`
+	EstimatedBirthDate       NullableTime `json:"estimated_birth_date,omitempty"` // Estimated date of birth for real-time age
+	Description              string       `json:"description"`
+	TrainerNotes             string       `json:"trainer_notes"`
+	ImageURL                 string       `json:"image_url,omitempty"`
 	Status                   string       `json:"status"`
 	GroupID                  uint         `json:"group_id,omitempty"`
 	ArrivalDate              NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
 	QuarantineStartDate      NullableTime `json:"quarantine_start_date,omitempty"`
 	QuarantineApprovalStatus string       `json:"quarantine_approval_status,omitempty"` // "" | "requested" | "granted"
-	IsReturned               *bool        `json:"is_returned,omitempty"` // Pointer to distinguish null from false
+	IsReturned               *bool        `json:"is_returned,omitempty"`                // Pointer to distinguish null from false
 }
 
 // DuplicateNameInfo represents information about animals with duplicate names

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -77,11 +77,12 @@ type AnimalRequest struct {
 	Description         string       `json:"description"`
 	TrainerNotes        string       `json:"trainer_notes"`
 	ImageURL            string       `json:"image_url,omitempty"`
-	Status              string       `json:"status"`
-	GroupID             uint         `json:"group_id,omitempty"`
-	ArrivalDate         NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
-	QuarantineStartDate NullableTime `json:"quarantine_start_date,omitempty"`
-	IsReturned          *bool        `json:"is_returned,omitempty"` // Pointer to distinguish null from false
+	Status                   string       `json:"status"`
+	GroupID                  uint         `json:"group_id,omitempty"`
+	ArrivalDate              NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
+	QuarantineStartDate      NullableTime `json:"quarantine_start_date,omitempty"`
+	QuarantineApprovalStatus string       `json:"quarantine_approval_status,omitempty"` // "" | "requested" | "granted"
+	IsReturned               *bool        `json:"is_returned,omitempty"` // Pointer to distinguish null from false
 }
 
 // DuplicateNameInfo represents information about animals with duplicate names

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -93,6 +93,11 @@ type DuplicateNameInfo struct {
 	HasDuplicates bool            `json:"has_duplicates"`
 }
 
+// isValidApprovalStatus returns true for the three allowed quarantine approval values.
+func isValidApprovalStatus(s string) bool {
+	return s == "" || s == "requested" || s == "granted"
+}
+
 // checkGroupAccess verifies if the user has access to a specific group
 func checkGroupAccess(db *gorm.DB, userID interface{}, isAdmin interface{}, groupID string) bool {
 	adminBool, ok := isAdmin.(bool)

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -1651,3 +1651,291 @@ func TestCreateAnimal_IsReturned(t *testing.T) {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+// stringPtr returns a pointer to a string literal.
+func stringPtr(s string) *string {
+	return &s
+}
+
+// --- Quarantine approval status tests ---
+
+// TestIsValidApprovalStatus verifies the helper covers all expected cases.
+func TestIsValidApprovalStatus(t *testing.T) {
+	cases := []struct {
+		input *string
+		want  bool
+	}{
+		{nil, true},
+		{stringPtr(""), true},
+		{stringPtr("requested"), true},
+		{stringPtr("granted"), true},
+		{stringPtr("approved"), false},
+		{stringPtr("GRANTED"), false},
+		{stringPtr("yes"), false},
+	}
+	for _, tc := range cases {
+		label := "nil"
+		if tc.input != nil {
+			label = *tc.input
+		}
+		if got := isValidApprovalStatus(tc.input); got != tc.want {
+			t.Errorf("isValidApprovalStatus(%q) = %v, want %v", label, got, tc.want)
+		}
+	}
+}
+
+// TestCreateAnimal_WithApprovalStatus verifies that approval status is persisted on create.
+func TestCreateAnimal_WithApprovalStatus(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser", "admin@example.com", false)
+
+	approvalStatus := "requested"
+	reqBody := AnimalRequest{
+		Name:                     "Fluffy",
+		Species:                  "Cat",
+		Status:                   "bite_quarantine",
+		QuarantineApprovalStatus: &approvalStatus,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	CreateAnimal(db)(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created models.Animal
+	json.Unmarshal(w.Body.Bytes(), &created)
+	if created.QuarantineApprovalStatus != "requested" {
+		t.Errorf("Expected approval_status 'requested', got %q", created.QuarantineApprovalStatus)
+	}
+	if created.QuarantineApprovalDate == nil {
+		t.Error("Expected approval_date to be set, got nil")
+	}
+}
+
+// TestUpdateAnimal_InvalidApprovalStatus verifies HTTP 400 for bad values.
+func TestUpdateAnimal_InvalidApprovalStatus(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser2", "admin2@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	badStatus := "approved"
+	reqBody := AnimalRequest{
+		Name:                     animal.Name,
+		QuarantineApprovalStatus: &badStatus,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestUpdateAnimal_ApprovalStatusSet verifies approval date is stamped when status is set.
+func TestUpdateAnimal_ApprovalStatusSet(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser3", "admin3@example.com", false)
+
+	now := time.Now()
+	animal := &models.Animal{
+		GroupID:          group.ID,
+		Name:             "Buddy",
+		Species:          "Dog",
+		Status:           "bite_quarantine",
+		ArrivalDate:      &now,
+		LastStatusChange: &now,
+		QuarantineStartDate: &now,
+	}
+	db.Create(animal)
+
+	newStatus := "granted"
+	reqBody := AnimalRequest{
+		Name:                     "Buddy",
+		Status:                   "bite_quarantine",
+		QuarantineApprovalStatus: &newStatus,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "granted" {
+		t.Errorf("Expected approval_status 'granted', got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate == nil {
+		t.Error("Expected approval_date to be set, got nil")
+	}
+}
+
+// TestUpdateAnimal_ApprovalStatusCleared verifies approval date is cleared when status is reset.
+func TestUpdateAnimal_ApprovalStatusCleared(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser4", "admin4@example.com", false)
+
+	now := time.Now()
+	animal := &models.Animal{
+		GroupID:                  group.ID,
+		Name:                     "Max",
+		Species:                  "Dog",
+		Status:                   "bite_quarantine",
+		ArrivalDate:              &now,
+		LastStatusChange:         &now,
+		QuarantineStartDate:      &now,
+		QuarantineApprovalStatus: "granted",
+		QuarantineApprovalDate:   &now,
+	}
+	db.Create(animal)
+
+	clearStatus := ""
+	reqBody := AnimalRequest{
+		Name:                     "Max",
+		Status:                   "bite_quarantine",
+		QuarantineApprovalStatus: &clearStatus,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "" {
+		t.Errorf("Expected approval_status '', got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate != nil {
+		t.Error("Expected approval_date to be nil, got non-nil")
+	}
+}
+
+// TestUpdateAnimal_ApprovalNotClearedWhenOmitted verifies that omitting the field doesn't clear it.
+func TestUpdateAnimal_ApprovalNotClearedWhenOmitted(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser5", "admin5@example.com", false)
+
+	now := time.Now()
+	animal := &models.Animal{
+		GroupID:                  group.ID,
+		Name:                     "Luna",
+		Species:                  "Cat",
+		Status:                   "bite_quarantine",
+		ArrivalDate:              &now,
+		LastStatusChange:         &now,
+		QuarantineStartDate:      &now,
+		QuarantineApprovalStatus: "requested",
+		QuarantineApprovalDate:   &now,
+	}
+	db.Create(animal)
+
+	// Update description only — no quarantine_approval_status in payload
+	reqBody := AnimalRequest{
+		Name:        "Luna",
+		Status:      "bite_quarantine",
+		Description: "Updated description",
+		// QuarantineApprovalStatus is nil (omitted)
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "requested" {
+		t.Errorf("Expected approval_status to remain 'requested', got %q", updated.QuarantineApprovalStatus)
+	}
+}
+
+// TestUpdateAnimal_ApprovalClearedOnTransitionToAvailable verifies both fields clear when leaving quarantine.
+func TestUpdateAnimal_ApprovalClearedOnTransitionToAvailable(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser6", "admin6@example.com", false)
+
+	now := time.Now()
+	animal := &models.Animal{
+		GroupID:                  group.ID,
+		Name:                     "Cleo",
+		Species:                  "Cat",
+		Status:                   "bite_quarantine",
+		ArrivalDate:              &now,
+		LastStatusChange:         &now,
+		QuarantineStartDate:      &now,
+		QuarantineApprovalStatus: "granted",
+		QuarantineApprovalDate:   &now,
+	}
+	db.Create(animal)
+
+	reqBody := AnimalRequest{
+		Name:   "Cleo",
+		Status: "available",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "" {
+		t.Errorf("Expected approval_status '', got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate != nil {
+		t.Error("Expected approval_date to be nil after leaving quarantine, got non-nil")
+	}
+}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -1939,3 +1939,51 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToAvailable(t *testing.T) {
 		t.Error("Expected approval_date to be nil after leaving quarantine, got non-nil")
 	}
 }
+
+// TestUpdateAnimal_ApprovalClearedOnTransitionToFoster verifies both fields clear on foster transition too.
+func TestUpdateAnimal_ApprovalClearedOnTransitionToFoster(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "adminuser7", "admin7@example.com", false)
+
+	now := time.Now()
+	animal := &models.Animal{
+		GroupID:                  group.ID,
+		Name:                     "Biscuit",
+		Species:                  "Dog",
+		Status:                   "bite_quarantine",
+		ArrivalDate:              &now,
+		LastStatusChange:         &now,
+		QuarantineStartDate:      &now,
+		QuarantineApprovalStatus: "requested",
+		QuarantineApprovalDate:   &now,
+	}
+	db.Create(animal)
+
+	reqBody := AnimalRequest{
+		Name:   "Biscuit",
+		Status: "foster",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	UpdateAnimal(db)(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated models.Animal
+	db.First(&updated, animal.ID)
+	if updated.QuarantineApprovalStatus != "" {
+		t.Errorf("Expected approval_status '' after foster transition, got %q", updated.QuarantineApprovalStatus)
+	}
+	if updated.QuarantineApprovalDate != nil {
+		t.Error("Expected approval_date to be nil after foster transition, got non-nil")
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -88,7 +88,7 @@ type Animal struct {
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
 	QuarantineApprovalStatus       string              `gorm:"default:''" json:"quarantine_approval_status"`                    // Third-party approval: "" (not requested), "requested", "granted"
-	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval was requested or granted
+	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval status last changed (nil when not requested)
 	ArchivedDate                   *time.Time          `json:"archived_date"`                                                   // When animal was archived
 	LastStatusChange               *time.Time          `json:"last_status_change"`                                              // Timestamp of last status change
 	IsReturned                     bool                `gorm:"default:false" json:"is_returned"`                                // Manually set by admins to indicate this animal was previously adopted and returned

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -87,6 +87,8 @@ type Animal struct {
 	ArrivalDate                    *time.Time          `json:"arrival_date"`                                                    // When animal first became available
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
+	QuarantineApprovalStatus       string              `gorm:"default:''" json:"quarantine_approval_status"`                    // Third-party approval: "" (not requested), "requested", "granted"
+	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval was requested or granted
 	ArchivedDate                   *time.Time          `json:"archived_date"`                                                   // When animal was archived
 	LastStatusChange               *time.Time          `json:"last_status_change"`                                              // Timestamp of last status change
 	IsReturned                     bool                `gorm:"default:false" json:"is_returned"`                                // Manually set by admins to indicate this animal was previously adopted and returned

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -49,22 +49,22 @@ type User struct {
 
 // Group represents a volunteer group (dogs, cats, modsquad, etc.)
 type Group struct {
-	ID             uint           `gorm:"primaryKey" json:"id"`
-	CreatedAt      time.Time      `json:"created_at"`
-	UpdatedAt      time.Time      `json:"updated_at"`
-	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
-	Name           string         `gorm:"uniqueIndex;not null" json:"name"`
-	Description    string         `json:"description"`
-	ImageURL       string         `json:"image_url"`
-	HeroImageURL   string         `json:"hero_image_url"`
-	HasProtocols   bool           `gorm:"column:has_protocols;default:false" json:"has_protocols"`     // Enable protocols feature for this group
-	GroupMeBotID   string         `gorm:"column:groupme_bot_id" json:"-"`                              // GroupMe Bot ID — omitted from API responses; exposed via adminGroupResponse only
-	GroupMeEnabled bool           `gorm:"column:groupme_enabled;default:false" json:"groupme_enabled"` // Enable GroupMe integration for this group
-	Users          []User         `gorm:"many2many:user_groups;" json:"users,omitempty"`
-	Animals        []Animal       `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
-	Updates        []Update       `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
-	Protocols      []Protocol     `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
-	Scripts        []Script       `gorm:"foreignKey:GroupID" json:"scripts,omitempty"`
+	ID             uint            `gorm:"primaryKey" json:"id"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt  `gorm:"index" json:"-"`
+	Name           string          `gorm:"uniqueIndex;not null" json:"name"`
+	Description    string          `json:"description"`
+	ImageURL       string          `json:"image_url"`
+	HeroImageURL   string          `json:"hero_image_url"`
+	HasProtocols   bool            `gorm:"column:has_protocols;default:false" json:"has_protocols"`     // Enable protocols feature for this group
+	GroupMeBotID   string          `gorm:"column:groupme_bot_id" json:"-"`                              // GroupMe Bot ID — omitted from API responses; exposed via adminGroupResponse only
+	GroupMeEnabled bool            `gorm:"column:groupme_enabled;default:false" json:"groupme_enabled"` // Enable GroupMe integration for this group
+	Users          []User          `gorm:"many2many:user_groups;" json:"users,omitempty"`
+	Animals        []Animal        `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
+	Updates        []Update        `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
+	Protocols      []Protocol      `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
+	Scripts        []Script        `gorm:"foreignKey:GroupID" json:"scripts,omitempty"`
 	Documents      []GroupDocument `gorm:"foreignKey:GroupID" json:"documents,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Adds a `quarantine_approval_status` field to animals in bite quarantine so staff can track whether third-party permission has been requested or granted before resuming work with the animal.

## Changes

### Backend
- **`internal/models/models.go`** — Added `QuarantineApprovalStatus string` (`""` | `"requested"` | `"granted"`) and `QuarantineApprovalDate *time.Time` to `Animal`. GORM will auto-migrate the columns on next startup — no manual migration needed.
- **`internal/handlers/animal_helpers.go`** — Added `QuarantineApprovalStatus` to `AnimalRequest`.
- **`internal/handlers/animal_crud.go`** — Create and Update handlers read/write the new field; transitioning away from `bite_quarantine` (to available or foster) automatically clears both fields.
- **`internal/handlers/animal_admin.go`** — Same logic for the admin/bulk update path.

### Frontend
- **`api/client.ts`** — Added `quarantine_approval_status?` and `quarantine_approval_date?` to the `Animal` TypeScript interface.
- **`AnimalForm.tsx`** — A **Third-Party Approval** select appears only when `status === 'bite_quarantine'`:
  - `""` → Not Requested
  - `"requested"` → Requested — Awaiting Response
  - `"granted"` → Granted — Cleared to Work
- **`AnimalDetailPage.tsx`** — Color-coded pill badge shown beneath quarantine dates.
- **`GroupPage.tsx`** — Compact approval pill on animal cards below the quarantine end date.
- **`BulkEditAnimalsPage.tsx`** — Approval row in card view alongside Quarantine End.
- **CSS** (`AnimalDetailPage.css`, `GroupPage.css`, `BulkEditAnimalsPage.css`) — Shared pill badge styles with dark-mode variants (grey = not requested, amber = requested, green = granted).

## Roadmap Impact

- Improves the bite quarantine workflow with explicit approval state tracking, addressing a real operational need for shelter staff managing third-party clearance before resuming animal handling.