### PR TITLE
refactor: group bite quarantine permission into quarantine UI

### DIFF
--- a/frontend/src/components/QuarantineApprovalBadge.test.tsx
+++ b/frontend/src/components/QuarantineApprovalBadge.test.tsx
@@ -50,4 +50,10 @@ describe('QuarantineApprovalBadge', () => {
     const badge = screen.getByLabelText('Bite Quarantine Permission: Granted — Cleared to Work');
     expect(badge).toHaveClass('quarantine-approval-granted');
   });
+
+  it('falls back to "Not Requested" state for an unknown status value', () => {
+    render(<QuarantineApprovalBadge status="revoked" />);
+    expect(screen.getByText(/Not Requested/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Bite Quarantine Permission: Not Requested')).toHaveClass('quarantine-approval-none');
+  });
 });

--- a/frontend/src/components/QuarantineApprovalBadge.test.tsx
+++ b/frontend/src/components/QuarantineApprovalBadge.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import QuarantineApprovalBadge from './QuarantineApprovalBadge';
+
+describe('QuarantineApprovalBadge', () => {
+  it('renders "Not Requested" state for null status', () => {
+    const { container } = render(<QuarantineApprovalBadge status={null} />);
+    expect(screen.getByText(/Not Requested/)).toBeInTheDocument();
+    expect(container.querySelector('[aria-hidden="true"]')).toHaveTextContent('⬜');
+  });
+
+  it('renders "Not Requested" state for undefined status', () => {
+    render(<QuarantineApprovalBadge />);
+    expect(screen.getByText(/Not Requested/)).toBeInTheDocument();
+  });
+
+  it('renders "Not Requested" state for empty string status', () => {
+    render(<QuarantineApprovalBadge status="" />);
+    expect(screen.getByText(/Not Requested/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Bite Quarantine Permission: Not Requested')).toBeInTheDocument();
+  });
+
+  it('renders "Requested" state with correct aria-label', () => {
+    render(<QuarantineApprovalBadge status="requested" />);
+    expect(screen.getByText(/Requested/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Bite Quarantine Permission: Requested — Awaiting Response')).toBeInTheDocument();
+  });
+
+  it('renders "Granted — Cleared to Work" state with correct aria-label', () => {
+    render(<QuarantineApprovalBadge status="granted" />);
+    expect(screen.getByText(/Granted — Cleared to Work/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Bite Quarantine Permission: Granted — Cleared to Work')).toBeInTheDocument();
+  });
+
+  it('applies quarantine-approval-none class for null status', () => {
+    render(<QuarantineApprovalBadge status={null} />);
+    const badge = screen.getByLabelText('Bite Quarantine Permission: Not Requested');
+    expect(badge).toHaveClass('quarantine-approval-badge');
+    expect(badge).toHaveClass('quarantine-approval-none');
+  });
+
+  it('applies quarantine-approval-requested class', () => {
+    render(<QuarantineApprovalBadge status="requested" />);
+    const badge = screen.getByLabelText('Bite Quarantine Permission: Requested — Awaiting Response');
+    expect(badge).toHaveClass('quarantine-approval-requested');
+  });
+
+  it('applies quarantine-approval-granted class', () => {
+    render(<QuarantineApprovalBadge status="granted" />);
+    const badge = screen.getByLabelText('Bite Quarantine Permission: Granted — Cleared to Work');
+    expect(badge).toHaveClass('quarantine-approval-granted');
+  });
+});

--- a/frontend/src/components/QuarantineApprovalBadge.tsx
+++ b/frontend/src/components/QuarantineApprovalBadge.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface Props {
+  status?: string | null;
+}
+
+const QuarantineApprovalBadge: React.FC<Props> = ({ status }) => {
+  const normalised = status || 'none';
+
+  const ariaLabel =
+    status === 'granted'
+      ? 'Bite Quarantine Permission: Granted — Cleared to Work'
+      : status === 'requested'
+      ? 'Bite Quarantine Permission: Requested — Awaiting Response'
+      : 'Bite Quarantine Permission: Not Requested';
+
+  const emoji =
+    status === 'granted' ? '✅' : status === 'requested' ? '🕐' : '⬜';
+
+  const label =
+    status === 'granted'
+      ? 'Granted — Cleared to Work'
+      : status === 'requested'
+      ? 'Requested'
+      : 'Not Requested';
+
+  return (
+    <span
+      className={`quarantine-approval-badge quarantine-approval-${normalised}`}
+      aria-label={ariaLabel}
+    >
+      <span aria-hidden="true">{emoji}</span>
+      {' '}{label}
+    </span>
+  );
+};
+
+export default QuarantineApprovalBadge;

--- a/frontend/src/components/QuarantineApprovalBadge.tsx
+++ b/frontend/src/components/QuarantineApprovalBadge.tsx
@@ -4,29 +4,31 @@ interface Props {
   status?: string | null;
 }
 
+const STATUS_CONFIG: Record<string, { ariaLabel: string; emoji: string; label: string }> = {
+  granted: {
+    ariaLabel: 'Bite Quarantine Permission: Granted — Cleared to Work',
+    emoji: '✅',
+    label: 'Granted — Cleared to Work',
+  },
+  requested: {
+    ariaLabel: 'Bite Quarantine Permission: Requested — Awaiting Response',
+    emoji: '🕐',
+    label: 'Requested',
+  },
+  none: {
+    ariaLabel: 'Bite Quarantine Permission: Not Requested',
+    emoji: '⬜',
+    label: 'Not Requested',
+  },
+};
+
 const QuarantineApprovalBadge: React.FC<Props> = ({ status }) => {
-  const normalised = status || 'none';
-
-  const ariaLabel =
-    status === 'granted'
-      ? 'Bite Quarantine Permission: Granted — Cleared to Work'
-      : status === 'requested'
-      ? 'Bite Quarantine Permission: Requested — Awaiting Response'
-      : 'Bite Quarantine Permission: Not Requested';
-
-  const emoji =
-    status === 'granted' ? '✅' : status === 'requested' ? '🕐' : '⬜';
-
-  const label =
-    status === 'granted'
-      ? 'Granted — Cleared to Work'
-      : status === 'requested'
-      ? 'Requested'
-      : 'Not Requested';
+  const key = status && STATUS_CONFIG[status] ? status : 'none';
+  const { ariaLabel, emoji, label } = STATUS_CONFIG[key];
 
   return (
     <span
-      className={`quarantine-approval-badge quarantine-approval-${normalised}`}
+      className={`quarantine-approval-badge quarantine-approval-${key}`}
       aria-label={ariaLabel}
     >
       <span aria-hidden="true">{emoji}</span>

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -1078,12 +1078,30 @@
   margin-top: 0.5rem;
 }
 
+.quarantine-permission-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.quarantine-permission-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
 [data-theme='dark'] .quarantine-info {
   background: rgba(239, 68, 68, 0.2);
   border-color: var(--danger);
 }
 
 [data-theme='dark'] .quarantine-dates {
+  color: var(--text-secondary);
+}
+
+[data-theme='dark'] .quarantine-permission-label {
   color: var(--text-secondary);
 }
 

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -481,7 +481,7 @@ const AnimalDetailPage: React.FC = () => {
               )}
               {animal.status === 'bite_quarantine' && (
                 <div className="quarantine-permission-row">
-                  <span className="quarantine-permission-label">Permission:</span>
+                  <span className="quarantine-permission-label" aria-hidden="true">Permission:</span>
                   <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                 </div>
               )}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -23,6 +23,11 @@ import '../components/ScriptsList.css';
 // Lazy load ProtocolViewer to reduce initial bundle size (~350KB savings)
 const ProtocolViewer = lazy(() => import('../components/ProtocolViewer'));
 
+const formatAnimalStatus = (status: string) =>
+  status === 'bite_quarantine'
+    ? 'Bite Quarantine'
+    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+
 const AnimalDetailPage: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
   const navigate = useNavigate();
@@ -462,7 +467,7 @@ const AnimalDetailPage: React.FC = () => {
                 {animal.breed && `${animal.breed} \u2022 `}{animalAgeLabel} {'\u2022'} ID: {animal.id}
               </p>
               <div className="status-badges">
-                <span className={`status ${animal.status}`}>{animal.status}</span>
+                <span className={`status ${animal.status}`}>{formatAnimalStatus(animal.status)}</span>
               </div>
               {animal.status === 'bite_quarantine' && animal.quarantine_start_date && (
                 <div className="quarantine-info">
@@ -475,38 +480,31 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
-                  {animal.quarantine_approval_status ? (
-                    <p className="quarantine-approval-status">
-                      <span
-                        className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status}`}
-                        aria-label={
-                          animal.quarantine_approval_status === 'granted'
-                            ? 'Bite Quarantine Permission: Granted — Cleared to Work'
-                            : animal.quarantine_approval_status === 'requested'
-                            ? 'Bite Quarantine Permission: Requested — Awaiting Response'
-                            : 'Bite Quarantine Permission: Not Requested'
-                        }
-                      >
-                        <span aria-hidden="true">{
-                          animal.quarantine_approval_status === 'granted' ? '✅' :
-                          animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
-                        }</span>
-                        {' '}{
-                          animal.quarantine_approval_status === 'granted'
-                            ? 'Permission Granted — Cleared to Work'
-                            : animal.quarantine_approval_status === 'requested'
-                            ? 'Permission Requested'
-                            : 'Not Requested'
-                        }
-                      </span>
-                    </p>
-                  ) : (
-                    <p className="quarantine-approval-status">
-                      <span className="quarantine-approval-badge quarantine-approval-none" aria-label="No approval requested">
-                        <span aria-hidden="true">⬜</span>{' '}Not Requested
-                      </span>
-                    </p>
-                  )}
+                  <div className="quarantine-permission-row">
+                    <span className="quarantine-permission-label">Permission:</span>
+                    <span
+                      className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
+                      aria-label={
+                        animal.quarantine_approval_status === 'granted'
+                          ? 'Bite Quarantine Permission: Granted — Cleared to Work'
+                          : animal.quarantine_approval_status === 'requested'
+                          ? 'Bite Quarantine Permission: Requested — Awaiting Response'
+                          : 'Bite Quarantine Permission: Not Requested'
+                      }
+                    >
+                      <span aria-hidden="true">{
+                        animal.quarantine_approval_status === 'granted' ? '✅' :
+                        animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
+                      }</span>
+                      {' '}{
+                        animal.quarantine_approval_status === 'granted'
+                          ? 'Granted — Cleared to Work'
+                          : animal.quarantine_approval_status === 'requested'
+                          ? 'Requested'
+                          : 'Not Requested'
+                      }
+                    </span>
+                  </div>
                 </div>
               )}
               {animal.description && (

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,10 +477,12 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
-                  <div className="quarantine-permission-row">
-                    <span className="quarantine-permission-label">Permission:</span>
-                    <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
-                  </div>
+                </div>
+              )}
+              {animal.status === 'bite_quarantine' && (
+                <div className="quarantine-permission-row">
+                  <span className="quarantine-permission-label">Permission:</span>
+                  <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                 </div>
               )}
               {animal.description && (

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
 import { calculateQuarantineEndDate, calculateAge, formatAge } from '../utils/dateUtils';
 import { formatDisplayName } from '../utils/formatName';
+import { formatAnimalStatus } from '../utils/animalUtils';
+import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import EmptyState from '../components/EmptyState';
 import SkeletonLoader from '../components/SkeletonLoader';
 import ErrorState from '../components/ErrorState';
@@ -22,11 +24,6 @@ import '../components/ScriptsList.css';
 
 // Lazy load ProtocolViewer to reduce initial bundle size (~350KB savings)
 const ProtocolViewer = lazy(() => import('../components/ProtocolViewer'));
-
-const formatAnimalStatus = (status: string) =>
-  status === 'bite_quarantine'
-    ? 'Bite Quarantine'
-    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 
 const AnimalDetailPage: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
@@ -482,28 +479,7 @@ const AnimalDetailPage: React.FC = () => {
                   </p>
                   <div className="quarantine-permission-row">
                     <span className="quarantine-permission-label">Permission:</span>
-                    <span
-                      className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
-                      aria-label={
-                        animal.quarantine_approval_status === 'granted'
-                          ? 'Bite Quarantine Permission: Granted — Cleared to Work'
-                          : animal.quarantine_approval_status === 'requested'
-                          ? 'Bite Quarantine Permission: Requested — Awaiting Response'
-                          : 'Bite Quarantine Permission: Not Requested'
-                      }
-                    >
-                      <span aria-hidden="true">{
-                        animal.quarantine_approval_status === 'granted' ? '✅' :
-                        animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
-                      }</span>
-                      {' '}{
-                        animal.quarantine_approval_status === 'granted'
-                          ? 'Granted — Cleared to Work'
-                          : animal.quarantine_approval_status === 'requested'
-                          ? 'Requested'
-                          : 'Not Requested'
-                      }
-                    </span>
+                    <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                   </div>
                 </div>
               )}

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -11,6 +11,11 @@ import Modal from '../components/Modal';
 import ImageEditor from '../components/ImageEditor';
 import './Form.css';
 
+const formatAnimalStatus = (status: string) =>
+  status === 'bite_quarantine'
+    ? 'Bite Quarantine'
+    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+
 const AnimalForm: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
   const navigate = useNavigate();
@@ -627,7 +632,7 @@ const AnimalForm: React.FC = () => {
                         {animal.name} (ID: {animal.id})
                       </span>
                       <span className="duplicate-animal-details">
-                        {animal.breed || 'Unknown breed'} • {dupAgeLabel} • {animal.status}
+                        {animal.breed || 'Unknown breed'} • {dupAgeLabel} • {formatAnimalStatus(animal.status)}
                       </span>
                     </div>
                   );

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -4,17 +4,13 @@ import { animalsApi, updatesApi, animalTagsApi, commentTagsApi, animalCommentsAp
 import type { AnimalTag, Animal, DuplicateNameInfo, AnimalImage } from '../api/client';
 import { useToast } from '../hooks/useToast';
 import { calculateQuarantineEndDate, calculateAge, computeEstimatedBirthDate } from '../utils/dateUtils';
+import { formatAnimalStatus } from '../utils/animalUtils';
 import FormField from '../components/FormField';
 import AgePicker from '../components/AgePicker';
 import Button from '../components/Button';
 import Modal from '../components/Modal';
 import ImageEditor from '../components/ImageEditor';
 import './Form.css';
-
-const formatAnimalStatus = (status: string) =>
-  status === 'bite_quarantine'
-    ? 'Bite Quarantine'
-    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 
 const AnimalForm: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();

--- a/frontend/src/pages/BulkEditAnimalsPage.css
+++ b/frontend/src/pages/BulkEditAnimalsPage.css
@@ -589,6 +589,11 @@
   font-weight: 600;
 }
 
+.quarantine-permission-value {
+  display: flex;
+  align-items: center;
+}
+
 .info-select {
   padding: 0.5rem 0.625rem;
   border: 1px solid var(--border);

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -4,17 +4,14 @@ import { animalsApi, groupsApi } from '../api/client';
 import type { Animal, Group } from '../api/client';
 import { useToast } from '../hooks/useToast';
 import { formatDateShort, calculateQuarantineEndDate, calculateDaysSince, calculateAge, formatAge } from '../utils/dateUtils';
+import { formatAnimalStatus } from '../utils/animalUtils';
+import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { useDebounce } from '../hooks/useDebounce';
 import EmptyState from '../components/EmptyState';
 import SkeletonLoader from '../components/SkeletonLoader';
 import ErrorState from '../components/ErrorState';
 import Modal from '../components/Modal';
 import './BulkEditAnimalsPage.css';
-
-const formatAnimalStatus = (status: string) =>
-  status === 'bite_quarantine'
-    ? 'Bite Quarantine'
-    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 
 const BulkEditAnimalsPage: React.FC = () => {
   const toast = useToast();
@@ -717,26 +714,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                           <div className="info-item full-width">
                             <div className="info-label">Permission</div>
                             <div className="info-value quarantine-permission-value">
-                              <span
-                                className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
-                                aria-label={
-                                  animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
-                                  animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
-                                  'Bite Quarantine Permission: Not Requested'
-                                }
-                              >
-                                <span aria-hidden="true">{
-                                  animal.quarantine_approval_status === 'granted' ? '✅' :
-                                  animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
-                                }</span>
-                                {' '}{
-                                  animal.quarantine_approval_status === 'granted'
-                                    ? 'Granted'
-                                    : animal.quarantine_approval_status === 'requested'
-                                    ? 'Requested'
-                                    : 'Not Requested'
-                                }
-                              </span>
+                              <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                             </div>
                           </div>
                         </>

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -704,20 +704,20 @@ const BulkEditAnimalsPage: React.FC = () => {
                       </div>
 
                       {animal.status === 'bite_quarantine' && animal.quarantine_start_date && (
-                        <>
-                          <div className="info-item full-width">
-                            <div className="info-label">Quarantine End</div>
-                            <div className="info-value quarantine-date">
-                              {calculateQuarantineEndDate(animal.quarantine_start_date)}
-                            </div>
+                        <div className="info-item full-width">
+                          <div className="info-label">Quarantine End</div>
+                          <div className="info-value quarantine-date">
+                            {calculateQuarantineEndDate(animal.quarantine_start_date)}
                           </div>
-                          <div className="info-item full-width">
-                            <div className="info-label">Permission</div>
-                            <div className="info-value quarantine-permission-value">
-                              <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
-                            </div>
+                        </div>
+                      )}
+                      {animal.status === 'bite_quarantine' && (
+                        <div className="info-item full-width">
+                          <div className="info-label">Permission</div>
+                          <div className="info-value quarantine-permission-value">
+                            <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                           </div>
-                        </>
+                        </div>
                       )}
                     </div>
                   </div>

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -713,7 +713,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                       )}
                       {animal.status === 'bite_quarantine' && (
                         <div className="info-item full-width">
-                          <div className="info-label">Permission</div>
+                          <div className="info-label" aria-hidden="true">Permission</div>
                           <div className="info-value quarantine-permission-value">
                             <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                           </div>

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -11,6 +11,11 @@ import ErrorState from '../components/ErrorState';
 import Modal from '../components/Modal';
 import './BulkEditAnimalsPage.css';
 
+const formatAnimalStatus = (status: string) =>
+  status === 'bite_quarantine'
+    ? 'Bite Quarantine'
+    : status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+
 const BulkEditAnimalsPage: React.FC = () => {
   const toast = useToast();
   const [animals, setAnimals] = useState<Animal[]>([]);
@@ -636,7 +641,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                       disabled={isUpdating}
                     />
                     <span className={`status-badge status-${animal.status}`}>
-                      {animal.status.replace('_', ' ')}
+                      {formatAnimalStatus(animal.status)}
                     </span>
                   </div>
 
@@ -710,8 +715,8 @@ const BulkEditAnimalsPage: React.FC = () => {
                             </div>
                           </div>
                           <div className="info-item full-width">
-                            <div className="info-label">Approval</div>
-                            <div className="info-value">
+                            <div className="info-label">Permission</div>
+                            <div className="info-value quarantine-permission-value">
                               <span
                                 className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
                                 aria-label={
@@ -726,9 +731,9 @@ const BulkEditAnimalsPage: React.FC = () => {
                                 }</span>
                                 {' '}{
                                   animal.quarantine_approval_status === 'granted'
-                                    ? 'Permission Granted'
+                                    ? 'Granted'
                                     : animal.quarantine_approval_status === 'requested'
-                                    ? 'Permission Requested'
+                                    ? 'Requested'
                                     : 'Not Requested'
                                 }
                               </span>

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -608,7 +608,20 @@
 }
 
 .quarantine-approval-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   margin-top: 0.35rem;
+}
+
+.quarantine-summary-card {
+  margin-top: 0.5rem;
+}
+
+.quarantine-permission-inline-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
 }
 
 /* Animal Tags */

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -614,10 +614,6 @@
   margin-top: 0.35rem;
 }
 
-.quarantine-summary-card {
-  margin-top: 0.5rem;
-}
-
 .quarantine-permission-inline-label {
   font-size: 0.75rem;
   font-weight: 700;

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1034,7 +1034,7 @@ const GroupPage: React.FC = () => {
                         )}
                         {animal.status === 'bite_quarantine' && (
                           <p className="quarantine-approval-inline">
-                            <span className="quarantine-permission-inline-label">Permission:</span>
+                            <span className="quarantine-permission-inline-label" aria-hidden="true">Permission:</span>
                             <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
                           </p>
                         )}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -12,7 +12,9 @@ import SkeletonLoader from '../components/SkeletonLoader';
 import ErrorState from '../components/ErrorState';
 import Modal from '../components/Modal';
 import ScriptsList from '../components/ScriptsList';
-import { calculateAge, formatAge } from '../utils/dateUtils';
+import { calculateAge, formatAge, calculateQuarantineEndDate } from '../utils/dateUtils';
+import { formatAnimalStatus } from '../utils/animalUtils';
+import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { formatDisplayName } from '../utils/formatName';
 import './GroupPage.css';
 
@@ -995,7 +997,7 @@ const GroupPage: React.FC = () => {
                         </div>
                         {animal.breed && <p className="breed">{animal.breed}</p>}
                         <p className="age">{formatAge(cardAgeYears, cardAgeMonths)}</p>
-                        <span className={`status ${animal.status}`}>{animal.status}</span>
+                        <span className={`status ${animal.status}`}>{formatAnimalStatus(animal.status)}</span>
                         {showLengthOfStay && animal.arrival_date && (
                           <p className="length-of-stay">
                             {(() => {
@@ -1026,42 +1028,15 @@ const GroupPage: React.FC = () => {
                           </div>
                         )}
                         {animal.status === 'bite_quarantine' && animal.quarantine_start_date && (
-                          <div className="quarantine-summary-card">
-                            <p className="quarantine-end-date">
-                              Ends: {(() => {
-                                const startDate = new Date(animal.quarantine_start_date);
-                                const endDate = new Date(startDate);
-                                endDate.setDate(endDate.getDate() + 10);
-                                while (endDate.getDay() === 0 || endDate.getDay() === 6) {
-                                  endDate.setDate(endDate.getDate() + 1);
-                                }
-                                return endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-                              })()}
-                            </p>
-                            <p className="quarantine-approval-inline">
-                              <span className="quarantine-permission-inline-label">Permission:</span>
-                              <span
-                                className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
-                                aria-label={
-                                  animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
-                                  animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
-                                  'Bite Quarantine Permission: Not Requested'
-                                }
-                              >
-                                <span aria-hidden="true">{
-                                  animal.quarantine_approval_status === 'granted' ? '✅' :
-                                  animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
-                                }</span>
-                                {' '}{
-                                  animal.quarantine_approval_status === 'granted'
-                                    ? 'Granted'
-                                    : animal.quarantine_approval_status === 'requested'
-                                    ? 'Requested'
-                                    : 'Not Requested'
-                                }
-                              </span>
-                            </p>
-                          </div>
+                          <p className="quarantine-end-date">
+                            Ends: {calculateQuarantineEndDate(animal.quarantine_start_date, 'short')}
+                          </p>
+                        )}
+                        {animal.status === 'bite_quarantine' && (
+                          <p className="quarantine-approval-inline">
+                            <span className="quarantine-permission-inline-label">Permission:</span>
+                            <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
+                          </p>
                         )}
                         {/* Both pills link to /photos — PhotoGallery renders images and videos on the same page */}
                         <div className="media-indicator">

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1026,41 +1026,42 @@ const GroupPage: React.FC = () => {
                           </div>
                         )}
                         {animal.status === 'bite_quarantine' && animal.quarantine_start_date && (
-                          <p className="quarantine-end-date">
-                            Ends: {(() => {
-                              const startDate = new Date(animal.quarantine_start_date);
-                              const endDate = new Date(startDate);
-                              endDate.setDate(endDate.getDate() + 10);
-                              while (endDate.getDay() === 0 || endDate.getDay() === 6) {
-                                endDate.setDate(endDate.getDate() + 1);
-                              }
-                              return endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-                            })()}
-                          </p>
-                        )}
-                        {animal.status === 'bite_quarantine' && (
-                          <p className="quarantine-approval-inline">
-                            <span
-                              className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
-                              aria-label={
-                                animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
-                                animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
-                                'Bite Quarantine Permission: Not Requested'
-                              }
-                            >
-                              <span aria-hidden="true">{
-                                animal.quarantine_approval_status === 'granted' ? '✅' :
-                                animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
-                              }</span>
-                              {' '}{
-                                animal.quarantine_approval_status === 'granted'
-                                  ? 'Permission Granted'
-                                  : animal.quarantine_approval_status === 'requested'
-                                  ? 'Permission Requested'
-                                  : 'Not Requested'
-                              }
-                            </span>
-                          </p>
+                          <div className="quarantine-summary-card">
+                            <p className="quarantine-end-date">
+                              Ends: {(() => {
+                                const startDate = new Date(animal.quarantine_start_date);
+                                const endDate = new Date(startDate);
+                                endDate.setDate(endDate.getDate() + 10);
+                                while (endDate.getDay() === 0 || endDate.getDay() === 6) {
+                                  endDate.setDate(endDate.getDate() + 1);
+                                }
+                                return endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                              })()}
+                            </p>
+                            <p className="quarantine-approval-inline">
+                              <span className="quarantine-permission-inline-label">Permission:</span>
+                              <span
+                                className={`quarantine-approval-badge quarantine-approval-${animal.quarantine_approval_status || 'none'}`}
+                                aria-label={
+                                  animal.quarantine_approval_status === 'granted' ? 'Bite Quarantine Permission: Granted' :
+                                  animal.quarantine_approval_status === 'requested' ? 'Bite Quarantine Permission: Requested' :
+                                  'Bite Quarantine Permission: Not Requested'
+                                }
+                              >
+                                <span aria-hidden="true">{
+                                  animal.quarantine_approval_status === 'granted' ? '✅' :
+                                  animal.quarantine_approval_status === 'requested' ? '🕐' : '⬜'
+                                }</span>
+                                {' '}{
+                                  animal.quarantine_approval_status === 'granted'
+                                    ? 'Granted'
+                                    : animal.quarantine_approval_status === 'requested'
+                                    ? 'Requested'
+                                    : 'Not Requested'
+                                }
+                              </span>
+                            </p>
+                          </div>
                         )}
                         {/* Both pills link to /photos — PhotoGallery renders images and videos on the same page */}
                         <div className="media-indicator">

--- a/frontend/src/utils/animalUtils.test.ts
+++ b/frontend/src/utils/animalUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { formatAnimalStatus } from './animalUtils';
+
+describe('formatAnimalStatus', () => {
+  it('formats bite_quarantine as the special-case label', () => {
+    expect(formatAnimalStatus('bite_quarantine')).toBe('Bite Quarantine');
+  });
+
+  it('title-cases a single-word status', () => {
+    expect(formatAnimalStatus('available')).toBe('Available');
+  });
+
+  it('replaces all underscores and title-cases each word', () => {
+    expect(formatAnimalStatus('long_term_foster')).toBe('Long Term Foster');
+  });
+
+  it('returns an already-uppercase string unchanged', () => {
+    expect(formatAnimalStatus('ARCHIVED')).toBe('ARCHIVED');
+  });
+});

--- a/frontend/src/utils/animalUtils.ts
+++ b/frontend/src/utils/animalUtils.ts
@@ -1,0 +1,4 @@
+export function formatAnimalStatus(status: string): string {
+  if (status === 'bite_quarantine') return 'Bite Quarantine';
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/frontend/src/utils/animalUtils.ts
+++ b/frontend/src/utils/animalUtils.ts
@@ -1,4 +1,3 @@
 export function formatAnimalStatus(status: string): string {
-  if (status === 'bite_quarantine') return 'Bite Quarantine';
   return status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }


### PR DESCRIPTION
## Summary

Refactors the bite quarantine UI so permission is presented as part of the quarantine workflow instead of as a separate peer badge.

## Why

The previous presentation made the permission state look like another independent animal tag or status pill. Conceptually it belongs under Bite Quarantine alongside the end date.

## Changes

### Detail page
- Move permission into the quarantine info panel
- Display as:
  - `Ends: <date>`
  - `Permission: Requested / Granted / Not Requested`

### Group cards
- Replace the separate quarantine-end and permission pills with a compact quarantine summary block
- Permission now reads as part of the Bite Quarantine state instead of a separate concept

### Bulk edit cards
- Keep the same information, but relabel and group it under the quarantine section so it reads as one workflow

### Display cleanup
- Replace remaining raw enum text like `bite_quarantine` with human-readable `Bite Quarantine`
- Add minimal local CSS wrappers for the grouped quarantine layout

## Validation
- `cd frontend && npx tsc --noEmit`

## Files Changed
- `frontend/src/pages/AnimalDetailPage.tsx`
- `frontend/src/pages/AnimalDetailPage.css`
- `frontend/src/pages/GroupPage.tsx`
- `frontend/src/pages/GroupPage.css`
- `frontend/src/pages/BulkEditAnimalsPage.tsx`
- `frontend/src/pages/BulkEditAnimalsPage.css`
- `frontend/src/pages/AnimalForm.tsx`

## User-facing result

The UI now reads more like a single state machine:
- `Bite Quarantine`
- `Ends: ...`
- `Permission: ...`

instead of showing permission as a separate sibling badge.