### PR TITLE
Persist bite-quarantine incident details on the animal record

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -375,8 +375,8 @@ func main() {
 		// These routes check for site admin OR group admin access within the handlers
 		groupAdminAnimals := protected.Group("/groups/:id/animals")
 		{
-			groupAdminAnimals.POST("", handlers.CreateAnimal(db))
-			groupAdminAnimals.PUT("/:animalId", handlers.UpdateAnimal(db))
+			groupAdminAnimals.POST("", handlers.CreateAnimal(db, emailService))
+			groupAdminAnimals.PUT("/:animalId", handlers.UpdateAnimal(db, emailService))
 			groupAdminAnimals.DELETE("/:animalId", handlers.DeleteAnimal(db))
 			// Tag assignment for animals
 			groupAdminAnimals.POST("/:animalId/tags", handlers.AssignTagsToAnimal(db))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -264,7 +264,7 @@ func main() {
 			admin.POST("/animals/import-csv", handlers.ImportAnimalsCSV(db))
 			admin.POST("/animals/export-csv", handlers.ExportAnimalsCSV(db))
 			admin.GET("/animals/export-comments-csv", handlers.ExportAnimalCommentsCSV(db))
-			admin.PUT("/animals/:animalId", handlers.UpdateAnimalAdmin(db))
+			admin.PUT("/animals/:animalId", handlers.UpdateAnimalAdmin(db, emailService))
 
 			// Animal image management (admin only)
 			admin.PUT("/animals/:animalId/images/:imageId/set-profile", handlers.SetAnimalProfilePicture(db))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -205,6 +205,7 @@ export interface Animal {
   foster_start_date?: string;
   quarantine_start_date?: string;
   quarantine_approval_status?: '' | 'requested' | 'granted';
+  quarantine_incident_details?: string;
   quarantine_approval_date?: string;
   archived_date?: string;
   last_status_change?: string;

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -1079,6 +1079,23 @@
   margin: 0.25rem 0;
 }
 
+.quarantine-incident {
+  margin-top: 0.75rem;
+}
+
+.quarantine-incident-label {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.quarantine-incident-text {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
 .quarantine-approval-status {
   margin-top: 0.5rem;
 }

--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import AnimalDetailPage from './AnimalDetailPage';
+import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, authApi } from '../api/client';
+import type { Animal } from '../api/client';
+import type { AxiosResponse } from 'axios';
+import { AuthProvider } from '../contexts/AuthContext';
+import { ToastProvider } from '../contexts/ToastContext';
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  authApi: {
+    getCurrentUser: vi.fn(),
+  },
+  animalsApi: {
+    getById: vi.fn(),
+  },
+  animalCommentsApi: {
+    getAll: vi.fn(),
+    getDeleted: vi.fn(),
+  },
+  commentTagsApi: {
+    getAll: vi.fn(),
+  },
+  groupsApi: {
+    getById: vi.fn(),
+    getMembership: vi.fn(),
+  },
+}));
+
+// Mock useParams to provide a fixed groupId/id, while keeping the rest of react-router-dom real.
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ groupId: '1', id: '1' }),
+  };
+});
+
+const baseAnimal: Animal = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Labrador',
+  age: 3,
+  description: '',
+  image_url: '',
+  status: 'available',
+  is_returned: false,
+};
+
+const mockAnimal = (overrides: Partial<Animal>) => {
+  vi.mocked(animalsApi.getById).mockResolvedValue({
+    data: { ...baseAnimal, ...overrides },
+  } as AxiosResponse<Animal>);
+};
+
+describe('AnimalDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(authApi.getCurrentUser).mockResolvedValue({
+      data: {
+        id: 1,
+        username: 'testuser',
+        email: 'test@example.com',
+        phone_number: '',
+        hide_email: false,
+        hide_phone_number: false,
+        is_admin: false,
+      },
+    } as AxiosResponse);
+
+    vi.mocked(groupsApi.getById).mockResolvedValue({
+      data: {},
+    } as AxiosResponse);
+
+    vi.mocked(groupsApi.getMembership).mockResolvedValue({
+      data: {},
+    } as AxiosResponse);
+
+    vi.mocked(commentTagsApi.getAll).mockResolvedValue({
+      data: [],
+    } as AxiosResponse);
+
+    vi.mocked(animalCommentsApi.getAll).mockResolvedValue({
+      data: { comments: [], total: 0, limit: 10, offset: 0, hasMore: false },
+    } as AxiosResponse);
+
+    vi.mocked(animalCommentsApi.getDeleted).mockResolvedValue({
+      data: [],
+    } as AxiosResponse);
+  });
+
+  const renderDetailPage = () => {
+    return render(
+      <BrowserRouter>
+        <AuthProvider>
+          <ToastProvider>
+            <AnimalDetailPage />
+          </ToastProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+  };
+
+  it('shows the bite quarantine incident details while in quarantine', async () => {
+    mockAnimal({
+      status: 'bite_quarantine',
+      quarantine_start_date: '2026-06-22T00:00:00Z',
+      quarantine_incident_details: 'Bit a volunteer on the hand.',
+    });
+
+    renderDetailPage();
+
+    expect(await screen.findByText('Bit a volunteer on the hand.')).toBeInTheDocument();
+  });
+
+  it('does not show incident details when not in quarantine', async () => {
+    mockAnimal({ status: 'available', quarantine_incident_details: '' });
+
+    renderDetailPage();
+
+    await screen.findByRole('heading', { name: 'Rex' });
+    expect(screen.queryByText(/Incident Details/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,7 +477,7 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
-                  {animal.quarantine_incident_details && (
+                  {animal.status === 'bite_quarantine' && animal.quarantine_incident_details && (
                     <div className="quarantine-incident">
                       <p className="quarantine-incident-label"><strong>Incident Details</strong></p>
                       <p className="quarantine-incident-text">{animal.quarantine_incident_details}</p>

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,6 +477,12 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
+                  {animal.quarantine_incident_details && (
+                    <div className="quarantine-incident">
+                      <p className="quarantine-incident-label"><strong>Incident Details</strong></p>
+                      <p className="quarantine-incident-text">{animal.quarantine_incident_details}</p>
+                    </div>
+                  )}
                 </div>
               )}
               {animal.status === 'bite_quarantine' && (

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import AnimalForm from './AnimalForm';
-import { animalsApi, updatesApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
+import { animalsApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
 import type { AxiosResponse } from 'axios';
 import { ToastProvider } from '../contexts/ToastContext';
 
@@ -16,9 +16,6 @@ vi.mock('../api/client', () => ({
     create: vi.fn(),
     update: vi.fn(),
     getImages: vi.fn(),
-  },
-  updatesApi: {
-    create: vi.fn(),
   },
   animalTagsApi: {
     getAll: vi.fn(),
@@ -144,7 +141,6 @@ describe('AnimalForm', () => {
     const payload = (animalsApi.update as Mock).mock.calls[0][2];
     expect(payload.quarantine_incident_details).toBe('Bit a volunteer.');
     expect(animalCommentsApi.create).toHaveBeenCalled();
-    expect(updatesApi.create).not.toHaveBeenCalled();
   });
 
   it('loads existing incident details and start date for an animal already in quarantine', async () => {
@@ -191,6 +187,5 @@ describe('AnimalForm', () => {
     const payload = (animalsApi.update as Mock).mock.calls[0][2];
     expect(payload.quarantine_incident_details).toBe('Corrected: bit a staff member, not a volunteer.');
     expect(animalCommentsApi.create).not.toHaveBeenCalled();
-    expect(updatesApi.create).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import AnimalForm from './AnimalForm';
+import { animalsApi, updatesApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
+import type { AxiosResponse } from 'axios';
+import { ToastProvider } from '../contexts/ToastContext';
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  animalsApi: {
+    getById: vi.fn(),
+    checkDuplicates: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    getImages: vi.fn(),
+  },
+  updatesApi: {
+    create: vi.fn(),
+  },
+  animalTagsApi: {
+    getAll: vi.fn(),
+    assignToAnimal: vi.fn(),
+  },
+  commentTagsApi: {
+    getAll: vi.fn(),
+  },
+  animalCommentsApi: {
+    create: vi.fn(),
+  },
+}));
+
+// Mock useParams/useNavigate for edit mode
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ groupId: '1', id: '1' }),
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const existingAnimal = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Mixed',
+  age: 3,
+  description: '',
+  image_url: '',
+  status: 'available',
+  is_returned: false,
+};
+
+describe('AnimalForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: existingAnimal,
+    } as AxiosResponse);
+
+    vi.mocked(animalsApi.checkDuplicates).mockResolvedValue({
+      data: { name: 'Rex', count: 0, animals: [], has_duplicates: false },
+    } as AxiosResponse);
+
+    vi.mocked(animalsApi.getImages).mockResolvedValue({
+      data: [],
+    } as AxiosResponse);
+
+    vi.mocked(animalTagsApi.getAll).mockResolvedValue({
+      data: [],
+    } as AxiosResponse);
+
+    vi.mocked(commentTagsApi.getAll).mockResolvedValue({
+      data: [],
+    } as AxiosResponse);
+
+    vi.mocked(animalsApi.update).mockResolvedValue({
+      data: { ...existingAnimal, id: 1 },
+    } as AxiosResponse);
+
+    vi.mocked(animalCommentsApi.create).mockResolvedValue({} as AxiosResponse);
+  });
+
+  const renderAnimalForm = () => {
+    return render(
+      <BrowserRouter>
+        <ToastProvider>
+          <AnimalForm />
+        </ToastProvider>
+      </BrowserRouter>
+    );
+  };
+
+  it('on quarantine submit: sends incident details, keeps the comment, drops the announcement', async () => {
+    const user = userEvent.setup();
+    renderAnimalForm();
+
+    // Wait for the form to populate from loadAnimal
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    // Change status to bite_quarantine
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    // Submit the main form -> opens the quarantine info modal
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    // Fill in the incident details textarea in the modal
+    const incidentTextarea = await screen.findByLabelText(/incident details/i);
+    await user.type(incidentTextarea, 'Bit a volunteer.');
+
+    // Submit the modal
+    const modalSubmitButton = screen.getByRole('button', { name: /save & notify/i });
+    await user.click(modalSubmitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_incident_details).toBe('Bit a volunteer.');
+    expect(animalCommentsApi.create).toHaveBeenCalled();
+    expect(updatesApi.create).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -56,6 +56,22 @@ const existingAnimal = {
   is_returned: false,
 };
 
+const existingQuarantinedAnimal = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Mixed',
+  age: 3,
+  description: '',
+  image_url: '',
+  status: 'bite_quarantine',
+  quarantine_start_date: '2026-06-01T00:00:00Z',
+  quarantine_approval_status: 'requested',
+  quarantine_incident_details: 'Bit a volunteer on the hand.',
+  is_returned: false,
+};
+
 describe('AnimalForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -128,6 +144,53 @@ describe('AnimalForm', () => {
     const payload = (animalsApi.update as Mock).mock.calls[0][2];
     expect(payload.quarantine_incident_details).toBe('Bit a volunteer.');
     expect(animalCommentsApi.create).toHaveBeenCalled();
+    expect(updatesApi.create).not.toHaveBeenCalled();
+  });
+
+  it('loads existing incident details and start date for an animal already in quarantine', async () => {
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: existingQuarantinedAnimal,
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const incidentTextarea = document.getElementById('quarantine_incident_details') as HTMLTextAreaElement;
+    const dateInput = document.getElementById('quarantine_start_date') as HTMLInputElement;
+
+    expect(incidentTextarea.value).toBe('Bit a volunteer on the hand.');
+    expect(dateInput.value).toBe('2026-06-01');
+  });
+
+  it('saves edited incident details/date for an already-quarantined animal via the normal save flow', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: existingQuarantinedAnimal,
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const incidentTextarea = document.getElementById('quarantine_incident_details') as HTMLTextAreaElement;
+    await user.clear(incidentTextarea);
+    await user.type(incidentTextarea, 'Corrected: bit a staff member, not a volunteer.');
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_incident_details).toBe('Corrected: bit a staff member, not a volunteer.');
+    expect(animalCommentsApi.create).not.toHaveBeenCalled();
     expect(updatesApi.create).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -45,6 +45,7 @@ const AnimalForm: React.FC = () => {
     status: 'available',
     arrival_date: '',
     quarantine_start_date: '',
+    quarantine_incident_details: '',
     quarantine_approval_status: 'requested',
     is_returned: false,
     protocol_document_url: '',
@@ -114,6 +115,7 @@ const AnimalForm: React.FC = () => {
         trainer_notes: animal.trainer_notes || '',
         arrival_date: animal.arrival_date ? animal.arrival_date.split('T')[0] : '',
         quarantine_start_date: animal.quarantine_start_date ? animal.quarantine_start_date.split('T')[0] : '',
+        quarantine_incident_details: animal.quarantine_incident_details || '',
         quarantine_approval_status: animal.quarantine_approval_status || 'requested',
         protocol_document_url: animal.protocol_document_url || '',
         protocol_document_name: animal.protocol_document_name || '',
@@ -430,6 +432,9 @@ const AnimalForm: React.FC = () => {
         quarantine_approval_status: formData.status === 'bite_quarantine'
           ? formData.quarantine_approval_status
           : undefined,
+        quarantine_incident_details: formData.status === 'bite_quarantine'
+          ? formData.quarantine_incident_details
+          : undefined,
       };
       
       if (id && groupId) {
@@ -721,6 +726,28 @@ const AnimalForm: React.FC = () => {
                 Track whether permission has been requested or granted to resume working with this animal.
               </p>
             </div>
+          )}
+
+          {formData.status === 'bite_quarantine' && originalStatus === 'bite_quarantine' && (
+            <>
+              <FormField
+                label="Quarantine Start Date"
+                id="quarantine_start_date"
+                type="date"
+                value={formData.quarantine_start_date}
+                onChange={(value) => setFormData({ ...formData, quarantine_start_date: value })}
+                helperText={`Quarantine will end: ${calculateQuarantineEndDate(formData.quarantine_start_date, 'long')}`}
+              />
+              <FormField
+                label="Incident Details"
+                id="quarantine_incident_details"
+                type="textarea"
+                value={formData.quarantine_incident_details}
+                onChange={(value) => setFormData({ ...formData, quarantine_incident_details: value })}
+                helperText="Shown on the animal's page for as long as it's in bite quarantine. Correcting this does not re-notify the group."
+                rows={4}
+              />
+            </>
           )}
 
           <div className="form-row">

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -509,8 +509,11 @@ const AnimalForm: React.FC = () => {
         animalId = response.data.id;
       }
 
+      const normalisedQuarantineDate = /^\d{4}-\d{2}-\d{2}$/.test(quarantineDate)
+        ? quarantineDate + 'T00:00:00'
+        : quarantineDate;
       const endDate = calculateQuarantineEndDate(quarantineDate, 'long');
-      
+
       // Create a comment on the animal with behavior tag
       if (animalId && groupId) {
         try {
@@ -518,10 +521,10 @@ const AnimalForm: React.FC = () => {
           const commentTagsResponse = await commentTagsApi.getAll(parseInt(groupId));
           const commentTags = commentTagsResponse.data;
           const behaviorTag = commentTags.find(tag => tag.name.toLowerCase() === 'behavior');
-          
+
           // Create comment with bite quarantine details
           const commentContent = `🚨 BITE QUARANTINE\n\n` +
-            `Quarantine Start: ${new Date(quarantineDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}\n` +
+            `Quarantine Start: ${new Date(normalisedQuarantineDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}\n` +
             `Quarantine End: ${endDate}\n\n` +
             `Incident Details:\n${quarantineContext}`;
           

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { animalsApi, updatesApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
+import { animalsApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
 import type { AnimalTag, Animal, DuplicateNameInfo, AnimalImage } from '../api/client';
 import { useToast } from '../hooks/useToast';
 import { calculateQuarantineEndDate, calculateAge, computeEstimatedBirthDate } from '../utils/dateUtils';
@@ -483,6 +483,7 @@ const AnimalForm: React.FC = () => {
     const updatedFormData = {
       ...formData,
       quarantine_start_date: quarantineDate,
+      quarantine_incident_details: quarantineContext,
     };
 
     setLoading(true);
@@ -541,19 +542,7 @@ const AnimalForm: React.FC = () => {
         console.warn('Missing animalId or groupId, skipping comment creation:', { animalId, groupId });
       }
 
-      // Create group update (post) with behavior tag context for activity feed
-      const updateTitle = `🚨 Bite Quarantine: ${formData.name}`;
-      const updateContent = `${formData.name} has been placed in bite quarantine.\n\n` +
-        `Quarantine Start: ${new Date(quarantineDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}\n` +
-        `Quarantine End: ${endDate}\n\n` +
-        `Details:\n${quarantineContext}\n\n` +
-        `#behavior`;
-
-      // Create group update (shows in activity feed) with email and GroupMe notification
-      // Parameters: (groupId, title, content, send_email, send_groupme, image_url?)
-      await updatesApi.create(parseInt(groupId), updateTitle, updateContent, true, true);
-
-      toast.showSuccess('Animal updated, comment added, and announcement posted successfully!');
+      toast.showSuccess('Animal placed in bite quarantine. Comment added and email notification sent.');
       setShowQuarantineModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
@@ -1045,7 +1034,7 @@ const AnimalForm: React.FC = () => {
         size="medium"
       >
         <p style={{ marginBottom: '1rem' }}>
-          Please provide details about the bite incident. This information will be posted as an announcement with the #behavior tag.
+          Please provide details about the bite incident. This information will be shown on the animal's page while in quarantine, saved as a behavior comment, and emailed to the group.
         </p>
         
         <div style={{ marginBottom: '1rem' }}>
@@ -1107,7 +1096,7 @@ const AnimalForm: React.FC = () => {
             loading={loading}
             disabled={loading || !quarantineContext.trim()}
           >
-            Save & Post Announcement
+            Save & Notify
           </Button>
         </div>
       </Modal>

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -484,9 +484,15 @@ const AnimalForm: React.FC = () => {
       return;
     }
 
+    // Compute birth date the same way saveAnimal does
+    const finalBirthDate = formData.estimated_birth_date ||
+      (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
+
     // Update formData with the quarantine date
     const updatedFormData = {
       ...formData,
+      estimated_birth_date: finalBirthDate || undefined,
+      age: birthYears,
       quarantine_start_date: quarantineDate,
       quarantine_incident_details: quarantineContext,
     };
@@ -497,15 +503,9 @@ const AnimalForm: React.FC = () => {
       let animalId: number | null = null;
       if (id && groupId) {
         const response = await animalsApi.update(parseInt(groupId), parseInt(id), updatedFormData);
-        console.log('Update response:', response);
-        console.log('Response data:', response.data);
-        console.log('Animal ID from response:', response.data.id);
         animalId = response.data.id;
       } else if (groupId) {
         const response = await animalsApi.create(parseInt(groupId), updatedFormData);
-        console.log('Create response:', response);
-        console.log('Response data:', response.data);
-        console.log('Animal ID from response:', response.data.id);
         animalId = response.data.id;
       }
 
@@ -525,10 +525,6 @@ const AnimalForm: React.FC = () => {
             `Quarantine End: ${endDate}\n\n` +
             `Incident Details:\n${quarantineContext}`;
           
-          console.log('Creating comment for animal ID:', animalId, 'in group:', groupId);
-          console.log('Comment tags:', commentTags);
-          console.log('Behavior tag:', behaviorTag);
-          
           await animalCommentsApi.create(
             parseInt(groupId),
             animalId,
@@ -536,15 +532,13 @@ const AnimalForm: React.FC = () => {
             undefined, // no image
             behaviorTag ? [behaviorTag.id] : [] // attach behavior tag if found
           );
-          
-          console.log('Comment created successfully');
         } catch (commentError) {
           console.error('Failed to create comment:', commentError);
-          // Don't fail the whole operation if comment creation fails
           toast.showWarning('Animal updated but comment creation failed');
+          setShowQuarantineModal(false);
+          navigate(`/groups/${groupId}`);
+          return;
         }
-      } else {
-        console.warn('Missing animalId or groupId, skipping comment creation:', { animalId, groupId });
       }
 
       toast.showSuccess('Animal placed in bite quarantine. Comment added.');

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -542,7 +542,7 @@ const AnimalForm: React.FC = () => {
         console.warn('Missing animalId or groupId, skipping comment creation:', { animalId, groupId });
       }
 
-      toast.showSuccess('Animal placed in bite quarantine. Comment added and email notification sent.');
+      toast.showSuccess('Animal placed in bite quarantine. Comment added.');
       setShowQuarantineModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -36,7 +36,10 @@ export function formatRelativeTime(dateString: string, cutoffDays = 30): string 
 export function calculateQuarantineEndDate(startDateString?: string, format: 'short' | 'long' = 'short'): string {
   if (!startDateString) return '-';
 
-  const startDate = new Date(startDateString);
+  const normalised = /^\d{4}-\d{2}-\d{2}$/.test(startDateString)
+    ? startDateString + 'T00:00:00'
+    : startDateString;
+  const startDate = new Date(normalised);
   if (isNaN(startDate.getTime())) return '-';
   const endDate = new Date(startDate);
   endDate.setDate(endDate.getDate() + 10);

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -16,7 +16,6 @@ import (
 // UpdateAnimalAdmin updates an existing animal by ID (admin only, no group check needed)
 func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ctx := c.Request.Context()
 		logger := middleware.GetLogger(c)
 		animalID := c.Param("animalId")
 
@@ -163,7 +162,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		}
 
 		if enteredQuarantine {
-			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
+			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -7,14 +7,16 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
 )
 
 // UpdateAnimalAdmin updates an existing animal by ID (admin only, no group check needed)
-func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
+func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		logger := middleware.GetLogger(c)
 		animalID := c.Param("animalId")
 
@@ -63,6 +65,7 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			updates["image_url"] = req.ImageURL
 		}
 		now := time.Now()
+		enteredQuarantine := false
 		if req.Status != "" && req.Status != animal.Status {
 			// Track status change
 			updates["status"] = req.Status
@@ -85,6 +88,7 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["archived_date"] = nil
 				updates["quarantine_incident_details"] = ""
 			case "bite_quarantine":
+				enteredQuarantine = true
 				// Use provided quarantine start date if available, otherwise use current time
 				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 					updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
@@ -156,6 +160,10 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 		if err := db.Preload("Tags").First(&animal, animalID).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reload animal"})
 			return
+		}
+
+		if enteredQuarantine {
+			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -76,12 +76,14 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
+				updates["quarantine_incident_details"] = ""
 			case "foster":
 				updates["foster_start_date"] = now
 				updates["quarantine_start_date"] = nil
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
+				updates["quarantine_incident_details"] = ""
 			case "bite_quarantine":
 				// Use provided quarantine start date if available, otherwise use current time
 				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
@@ -96,6 +98,9 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 					updates["quarantine_approval_status"] = *req.QuarantineApprovalStatus
 					updates["quarantine_approval_date"] = now
 				}
+				if req.QuarantineIncidentDetails != nil {
+					updates["quarantine_incident_details"] = *req.QuarantineIncidentDetails
+				}
 				updates["foster_start_date"] = nil
 				updates["archived_date"] = nil
 			case "archived":
@@ -103,6 +108,7 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = now
+				updates["quarantine_incident_details"] = ""
 			case "under_vet_care":
 				// No dedicated date field for vet care, so clear the same fields as "available"
 				updates["foster_start_date"] = nil
@@ -110,6 +116,7 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
+				updates["quarantine_incident_details"] = ""
 			}
 		} else if animal.Status == "bite_quarantine" {
 			// Update approval status only when explicitly provided (nil = not sent = no change)
@@ -125,6 +132,9 @@ func UpdateAnimalAdmin(db *gorm.DB) gin.HandlerFunc {
 			// Update quarantine start date independently — both fields can change in one request
 			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
+			}
+			if req.QuarantineIncidentDetails != nil {
+				updates["quarantine_incident_details"] = *req.QuarantineIncidentDetails
 			}
 		}
 		if req.GroupID != 0 {

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -147,6 +147,88 @@ func TestUpdateAnimalAdmin_StatusTransition(t *testing.T) {
 	}
 }
 
+// TestUpdateAnimalAdmin_EnterQuarantine_StoresIncidentDetails verifies that
+// entering bite_quarantine via the admin handler stores the incident details.
+func TestUpdateAnimalAdmin_EnterQuarantine_StoresIncidentDetails(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	details := "Bit a volunteer."
+	updateReq := AnimalRequest{
+		Name:                      "Rex",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "Bit a volunteer." {
+		t.Errorf("incident not stored: %q", got.QuarantineIncidentDetails)
+	}
+}
+
+// TestUpdateAnimalAdmin_LeaveQuarantine_ClearsIncidentDetails verifies that
+// leaving bite_quarantine via the admin handler clears the stored incident details.
+func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsIncidentDetails(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Seed an animal already in BQ with details
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Bit a volunteer.",
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+	}
+
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "" {
+		t.Errorf("incident not cleared on leaving BQ: %q", got.QuarantineIncidentDetails)
+	}
+}
+
 // TestUpdateAnimalAdmin_UnderVetCareTransition tests transitioning to under_vet_care clears other status fields
 func TestUpdateAnimalAdmin_UnderVetCareTransition(t *testing.T) {
 	db := setupAnimalTestDB(t)

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -37,7 +37,7 @@ func TestUpdateAnimalAdmin_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -86,7 +86,7 @@ func TestUpdateAnimalAdmin_PartialUpdate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -126,7 +126,7 @@ func TestUpdateAnimalAdmin_StatusTransition(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -169,7 +169,7 @@ func TestUpdateAnimalAdmin_EnterQuarantine_StoresIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -213,7 +213,7 @@ func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -252,7 +252,7 @@ func TestUpdateAnimalAdmin_UnderVetCareTransition(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -299,7 +299,7 @@ func TestUpdateAnimalAdmin_MoveGroup(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -332,7 +332,7 @@ func TestUpdateAnimalAdmin_NotFound(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/api/v1/admin/animals/99999", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusNotFound {
@@ -360,7 +360,7 @@ func TestUpdateAnimalAdmin_NoUpdates(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	// The handler will accept this as an update (even though the value is the same)
@@ -387,7 +387,7 @@ func TestUpdateAnimalAdmin_ValidationError(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db)
+	handler := UpdateAnimalAdmin(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -584,7 +584,7 @@ func TestUpdateAnimalAdmin_ApprovalStatusSet(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimalAdmin(db)(c)
+	UpdateAnimalAdmin(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -620,7 +620,7 @@ func TestUpdateAnimalAdmin_ApprovalClearedOnTransitionToAvailable(t *testing.T) 
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimalAdmin(db)(c)
+	UpdateAnimalAdmin(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -190,7 +190,7 @@ func GetAnimal(db *gorm.DB) gin.HandlerFunc {
 }
 
 // CreateAnimal creates a new animal in a group
-func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
+func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		groupID := c.Param("id")
@@ -268,6 +268,9 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 				animal.QuarantineApprovalDate = &now
 			}
+			if req.QuarantineIncidentDetails != nil {
+				animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails
+			}
 		case "archived":
 			animal.ArchivedDate = &now
 		case "under_vet_care":
@@ -281,6 +284,10 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 		if err := db.WithContext(ctx).Create(&animal).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create animal"})
 			return
+		}
+
+		if animal.Status == "bite_quarantine" {
+			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal
@@ -306,7 +313,7 @@ func CreateAnimal(db *gorm.DB) gin.HandlerFunc {
 }
 
 // UpdateAnimal updates an existing animal
-func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
+func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		groupID := c.Param("id")
@@ -361,8 +368,10 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 		oldStatus := animal.Status
 		newStatus := req.Status
 		now := time.Now()
+		enteredQuarantine := false
 		if newStatus != "" && newStatus != oldStatus {
 			animal.LastStatusChange = &now
+			enteredQuarantine = newStatus == "bite_quarantine" && oldStatus != "bite_quarantine"
 
 			// Update status-specific dates
 			switch newStatus {
@@ -377,12 +386,14 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
+				animal.QuarantineIncidentDetails = ""
 			case "foster":
 				animal.FosterStartDate = &now
 				animal.QuarantineStartDate = nil
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
+				animal.QuarantineIncidentDetails = ""
 			case "bite_quarantine":
 				// Use provided quarantine start date if available, otherwise use current time
 				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
@@ -397,6 +408,9 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 					animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
 					animal.QuarantineApprovalDate = &now
 				}
+				if req.QuarantineIncidentDetails != nil {
+					animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails
+				}
 				animal.FosterStartDate = nil
 				animal.ArchivedDate = nil
 			case "archived":
@@ -404,6 +418,7 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = &now
+				animal.QuarantineIncidentDetails = ""
 			case "under_vet_care":
 				// No dedicated date field for vet care, so clear the same fields as "available"
 				animal.FosterStartDate = nil
@@ -411,6 +426,7 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
+				animal.QuarantineIncidentDetails = ""
 			}
 			animal.Status = newStatus
 		} else if animal.Status == "bite_quarantine" {
@@ -427,6 +443,9 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 			// Update quarantine start date independently — both fields can change in one request
 			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
+			}
+			if req.QuarantineIncidentDetails != nil {
+				animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails
 			}
 		}
 
@@ -461,6 +480,10 @@ func UpdateAnimal(db *gorm.DB) gin.HandlerFunc {
 		if err := db.WithContext(ctx).Save(&animal).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update animal"})
 			return
+		}
+
+		if enteredQuarantine {
+			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -8,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
@@ -29,6 +33,46 @@ type animalWithCounts struct {
 	models.Animal
 	ImageCount int `json:"image_count"`
 	VideoCount int `json:"video_count"`
+}
+
+// buildQuarantineEmail returns the subject and body for a bite-quarantine
+// notification email for the given animal.
+func buildQuarantineEmail(animal *models.Animal) (string, string) {
+	const dateLayout = "January 2, 2006"
+	start := ""
+	if animal.QuarantineStartDate != nil {
+		start = animal.QuarantineStartDate.Format(dateLayout)
+	}
+	end := ""
+	if e := animal.QuarantineEndDate(); e != nil {
+		end = e.Format(dateLayout)
+	}
+	title := fmt.Sprintf("🚨 Bite Quarantine: %s", animal.Name)
+	body := fmt.Sprintf(
+		"%s has been placed in bite quarantine.\n\nQuarantine Start: %s\nQuarantine End: %s\n\nIncident Details:\n%s",
+		animal.Name, start, end, animal.QuarantineIncidentDetails,
+	)
+	return title, body
+}
+
+// sendQuarantineNotificationEmail asynchronously emails group members about a
+// new bite-quarantine incident. It is a no-op when the email service is
+// unavailable or there are no incident details to report.
+func sendQuarantineNotificationEmail(ctx context.Context, db *gorm.DB, emailService *email.Service, animal *models.Animal) {
+	if emailService == nil || !emailService.IsConfigured() {
+		return
+	}
+	if strings.TrimSpace(animal.QuarantineIncidentDetails) == "" {
+		return
+	}
+	title, content := buildQuarantineEmail(animal)
+	groupID := animal.GroupID
+	go func() {
+		bgCtx := context.Background()
+		if err := sendGroupAnnouncementEmails(bgCtx, db, emailService, groupID, title, content); err != nil {
+			logging.WithContext(bgCtx).Error("Error sending bite quarantine notification emails", err)
+		}
+	}()
 }
 
 // GetAnimals returns all animals in a group with optional filtering

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -58,7 +58,7 @@ func buildQuarantineEmail(animal *models.Animal) (string, string) {
 // sendQuarantineNotificationEmail asynchronously emails group members about a
 // new bite-quarantine incident. It is a no-op when the email service is
 // unavailable or there are no incident details to report.
-func sendQuarantineNotificationEmail(ctx context.Context, db *gorm.DB, emailService *email.Service, animal *models.Animal) {
+func sendQuarantineNotificationEmail(db *gorm.DB, emailService *email.Service, animal *models.Animal) {
 	if emailService == nil || !emailService.IsConfigured() {
 		return
 	}
@@ -287,7 +287,7 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if animal.Status == "bite_quarantine" {
-			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
+			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal
@@ -483,7 +483,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if enteredQuarantine {
-			sendQuarantineNotificationEmail(ctx, db, emailService, &animal)
+			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -1,11 +1,17 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
@@ -34,4 +40,124 @@ func TestBuildQuarantineEmailBody(t *testing.T) {
 func TestSendQuarantineNotificationEmail_NilServiceNoPanic(t *testing.T) {
 	// nil email service must be a safe no-op
 	sendQuarantineNotificationEmail(context.Background(), nil, nil, &models.Animal{Name: "Rex"})
+}
+
+// TestUpdateAnimal_EnterQuarantine_StoresIncidentAndKeepsItOnEdit verifies that
+// entering bite_quarantine stores the incident details, and that a subsequent
+// edit while still in bite_quarantine (without resending incident details)
+// does not clear the previously stored details.
+func TestUpdateAnimal_EnterQuarantine_StoresIncidentAndKeepsItOnEdit(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Transition into bite quarantine with incident details
+	details := "Bit a volunteer."
+	updateReq := AnimalRequest{
+		Name:                      "Rex",
+		Species:                   "Dog",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "Bit a volunteer." {
+		t.Errorf("incident not stored: %q", got.QuarantineIncidentDetails)
+	}
+
+	// Editing another field while already in BQ (no incident details in payload)
+	// must NOT clear the previously stored details.
+	updateReq2 := AnimalRequest{
+		Name:    "Rex Updated",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+	}
+	jsonData2, _ := json.Marshal(updateReq2)
+
+	c2, w2 := setupAnimalTestContext(user.ID, false)
+	c2.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c2.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData2))
+	c2.Request.Header.Set("Content-Type", "application/json")
+
+	handler2 := UpdateAnimal(db, nil)
+	handler2(c2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w2.Code, w2.Body.String())
+	}
+
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "Bit a volunteer." {
+		t.Errorf("incident wrongly cleared on edit: %q", got.QuarantineIncidentDetails)
+	}
+}
+
+// TestUpdateAnimal_LeaveQuarantine_ClearsIncident verifies that leaving
+// bite_quarantine clears the stored incident details.
+func TestUpdateAnimal_LeaveQuarantine_ClearsIncident(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Seed an animal already in BQ with details
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Bit a volunteer.",
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "available",
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "" {
+		t.Errorf("incident not cleared on leaving BQ: %q", got.QuarantineIncidentDetails)
+	}
 }

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -161,3 +161,46 @@ func TestUpdateAnimal_LeaveQuarantine_ClearsIncident(t *testing.T) {
 		t.Errorf("incident not cleared on leaving BQ: %q", got.QuarantineIncidentDetails)
 	}
 }
+
+// TestCreateAnimal_BiteQuarantine_StoresIncidentDetails verifies that creating
+// an animal directly with status "bite_quarantine" stores the provided
+// incident details.
+func TestCreateAnimal_BiteQuarantine_StoresIncidentDetails(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	details := "Bit a volunteer."
+	animalReq := AnimalRequest{
+		Name:                      "Rex",
+		Species:                   "Dog",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+
+	jsonData, _ := json.Marshal(animalReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	var created models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	var got models.Animal
+	if err := db.First(&got, created.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineIncidentDetails != "Bit a volunteer." {
+		t.Errorf("incident not stored on create: %q", got.QuarantineIncidentDetails)
+	}
+}

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+)
+
+func TestBuildQuarantineEmailBody(t *testing.T) {
+	start := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	a := &models.Animal{
+		Name:                      "Rex",
+		QuarantineStartDate:       &start,
+		QuarantineIncidentDetails: "Bit a volunteer on the hand during leashing.",
+	}
+	title, body := buildQuarantineEmail(a)
+	if title != "🚨 Bite Quarantine: Rex" {
+		t.Errorf("unexpected title: %q", title)
+	}
+	if !strings.Contains(body, "Rex has been placed in bite quarantine") {
+		t.Errorf("body missing intro: %q", body)
+	}
+	if !strings.Contains(body, "June 22, 2026") {
+		t.Errorf("body missing formatted start date: %q", body)
+	}
+	if !strings.Contains(body, "Bit a volunteer on the hand during leashing.") {
+		t.Errorf("body missing incident details: %q", body)
+	}
+}
+
+func TestSendQuarantineNotificationEmail_NilServiceNoPanic(t *testing.T) {
+	// nil email service must be a safe no-op
+	sendQuarantineNotificationEmail(context.Background(), nil, nil, &models.Animal{Name: "Rex"})
+}

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,7 +38,7 @@ func TestBuildQuarantineEmailBody(t *testing.T) {
 
 func TestSendQuarantineNotificationEmail_NilServiceNoPanic(t *testing.T) {
 	// nil email service must be a safe no-op
-	sendQuarantineNotificationEmail(context.Background(), nil, nil, &models.Animal{Name: "Rex"})
+	sendQuarantineNotificationEmail(nil, nil, &models.Animal{Name: "Rex"})
 }
 
 // TestUpdateAnimal_EnterQuarantine_StoresIncidentAndKeepsItOnEdit verifies that

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -69,21 +69,21 @@ func (nt NullableTime) MarshalJSON() ([]byte, error) {
 
 // AnimalRequest represents the request structure for creating/updating animals
 type AnimalRequest struct {
-	Name                     string       `json:"name" binding:"required"`
-	Species                  string       `json:"species"`
-	Breed                    string       `json:"breed"`
-	Age                      int          `json:"age"`
-	EstimatedBirthDate       NullableTime `json:"estimated_birth_date,omitempty"` // Estimated date of birth for real-time age
-	Description              string       `json:"description"`
-	TrainerNotes             string       `json:"trainer_notes"`
-	ImageURL                 string       `json:"image_url,omitempty"`
-	Status                   string       `json:"status"`
-	GroupID                  uint         `json:"group_id,omitempty"`
-	ArrivalDate              NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
-	QuarantineStartDate      NullableTime `json:"quarantine_start_date,omitempty"`
-	QuarantineApprovalStatus *string      `json:"quarantine_approval_status,omitempty"` // nil = not provided; "" | "requested" | "granted" when set
-	QuarantineIncidentDetails *string     `json:"quarantine_incident_details,omitempty"` // nil = not provided; set when entering bite quarantine
-	IsReturned               *bool        `json:"is_returned,omitempty"`                // Pointer to distinguish null from false
+	Name                      string       `json:"name" binding:"required"`
+	Species                   string       `json:"species"`
+	Breed                     string       `json:"breed"`
+	Age                       int          `json:"age"`
+	EstimatedBirthDate        NullableTime `json:"estimated_birth_date,omitempty"` // Estimated date of birth for real-time age
+	Description               string       `json:"description"`
+	TrainerNotes              string       `json:"trainer_notes"`
+	ImageURL                  string       `json:"image_url,omitempty"`
+	Status                    string       `json:"status"`
+	GroupID                   uint         `json:"group_id,omitempty"`
+	ArrivalDate               NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
+	QuarantineStartDate       NullableTime `json:"quarantine_start_date,omitempty"`
+	QuarantineApprovalStatus  *string      `json:"quarantine_approval_status,omitempty"`  // nil = not provided; "" | "requested" | "granted" when set
+	QuarantineIncidentDetails *string      `json:"quarantine_incident_details,omitempty"` // nil = not provided; set when entering bite quarantine
+	IsReturned                *bool        `json:"is_returned,omitempty"`                 // Pointer to distinguish null from false
 }
 
 // DuplicateNameInfo represents information about animals with duplicate names

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -82,6 +82,7 @@ type AnimalRequest struct {
 	ArrivalDate              NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
 	QuarantineStartDate      NullableTime `json:"quarantine_start_date,omitempty"`
 	QuarantineApprovalStatus *string      `json:"quarantine_approval_status,omitempty"` // nil = not provided; "" | "requested" | "granted" when set
+	QuarantineIncidentDetails *string     `json:"quarantine_incident_details,omitempty"` // nil = not provided; set when entering bite quarantine
 	IsReturned               *bool        `json:"is_returned,omitempty"`                // Pointer to distinguish null from false
 }
 

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -420,7 +420,7 @@ func TestCreateAnimal_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db)
+	handler := CreateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -473,7 +473,7 @@ func TestCreateAnimal_ValidationError(t *testing.T) {
 			c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := CreateAnimal(db)
+			handler := CreateAnimal(db, nil)
 			handler(c)
 
 			if w.Code != http.StatusBadRequest {
@@ -501,7 +501,7 @@ func TestCreateAnimal_DefaultStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db)
+	handler := CreateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -573,7 +573,7 @@ func TestCreateAnimal_StatusSpecificDates(t *testing.T) {
 			c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := CreateAnimal(db)
+			handler := CreateAnimal(db, nil)
 			handler(c)
 
 			if w.Code != http.StatusCreated {
@@ -611,7 +611,7 @@ func TestCreateAnimal_AccessDenied(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group1.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db)
+	handler := CreateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusForbidden {
@@ -636,7 +636,7 @@ func TestCreateAnimal_InvalidGroupID(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/groups/invalid/animals", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db)
+	handler := CreateAnimal(db, nil)
 	handler(c)
 
 	// Invalid group ID causes checkGroupAccess to fail (returns 403) or parsing fails (returns 400)
@@ -774,7 +774,7 @@ func TestUpdateAnimal_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -820,7 +820,7 @@ func TestUpdateAnimal_NotFound(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/99999", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusNotFound {
@@ -917,7 +917,7 @@ func TestUpdateAnimal_StatusTransition(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db)
+			handler := UpdateAnimal(db, nil)
 			handler(c)
 
 			if w.Code != http.StatusOK {
@@ -984,7 +984,7 @@ func TestUpdateAnimal_NoStatusChange(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1034,7 +1034,7 @@ func TestUpdateAnimal_ValidationError(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -1066,7 +1066,7 @@ func TestUpdateAnimal_AccessDenied(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group1.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusForbidden {
@@ -1109,7 +1109,7 @@ func TestUpdateAnimal_CustomQuarantineDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1470,7 +1470,7 @@ func TestUpdateAnimal_EmptyQuarantineDateString(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBufferString(tt.jsonBody))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db)
+			handler := UpdateAnimal(db, nil)
 			handler(c)
 
 			if w.Code != tt.wantStatus {
@@ -1518,7 +1518,7 @@ func TestUpdateAnimal_NameHistory(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db)
+	handler := UpdateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1608,7 +1608,7 @@ func TestUpdateAnimal_IsReturned(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(body))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db)
+			handler := UpdateAnimal(db, nil)
 			handler(c)
 
 			if w.Code != http.StatusOK {
@@ -1723,7 +1723,7 @@ func TestCreateAnimal_IsReturned(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db)
+	handler := CreateAnimal(db, nil)
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -1796,7 +1796,7 @@ func TestCreateAnimal_WithApprovalStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	CreateAnimal(db)(c)
+	CreateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
@@ -1832,7 +1832,7 @@ func TestUpdateAnimal_InvalidApprovalStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected 400, got %d: %s", w.Code, w.Body.String())
@@ -1872,7 +1872,7 @@ func TestUpdateAnimal_ApprovalStatusSet(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -1922,7 +1922,7 @@ func TestUpdateAnimal_ApprovalStatusCleared(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -1973,7 +1973,7 @@ func TestUpdateAnimal_ApprovalNotClearedWhenOmitted(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2018,7 +2018,7 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToAvailable(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2066,7 +2066,7 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToFoster(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db)(c)
+	UpdateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2101,7 +2101,7 @@ func TestCreateAnimal_DefaultApprovalStatusWhenOmitted(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	CreateAnimal(db)(c)
+	CreateAnimal(db, nil)(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -89,6 +89,7 @@ type Animal struct {
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
 	QuarantineApprovalStatus       string              `gorm:"default:'requested'" json:"quarantine_approval_status"`           // Bite quarantine permission: "requested" (default), "granted", or "" (legacy — displayed as Not Requested)
 	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval status last changed (nil when not requested)
+	QuarantineIncidentDetails      string              `json:"quarantine_incident_details"`                                     // Bite incident context; set on entering BQ, cleared on leaving. Shown atop the detail page.
 	ArchivedDate                   *time.Time          `json:"archived_date"`                                                   // When animal was archived
 	LastStatusChange               *time.Time          `json:"last_status_change"`                                              // Timestamp of last status change
 	IsReturned                     bool                `gorm:"default:false" json:"is_returned"`                                // Manually set by admins to indicate this animal was previously adopted and returned

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -357,4 +359,15 @@ func TestAnimal_MethodsWithRealData(t *testing.T) {
 			t.Error("Quarantine end date should not be on a weekend")
 		}
 	})
+}
+
+func TestAnimal_QuarantineIncidentDetails_JSONTag(t *testing.T) {
+	a := Animal{QuarantineIncidentDetails: "bit a volunteer on the hand"}
+	b, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(b), `"quarantine_incident_details":"bit a volunteer on the hand"`) {
+		t.Errorf("expected quarantine_incident_details in JSON, got %s", string(b))
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `QuarantineIncidentDetails` to the Animal model, shown at the top of the animal's detail page for as long as the animal is in bite quarantine (cleared when it leaves BQ).
- Drops the redundant one-time announcement post for BQ events; keeps the existing behavior-tagged comment as the historical record.
- Moves the BQ notification email server-side (email only, no GroupMe), sent exactly once on the transition into bite quarantine.
- Closes a gap in `UpdateAnimalAdmin` so the admin update path stays consistent with the main animal-update path for this new field.

## Test plan
- [x] Backend: `go test ./internal/...` — all passing except one pre-existing, unrelated failure (`TestCreateGroup/accepts_valid_GroupMe_bot_id`), confirmed failing on `main` before this branch
- [x] Frontend: `npm test` — 304/304 passing
- [x] Frontend: `npm run build` — clean
- [x] Manual review: every task individually reviewed (spec + quality), plus a final whole-branch review (Ready to merge: Yes) and a follow-up fix pass for its two minor findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)