### PR TITLE
Add 'Under Vet Care' animal status

### DIFF
--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -180,6 +180,11 @@
   color: #742a2a;
 }
 
+.status.under_vet_care {
+  background: #fde68a;
+  color: #92400e;
+}
+
 .status.archived {
   background: #e2e8f0;
   color: #4a5568;

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -181,8 +181,8 @@
 }
 
 .status.under_vet_care {
-  background: #fde68a;
-  color: #92400e;
+  background: #fef08a;
+  color: #854d0e;
 }
 
 .status.archived {

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -706,6 +706,7 @@ const AnimalForm: React.FC = () => {
                 <option value="available">Available</option>
                 <option value="foster">Foster</option>
                 <option value="bite_quarantine">Bite Quarantine</option>
+                <option value="under_vet_care">Under Vet Care</option>
                 <option value="archived">Archived</option>
               </select>
               <p className="form-field__helper">Current status of the animal</p>
@@ -1120,7 +1121,15 @@ const AnimalForm: React.FC = () => {
       >
         <p style={{ marginBottom: '1rem' }}>
           You are changing <strong>{formData.name}</strong> from <strong>Archived</strong> to{' '}
-          <strong>{pendingStatusChange === 'available' ? 'Available' : pendingStatusChange === 'foster' ? 'Foster' : 'Bite Quarantine'}</strong>.
+          <strong>
+            {pendingStatusChange === 'available'
+              ? 'Available'
+              : pendingStatusChange === 'foster'
+              ? 'Foster'
+              : pendingStatusChange === 'under_vet_care'
+              ? 'Under Vet Care'
+              : 'Bite Quarantine'}
+          </strong>.
         </p>
         
         <div className="modal__actions" style={{ marginTop: '1.5rem', display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -1121,15 +1121,7 @@ const AnimalForm: React.FC = () => {
       >
         <p style={{ marginBottom: '1rem' }}>
           You are changing <strong>{formData.name}</strong> from <strong>Archived</strong> to{' '}
-          <strong>
-            {pendingStatusChange === 'available'
-              ? 'Available'
-              : pendingStatusChange === 'foster'
-              ? 'Foster'
-              : pendingStatusChange === 'under_vet_care'
-              ? 'Under Vet Care'
-              : 'Bite Quarantine'}
-          </strong>.
+          <strong>{formatAnimalStatus(pendingStatusChange)}</strong>.
         </p>
         
         <div className="modal__actions" style={{ marginTop: '1.5rem', display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>

--- a/frontend/src/pages/BulkEditAnimalsPage.css
+++ b/frontend/src/pages/BulkEditAnimalsPage.css
@@ -491,8 +491,8 @@
 }
 
 .status-badge.status-under_vet_care {
-  background: #fde68a;
-  color: #92400e;
+  background: #fef08a;
+  color: #854d0e;
 }
 
 .status-badge.status-archived {
@@ -516,8 +516,8 @@
 }
 
 [data-theme='dark'] .status-badge.status-under_vet_care {
-  background: #92400e;
-  color: #fde68a;
+  background: #854d0e;
+  color: #fef08a;
 }
 
 .animal-card-image {

--- a/frontend/src/pages/BulkEditAnimalsPage.css
+++ b/frontend/src/pages/BulkEditAnimalsPage.css
@@ -490,6 +490,11 @@
   color: #991b1b;
 }
 
+.status-badge.status-under_vet_care {
+  background: #fde68a;
+  color: #92400e;
+}
+
 .status-badge.status-archived {
   background: var(--neutral-200);
   color: var(--neutral-700);
@@ -508,6 +513,11 @@
 [data-theme='dark'] .status-badge.status-bite_quarantine {
   background: #991b1b;
   color: #fee2e2;
+}
+
+[data-theme='dark'] .status-badge.status-under_vet_care {
+  background: #92400e;
+  color: #fde68a;
 }
 
 .animal-card-image {

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -69,12 +69,13 @@ const BulkEditAnimalsPage: React.FC = () => {
     const available = animals.filter(a => a.status === 'available').length;
     const foster = animals.filter(a => a.status === 'foster').length;
     const quarantine = animals.filter(a => a.status === 'bite_quarantine').length;
+    const underVetCare = animals.filter(a => a.status === 'under_vet_care').length;
     const archived = animals.filter(a => a.status === 'archived').length;
     const avgStay = total > 0
       ? Math.round(animals.reduce((sum, a) => sum + calculateDaysSince(a.arrival_date), 0) / total)
       : 0;
 
-    return { total, available, foster, quarantine, archived, avgStay };
+    return { total, available, foster, quarantine, underVetCare, archived, avgStay };
   }, [animals]);
 
   const handleSelectAll = () => {
@@ -442,6 +443,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                 <option value="available">Available</option>
                 <option value="foster">Foster</option>
                 <option value="bite_quarantine">Bite Quarantine</option>
+                <option value="under_vet_care">Under Vet Care</option>
                 <option value="archived">Archived</option>
               </select>
             </div>
@@ -575,6 +577,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                     <option value="available">Available</option>
                     <option value="foster">Foster</option>
                     <option value="bite_quarantine">Bite Quarantine</option>
+                    <option value="under_vet_care">Under Vet Care</option>
                     <option value="archived">Archived</option>
                   </select>
                 )}
@@ -689,6 +692,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                           <option value="available">Available</option>
                           <option value="foster">Foster</option>
                           <option value="bite_quarantine">Quarantine</option>
+                          <option value="under_vet_care">Under Vet Care</option>
                           <option value="archived">Archived</option>
                         </select>
                       </div>
@@ -786,6 +790,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                           <option value="available">Available</option>
                           <option value="foster">Foster</option>
                           <option value="bite_quarantine">Bite Quarantine</option>
+                          <option value="under_vet_care">Under Vet Care</option>
                           <option value="archived">Archived</option>
                         </select>
                       </td>

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -344,8 +344,8 @@
 }
 
 .status-under_vet_care {
-  background-color: rgba(217, 119, 6, 0.2);
-  color: #b45309;
+  background-color: rgba(202, 138, 4, 0.2);
+  color: #854d0e;
 }
 
 .status-archived {

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -343,6 +343,11 @@
   color: var(--danger-600);
 }
 
+.status-under_vet_care {
+  background-color: rgba(217, 119, 6, 0.2);
+  color: #b45309;
+}
+
 .status-archived {
   background-color: rgba(156, 163, 175, 0.2);
   color: var(--neutral-500);

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -586,6 +586,12 @@
   border: 1px solid var(--danger);
 }
 
+.status.under_vet_care {
+  background: rgba(217, 119, 6, 0.1);
+  color: #b45309;
+  border: 1px solid #d97706;
+}
+
 .quarantine-block {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -587,9 +587,9 @@
 }
 
 .status.under_vet_care {
-  background: rgba(217, 119, 6, 0.1);
-  color: #b45309;
-  border: 1px solid #d97706;
+  background: rgba(202, 138, 4, 0.1);
+  color: #854d0e;
+  border: 1px solid #ca8a04;
 }
 
 .quarantine-block {

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -930,11 +930,12 @@ const GroupPage: React.FC = () => {
                   onChange={(e) => setStatusFilter(e.target.value)}
                   aria-label="Filter animals by status"
                 >
-                  <option value="">Available & Bite Quarantine (default)</option>
+                  <option value="">Available, Bite Quarantine & Vet Care (default)</option>
                   <option value="all">All Animals</option>
                   <option value="available">Available Only</option>
                   <option value="foster">Foster</option>
                   <option value="bite_quarantine">Bite Quarantine Only</option>
+                  <option value="under_vet_care">Under Vet Care Only</option>
                   <option value="archived">Archived</option>
                 </select>
               </div>

--- a/frontend/src/utils/animalUtils.test.ts
+++ b/frontend/src/utils/animalUtils.test.ts
@@ -14,6 +14,10 @@ describe('formatAnimalStatus', () => {
     expect(formatAnimalStatus('long_term_foster')).toBe('Long Term Foster');
   });
 
+  it('formats under_vet_care as Under Vet Care', () => {
+    expect(formatAnimalStatus('under_vet_care')).toBe('Under Vet Care');
+  });
+
   it('returns an already-uppercase string unchanged', () => {
     expect(formatAnimalStatus('ARCHIVED')).toBe('ARCHIVED');
   });

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -103,6 +103,12 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = now
+			case "under_vet_care":
+				updates["foster_start_date"] = nil
+				updates["quarantine_start_date"] = nil
+				updates["quarantine_approval_status"] = ""
+				updates["quarantine_approval_date"] = nil
+				updates["archived_date"] = nil
 			}
 		} else if animal.Status == "bite_quarantine" {
 			// Update approval status only when explicitly provided (nil = not sent = no change)

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -104,6 +104,7 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = now
 			case "under_vet_care":
+				// No dedicated date field for vet care, so clear the same fields as "available"
 				updates["foster_start_date"] = nil
 				updates["quarantine_start_date"] = nil
 				updates["quarantine_approval_status"] = ""

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
@@ -143,6 +144,50 @@ func TestUpdateAnimalAdmin_StatusTransition(t *testing.T) {
 
 	if updatedAnimal.QuarantineStartDate == nil {
 		t.Error("Expected QuarantineStartDate to be set")
+	}
+}
+
+// TestUpdateAnimalAdmin_UnderVetCareTransition tests transitioning to under_vet_care clears other status fields
+func TestUpdateAnimalAdmin_UnderVetCareTransition(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+	now := time.Now()
+	animal.Status = "archived"
+	animal.ArchivedDate = &now
+	db.Save(animal)
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "under_vet_care",
+	}
+
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var updatedAnimal models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &updatedAnimal); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if updatedAnimal.Status != "under_vet_care" {
+		t.Errorf("Expected status 'under_vet_care', got '%s'", updatedAnimal.Status)
+	}
+
+	if updatedAnimal.ArchivedDate != nil {
+		t.Error("Expected ArchivedDate to be cleared when transitioning to under_vet_care")
 	}
 }
 

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -226,6 +226,8 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 			}
 		case "archived":
 			animal.ArchivedDate = &now
+		case "under_vet_care":
+			// No dedicated date field for vet care; LastStatusChange (set elsewhere) is sufficient.
 		}
 
 		if req.IsReturned != nil {

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -361,6 +361,7 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = &now
 			case "under_vet_care":
+				// No dedicated date field for vet care, so clear the same fields as "available"
 				animal.FosterStartDate = nil
 				animal.QuarantineStartDate = nil
 				animal.QuarantineApprovalStatus = ""

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -48,11 +48,11 @@ func GetAnimals(db *gorm.DB) gin.HandlerFunc {
 		// Build query with filters
 		query := db.WithContext(ctx).Where("group_id = ?", groupID)
 
-		// Status filter (default to "available" and "bite_quarantine" if not specified)
+		// Status filter (default to "available", "bite_quarantine", and "under_vet_care" if not specified)
 		status := c.Query("status")
 		if status == "" {
-			// Default: show available and bite_quarantine animals
-			query = query.Where("status IN ?", []string{"available", "bite_quarantine"})
+			// Default: show available, bite_quarantine, and under_vet_care animals
+			query = query.Where("status IN ?", []string{"available", "bite_quarantine", "under_vet_care"})
 		} else if status != "all" {
 			// Support comma-separated statuses for multiple filters
 			if strings.Contains(status, ",") {
@@ -360,6 +360,12 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = &now
+			case "under_vet_care":
+				animal.FosterStartDate = nil
+				animal.QuarantineStartDate = nil
+				animal.QuarantineApprovalStatus = ""
+				animal.QuarantineApprovalDate = nil
+				animal.ArchivedDate = nil
 			}
 			animal.Status = newStatus
 		} else if animal.Status == "bite_quarantine" {

--- a/internal/handlers/animal_import_export.go
+++ b/internal/handlers/animal_import_export.go
@@ -201,12 +201,13 @@ func ImportAnimalsCSV(db *gorm.DB) gin.HandlerFunc {
 					"available":       true,
 					"foster":          true,
 					"bite_quarantine": true,
+					"under_vet_care":  true,
 					"archived":        true,
 				}
 				if status != "" && validStatuses[status] {
 					animal.Status = status
 				} else if status != "" {
-					errors = append(errors, fmt.Sprintf("Line %d: Invalid status '%s' (must be available, foster, bite_quarantine, or archived)", lineNum, status))
+					errors = append(errors, fmt.Sprintf("Line %d: Invalid status '%s' (must be available, foster, bite_quarantine, under_vet_care, or archived)", lineNum, status))
 					continue
 				} else {
 					animal.Status = "available"

--- a/internal/handlers/animal_import_export_test.go
+++ b/internal/handlers/animal_import_export_test.go
@@ -152,6 +152,44 @@ func TestImportAnimalsCSV_Success(t *testing.T) {
 	}
 }
 
+// TestImportAnimalsCSV_UnderVetCareStatus tests importing an animal with the under_vet_care status
+func TestImportAnimalsCSV_UnderVetCareStatus(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+
+	csvContent := fmt.Sprintf(`group_id,name,species,breed,age,description,status,image_url
+%d,Rex,Dog,Golden Retriever,3,Recovering from surgery,under_vet_care,/uploads/rex.jpg`, group.ID)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "animals.csv")
+	if err != nil {
+		t.Fatalf("Failed to create form file: %v", err)
+	}
+	part.Write([]byte(csvContent))
+	writer.Close()
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	handler := ImportAnimalsCSV(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var animal models.Animal
+	if err := db.Where("group_id = ? AND name = ?", group.ID, "Rex").First(&animal).Error; err != nil {
+		t.Fatalf("Failed to find imported animal: %v", err)
+	}
+
+	if animal.Status != "under_vet_care" {
+		t.Errorf("Expected status 'under_vet_care', got '%s'", animal.Status)
+	}
+}
+
 // TestImportAnimalsCSV_InvalidFile tests importing non-CSV file
 func TestImportAnimalsCSV_InvalidFile(t *testing.T) {
 	db := setupAnimalTestDB(t)

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -69,15 +69,23 @@ func TestGetAnimals_StatusFilter(t *testing.T) {
 	animal3.Status = "bite_quarantine"
 	db.Save(animal3)
 
+	animal4 := createTestAnimal(t, db, group.ID, "Bella", "Cat")
+	animal4.Status = "under_vet_care"
+	db.Save(animal4)
+
+	animal5 := createTestAnimal(t, db, group.ID, "Spot", "Dog")
+	animal5.Status = "archived"
+	db.Save(animal5)
+
 	tests := []struct {
 		name          string
 		statusQuery   string
 		expectedCount int
 	}{
 		{
-			name:          "default filter (available and bite_quarantine)",
+			name:          "default filter (available, bite_quarantine, and under_vet_care)",
 			statusQuery:   "",
-			expectedCount: 2, // available and bite_quarantine
+			expectedCount: 3, // available, bite_quarantine, and under_vet_care
 		},
 		{
 			name:          "filter by available",
@@ -92,12 +100,17 @@ func TestGetAnimals_StatusFilter(t *testing.T) {
 		{
 			name:          "filter by all",
 			statusQuery:   "all",
-			expectedCount: 3,
+			expectedCount: 5,
 		},
 		{
 			name:          "filter by multiple statuses",
 			statusQuery:   "available,foster",
 			expectedCount: 2,
+		},
+		{
+			name:          "filter by under_vet_care",
+			statusQuery:   "under_vet_care",
+			expectedCount: 1,
 		},
 	}
 
@@ -799,6 +812,18 @@ func TestUpdateAnimal_StatusTransition(t *testing.T) {
 			},
 			checkClearedField: func(a *models.Animal) bool {
 				return true // archived doesn't clear other fields by default
+			},
+		},
+		{
+			name:      "transition to under_vet_care",
+			newStatus: "under_vet_care",
+			checkDateField: func(a *models.Animal) bool {
+				return true // under_vet_care has no status-specific date field
+			},
+			checkClearedField: func(a *models.Animal) bool {
+				return a.FosterStartDate == nil && a.QuarantineStartDate == nil &&
+					a.QuarantineApprovalStatus == "" && a.QuarantineApprovalDate == nil &&
+					a.ArchivedDate == nil
 			},
 		},
 		{

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -475,6 +475,13 @@ func TestCreateAnimal_StatusSpecificDates(t *testing.T) {
 				return a.ArchivedDate != nil
 			},
 		},
+		{
+			name:   "under_vet_care status sets no special date field",
+			status: "under_vet_care",
+			checkDateFunc: func(a *models.Animal) bool {
+				return a.Status == "under_vet_care"
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -145,6 +145,67 @@ func TestGetAnimals_StatusFilter(t *testing.T) {
 	}
 }
 
+// TestGetAnimals_DefaultFilterExcludesFosterAndArchived verifies by name (not just count)
+// that the default filter excludes foster and archived animals while including
+// available, bite_quarantine, and under_vet_care animals.
+func TestGetAnimals_DefaultFilterExcludesFosterAndArchived(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	available := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+	available.Status = "available"
+	db.Save(available)
+
+	foster := createTestAnimal(t, db, group.ID, "Fluffy", "Cat")
+	foster.Status = "foster"
+	db.Save(foster)
+
+	quarantine := createTestAnimal(t, db, group.ID, "Max", "Dog")
+	quarantine.Status = "bite_quarantine"
+	db.Save(quarantine)
+
+	vetCare := createTestAnimal(t, db, group.ID, "Bella", "Cat")
+	vetCare.Status = "under_vet_care"
+	db.Save(vetCare)
+
+	archived := createTestAnimal(t, db, group.ID, "Spot", "Dog")
+	archived.Status = "archived"
+	db.Save(archived)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), nil)
+
+	handler := GetAnimals(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var animals []animalListItem
+	if err := json.Unmarshal(w.Body.Bytes(), &animals); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	names := make(map[string]bool, len(animals))
+	for _, a := range animals {
+		names[a.Name] = true
+	}
+
+	for _, expectedIncluded := range []string{"Rex", "Max", "Bella"} {
+		if !names[expectedIncluded] {
+			t.Errorf("Expected %q to be included in the default filter, but it was missing", expectedIncluded)
+		}
+	}
+
+	for _, expectedExcluded := range []string{"Fluffy", "Spot"} {
+		if names[expectedExcluded] {
+			t.Errorf("Expected %q (foster/archived) to be excluded from the default filter, but it was present", expectedExcluded)
+		}
+	}
+}
+
 // TestGetAnimals_NameSearch tests searching animals by name
 func TestGetAnimals_NameSearch(t *testing.T) {
 	db := setupAnimalTestDB(t)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -83,7 +83,7 @@ type Animal struct {
 	Description                    string              `json:"description"`
 	TrainerNotes                   string              `json:"trainer_notes"` // Optional notes for trainer meetings
 	ImageURL                       string              `json:"image_url"`
-	Status                         string              `gorm:"default:'available';index:idx_animal_group_status" json:"status"` // available, foster, bite_quarantine, archived
+	Status                         string              `gorm:"default:'available';index:idx_animal_group_status" json:"status"` // available, foster, bite_quarantine, under_vet_care, archived
 	ArrivalDate                    *time.Time          `json:"arrival_date"`                                                    // When animal first became available
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started


### PR DESCRIPTION
## Summary
- Adds a new animal status, `under_vet_care` (displayed "Under Vet Care"), behaving as a restricted status like `bite_quarantine` (excluded from adoption) but included in the default animal list view.
- No database migration needed — `Status` is a plain string column with no DB-level enum constraint, and `under_vet_care` reuses the existing generic `LastStatusChange` timestamp instead of a dedicated date field.
- Backend: model comment, CSV import whitelist + validation message, status-transition cleanup logic in `CreateAnimal`, `UpdateAnimal`, and the admin PATCH handler, and the default animal-list status filter.
- Frontend: all 6 status dropdowns (AnimalForm, BulkEditAnimalsPage ×4, GroupPage), the AnimalForm archive-confirmation modal text, a `underVetCare` stats counter in BulkEditAnimalsPage, and a distinct gold/yellow badge color across 4 stylesheets (chosen to be visually distinct from both `bite_quarantine`'s red and `foster`'s amber, after a review caught a near-collision with `foster`'s color).

## Test plan
- [x] `go test ./...` passes (only the pre-existing, unrelated `TestCreateGroup/accepts_valid_GroupMe_bot_id` failure, present on `main` before this branch)
- [x] `npm run build` succeeds with no TypeScript errors
- [x] `npm run lint` shows no new errors in changed files
- [x] New/extended Go tests cover: CSV import accepting `under_vet_care`, CreateAnimal setting no special date field, UpdateAnimal and admin-PATCH clearing other status fields on transition into `under_vet_care`, and the default filter including `under_vet_care`
- [ ] Manual browser smoke test (not performed in this session — no browser tool available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)