### PR TITLE
feat: Rename approval to 'Bite Quarantine Permission', default to requested

### DIFF
--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -479,10 +479,10 @@ const AnimalDetailPage: React.FC = () => {
                     <p className="quarantine-approval-status">
                       <span
                         className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}
-                        aria-label={animal.quarantine_approval_status === 'requested' ? 'Approval Requested — Awaiting Response' : 'Approved — Cleared to Work'}
+                        aria-label={animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested — Awaiting Response' : 'Bite Quarantine Permission: Granted — Cleared to Work'}
                       >
                         <span aria-hidden="true">{animal.quarantine_approval_status === 'requested' ? '🕐' : '✅'}</span>
-                        {' '}{animal.quarantine_approval_status === 'requested' ? 'Approval Requested' : 'Approved — Cleared to Work'}
+                        {' '}{animal.quarantine_approval_status === 'requested' ? 'Permission Requested' : 'Permission Granted — Cleared to Work'}
                       </span>
                     </p>
                   ) : (

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -479,7 +479,13 @@ const AnimalDetailPage: React.FC = () => {
                     <p className="quarantine-approval-status">
                       <span
                         className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}
-                        aria-label={animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested — Awaiting Response' : 'Bite Quarantine Permission: Granted — Cleared to Work'}
+                        aria-label={
+                          animal.quarantine_approval_status === 'granted'
+                            ? 'Bite Quarantine Permission: Granted — Cleared to Work'
+                            : animal.quarantine_approval_status === 'requested'
+                            ? 'Bite Quarantine Permission: Requested — Awaiting Response'
+                            : 'Bite Quarantine Permission: Not Requested'
+                        }
                       >
                         <span aria-hidden="true">{animal.quarantine_approval_status === 'requested' ? '🕐' : '✅'}</span>
                         {' '}{animal.quarantine_approval_status === 'requested' ? 'Permission Requested' : 'Permission Granted — Cleared to Work'}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -487,8 +487,17 @@ const AnimalDetailPage: React.FC = () => {
                             : 'Bite Quarantine Permission: Not Requested'
                         }
                       >
-                        <span aria-hidden="true">{animal.quarantine_approval_status === 'requested' ? '🕐' : '✅'}</span>
-                        {' '}{animal.quarantine_approval_status === 'requested' ? 'Permission Requested' : 'Permission Granted — Cleared to Work'}
+                        <span aria-hidden="true">{
+                          animal.quarantine_approval_status === 'granted' ? '✅' :
+                          animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
+                        }</span>
+                        {' '}{
+                          animal.quarantine_approval_status === 'granted'
+                            ? 'Permission Granted — Cleared to Work'
+                            : animal.quarantine_approval_status === 'requested'
+                            ? 'Permission Requested'
+                            : 'Not Requested'
+                        }
                       </span>
                     </p>
                   ) : (

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -44,7 +44,7 @@ const AnimalForm: React.FC = () => {
     status: 'available',
     arrival_date: '',
     quarantine_start_date: '',
-    quarantine_approval_status: '',
+    quarantine_approval_status: 'requested',
     is_returned: false,
     protocol_document_url: '',
     protocol_document_name: '',
@@ -113,7 +113,7 @@ const AnimalForm: React.FC = () => {
         trainer_notes: animal.trainer_notes || '',
         arrival_date: animal.arrival_date ? animal.arrival_date.split('T')[0] : '',
         quarantine_start_date: animal.quarantine_start_date ? animal.quarantine_start_date.split('T')[0] : '',
-        quarantine_approval_status: animal.quarantine_approval_status || '',
+        quarantine_approval_status: animal.quarantine_approval_status || 'requested',
         protocol_document_url: animal.protocol_document_url || '',
         protocol_document_name: animal.protocol_document_name || '',
       });
@@ -714,7 +714,7 @@ const AnimalForm: React.FC = () => {
           {formData.status === 'bite_quarantine' && (
             <div className="form-field">
               <label htmlFor="quarantine_approval_status" className="form-field__label">
-                Third-Party Approval
+                Bite Quarantine Permission
               </label>
               <select
                 id="quarantine_approval_status"
@@ -722,12 +722,12 @@ const AnimalForm: React.FC = () => {
                 onChange={(e) => setFormData({ ...formData, quarantine_approval_status: e.target.value as '' | 'requested' | 'granted' })}
                 className="form-field__input"
               >
-                <option value="">Not Requested</option>
                 <option value="requested">Requested — Awaiting Response</option>
                 <option value="granted">Granted — Cleared to Work</option>
+                <option value="">Not Requested</option>
               </select>
               <p className="form-field__helper">
-                Track whether third-party permission has been requested or granted to resume working with this animal.
+                Track whether permission has been requested or granted to resume working with this animal.
               </p>
             </div>
           )}

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -715,9 +715,9 @@ const BulkEditAnimalsPage: React.FC = () => {
                               <span
                                 className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
                                 aria-label={
-                                  animal.quarantine_approval_status === 'granted' ? 'Approved' :
-                                  animal.quarantine_approval_status === 'requested' ? 'Approval Pending' :
-                                  'No approval requested'
+                                  animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
+                                  animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
+                                  'Bite Quarantine Permission: Not Requested'
                                 }
                               >
                                 <span aria-hidden="true">{
@@ -726,9 +726,9 @@ const BulkEditAnimalsPage: React.FC = () => {
                                 }</span>
                                 {' '}{
                                   animal.quarantine_approval_status === 'granted'
-                                    ? 'Approved'
+                                    ? 'Permission Granted'
                                     : animal.quarantine_approval_status === 'requested'
-                                    ? 'Pending'
+                                    ? 'Permission Requested'
                                     : 'Not Requested'
                                 }
                               </span>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1043,9 +1043,9 @@ const GroupPage: React.FC = () => {
                             <span
                               className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
                               aria-label={
-                                animal.quarantine_approval_status === 'granted' ? 'Approved' :
-                                animal.quarantine_approval_status === 'requested' ? 'Approval Pending' :
-                                'No approval requested'
+                                animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
+                                animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
+                                'Bite Quarantine Permission: Not Requested'
                               }
                             >
                               <span aria-hidden="true">{
@@ -1054,9 +1054,9 @@ const GroupPage: React.FC = () => {
                               }</span>
                               {' '}{
                                 animal.quarantine_approval_status === 'granted'
-                                  ? 'Approved'
+                                  ? 'Permission Granted'
                                   : animal.quarantine_approval_status === 'requested'
-                                  ? 'Approval Pending'
+                                  ? 'Permission Requested'
                                   : 'Not Requested'
                               }
                             </span>

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -219,7 +219,7 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 			} else {
 				animal.QuarantineStartDate = &now
 			}
-			// Set third-party approval status if provided
+			// Set bite quarantine permission status if provided
 			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
 				animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 				animal.QuarantineApprovalDate = &now

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -1987,3 +1987,41 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToFoster(t *testing.T) {
 		t.Error("Expected approval_date to be nil after foster transition, got non-nil")
 	}
 }
+
+// TestCreateAnimal_DefaultApprovalStatusWhenOmitted verifies that creating a bite_quarantine
+// animal without an explicit quarantine_approval_status stores "requested" (the GORM default).
+func TestCreateAnimal_DefaultApprovalStatusWhenOmitted(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "defaultstatus", "defaultstatus@example.com", false)
+
+	// No QuarantineApprovalStatus field — should default to "requested"
+	reqBody := AnimalRequest{
+		Name:    "Pepper",
+		Species: "Cat",
+		Status:  "bite_quarantine",
+		// QuarantineApprovalStatus intentionally omitted (nil)
+	}
+	body, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	CreateAnimal(db)(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created models.Animal
+	json.Unmarshal(w.Body.Bytes(), &created)
+
+	// GORM default:'requested' should be applied since no value was provided
+	if created.QuarantineApprovalStatus != "requested" {
+		t.Errorf("Expected default approval_status 'requested', got %q", created.QuarantineApprovalStatus)
+	}
+	// Date should NOT be set since no explicit status was provided by the handler
+	if created.QuarantineApprovalDate != nil {
+		t.Error("Expected approval_date to be nil when status defaulted via GORM, got non-nil")
+	}
+}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -1753,12 +1753,12 @@ func TestUpdateAnimal_ApprovalStatusSet(t *testing.T) {
 
 	now := time.Now()
 	animal := &models.Animal{
-		GroupID:          group.ID,
-		Name:             "Buddy",
-		Species:          "Dog",
-		Status:           "bite_quarantine",
-		ArrivalDate:      &now,
-		LastStatusChange: &now,
+		GroupID:             group.ID,
+		Name:                "Buddy",
+		Species:             "Dog",
+		Status:              "bite_quarantine",
+		ArrivalDate:         &now,
+		LastStatusChange:    &now,
 		QuarantineStartDate: &now,
 	}
 	db.Create(animal)
@@ -2014,9 +2014,9 @@ func TestCreateAnimal_DefaultApprovalStatusWhenOmitted(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 	var created models.Animal
-	json.Unmarshal(w.Body.Bytes(), &created)
-
-	// GORM default:'requested' should be applied since no value was provided
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
 	if created.QuarantineApprovalStatus != "requested" {
 		t.Errorf("Expected default approval_status 'requested', got %q", created.QuarantineApprovalStatus)
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -87,7 +87,7 @@ type Animal struct {
 	ArrivalDate                    *time.Time          `json:"arrival_date"`                                                    // When animal first became available
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
-	QuarantineApprovalStatus       string              `gorm:"default:''" json:"quarantine_approval_status"`                    // Third-party approval: "" (not requested), "requested", "granted"
+	QuarantineApprovalStatus       string              `gorm:"default:'requested'" json:"quarantine_approval_status"`            // Bite quarantine permission: "" (not requested), "requested", "granted"
 	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval status last changed (nil when not requested)
 	ArchivedDate                   *time.Time          `json:"archived_date"`                                                   // When animal was archived
 	LastStatusChange               *time.Time          `json:"last_status_change"`                                              // Timestamp of last status change

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -87,7 +87,7 @@ type Animal struct {
 	ArrivalDate                    *time.Time          `json:"arrival_date"`                                                    // When animal first became available
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
-	QuarantineApprovalStatus       string              `gorm:"default:'requested'" json:"quarantine_approval_status"`            // Bite quarantine permission: "" (not requested), "requested", "granted"
+	QuarantineApprovalStatus       string              `gorm:"default:'requested'" json:"quarantine_approval_status"`           // Bite quarantine permission: "requested" (default), "granted", or "" (legacy — displayed as Not Requested)
 	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval status last changed (nil when not requested)
 	ArchivedDate                   *time.Time          `json:"archived_date"`                                                   // When animal was archived
 	LastStatusChange               *time.Time          `json:"last_status_change"`                                              // Timestamp of last status change


### PR DESCRIPTION
## Summary

Renames the bite quarantine approval field from "Third-Party Approval" to the more descriptive **"Bite Quarantine Permission"**, and changes the default value from blank to `"requested"` so the permission is automatically flagged as requested whenever an animal is placed in bite quarantine.

## Changes

### Label / Terminology
- Form label: "Third-Party Approval" → **"Bite Quarantine Permission"**
- Badge text: "Approval Requested" → "Permission Requested", "Approved — Cleared to Work" → "Permission Granted — Cleared to Work"
- `aria-label` updated to prefix "Bite Quarantine Permission: \<state\>" on all three pages

### Default changed to `"requested"`
- `AnimalForm.tsx` initial state defaults to `'requested'` — the permission field appears pre-selected when setting bite quarantine status
- `loadAnimal` fallback: `|| 'requested'` — existing animals with no stored value display as "Permission Requested"
- GORM model: `gorm:"default:'requested'"` — new DB records default to requested
- Select option order: **Requested** first, Granted second, Not Requested last (explicit downgrade)

### Helper text
- "Track whether third-party permission has been requested or granted..." → "Track whether permission has been requested or granted to resume working with this animal."

## Files Changed
- `internal/models/models.go` — GORM default and comment
- `internal/handlers/animal_crud.go` — inline comment
- `frontend/src/pages/AnimalForm.tsx` — label, helper text, option order, default state
- `frontend/src/pages/AnimalDetailPage.tsx` — badge text and aria-label
- `frontend/src/pages/GroupPage.tsx` — badge text and aria-label
- `frontend/src/pages/BulkEditAnimalsPage.tsx` — badge text and aria-label