### PR TITLE
fix: exclude git worktrees from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,11 @@
 *.swp
 *.swo
 
+# Git worktrees and dev tool artifacts (can contain large nested checkouts)
+.worktrees
+.claude/worktrees
+.playwright-mcp
+
 # Frontend development
 node_modules
 frontend/node_modules


### PR DESCRIPTION
## Summary
- `.claude/worktrees` and `.worktrees` contain nested git checkouts (~280MB, including their own `frontend/node_modules`) that weren't excluded from the Docker build context.
- Since these directories change frequently during active development, they were busting the `COPY . .` layer cache on every build, forcing a full npm/go rebuild each time — a likely contributor to the reported 36-minute build times.
- Also excludes `.playwright-mcp` (test screenshots/artifacts).

## Test plan
- [x] Verified build context size drops from ~670MB to ~29MB with the new exclusions
- [ ] Run an actual `docker build` to confirm build time improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)