### PR TITLE
Make bite-quarantine end date editable

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -204,6 +204,7 @@ export interface Animal {
   arrival_date?: string;
   foster_start_date?: string;
   quarantine_start_date?: string;
+  quarantine_end_date?: string;
   quarantine_approval_status?: '' | 'requested' | 'granted';
   quarantine_incident_details?: string;
   quarantine_approval_date?: string;

--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -126,4 +126,27 @@ describe('AnimalDetailPage', () => {
     await screen.findByRole('heading', { name: 'Rex' });
     expect(screen.queryByText(/Incident Details/i)).not.toBeInTheDocument();
   });
+
+  it('shows the stored quarantine end date rather than a recomputed one', async () => {
+    mockAnimal({
+      status: 'bite_quarantine',
+      quarantine_start_date: '2026-06-22T00:00:00Z',
+      quarantine_end_date: '2026-07-15T12:00:00Z', // manually overridden by staff (noon UTC avoids timezone-shift to previous day)
+    });
+
+    renderDetailPage();
+
+    expect(await screen.findByText(/End: July 15, 2026/)).toBeInTheDocument();
+  });
+
+  it('falls back to a computed end date when no stored end date is present yet', async () => {
+    mockAnimal({
+      status: 'bite_quarantine',
+      quarantine_start_date: '2024-06-03T12:00:00Z', // Monday
+    });
+
+    renderDetailPage();
+
+    expect(await screen.findByText(/End: June 13, 2024/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -475,7 +475,9 @@ const AnimalDetailPage: React.FC = () => {
                     Start: {new Date(animal.quarantine_start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
                   </p>
                   <p className="quarantine-dates">
-                    End: {calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
+                    End: {animal.quarantine_end_date
+                      ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+                      : calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
                   </p>
                   {animal.status === 'bite_quarantine' && animal.quarantine_incident_details && (
                     <div className="quarantine-incident">

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -4,7 +4,7 @@ import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, scriptsApi } 
 import type { Animal, AnimalComment, CommentTag, CommentHistory, Group, GroupMembership, SessionMetadata, Script } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
-import { calculateQuarantineEndDate, calculateAge, formatAge } from '../utils/dateUtils';
+import { formatCalendarDate, formatQuarantineEndDate, calculateAge, formatAge } from '../utils/dateUtils';
 import { formatDisplayName } from '../utils/formatName';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
@@ -472,12 +472,10 @@ const AnimalDetailPage: React.FC = () => {
                     <strong>⚠️ Bite Quarantine</strong>
                   </p>
                   <p className="quarantine-dates">
-                    Start: {new Date(animal.quarantine_start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                    Start: {formatCalendarDate(animal.quarantine_start_date, 'long')}
                   </p>
                   <p className="quarantine-dates">
-                    End: {animal.quarantine_end_date
-                      ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
-                      : calculateQuarantineEndDate(animal.quarantine_start_date, 'long')}
+                    End: {formatQuarantineEndDate(animal, 'long')}
                   </p>
                   {animal.status === 'bite_quarantine' && animal.quarantine_incident_details && (
                     <div className="quarantine-incident">

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -188,4 +188,86 @@ describe('AnimalForm', () => {
     expect(payload.quarantine_incident_details).toBe('Corrected: bit a staff member, not a volunteer.');
     expect(animalCommentsApi.create).not.toHaveBeenCalled();
   });
+
+  it('loads the stored quarantine end date for an animal already in quarantine', async () => {
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
+    expect(endDateInput.value).toBe('2026-06-15');
+  });
+
+  it('recomputes the end date field when the start date changes', async () => {
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const startDateInput = document.getElementById('quarantine_start_date') as HTMLInputElement;
+    fireEvent.change(startDateInput, { target: { value: '2024-06-03' } }); // Monday
+
+    const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
+    expect(endDateInput.value).toBe('2024-06-13'); // 10 days later (Thursday)
+  });
+
+  it('keeps a manually edited end date on submit instead of recomputing it', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-11T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
+    fireEvent.change(endDateInput, { target: { value: '2026-06-20' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_end_date).toBe('2026-06-20');
+  });
+
+  it('blocks submit with a validation error when the end date is before the start date', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-11T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
+    fireEvent.change(endDateInput, { target: { value: '2026-05-01' } }); // before start date 2026-06-01
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    expect(animalsApi.update).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -266,6 +266,8 @@ describe('AnimalForm', () => {
     fireEvent.change(endDateInput, { target: { value: '2026-05-01' } }); // before start date 2026-06-01
 
     const submitButton = screen.getByRole('button', { name: /update animal/i });
+    expect(submitButton).toBeDisabled();
+
     await user.click(submitButton);
 
     expect(animalsApi.update).not.toHaveBeenCalled();

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { animalsApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
 import type { AnimalTag, Animal, DuplicateNameInfo, AnimalImage } from '../api/client';
 import { useToast } from '../hooks/useToast';
-import { calculateQuarantineEndDate, calculateAge, computeEstimatedBirthDate } from '../utils/dateUtils';
+import { calculateQuarantineEndDate, calculateQuarantineEndDateISO, calculateAge, computeEstimatedBirthDate } from '../utils/dateUtils';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import FormField from '../components/FormField';
 import AgePicker from '../components/AgePicker';
@@ -45,6 +45,7 @@ const AnimalForm: React.FC = () => {
     status: 'available',
     arrival_date: '',
     quarantine_start_date: '',
+    quarantine_end_date: '',
     quarantine_incident_details: '',
     quarantine_approval_status: 'requested',
     is_returned: false,
@@ -115,6 +116,9 @@ const AnimalForm: React.FC = () => {
         trainer_notes: animal.trainer_notes || '',
         arrival_date: animal.arrival_date ? animal.arrival_date.split('T')[0] : '',
         quarantine_start_date: animal.quarantine_start_date ? animal.quarantine_start_date.split('T')[0] : '',
+        quarantine_end_date: animal.quarantine_end_date
+          ? animal.quarantine_end_date.split('T')[0]
+          : calculateQuarantineEndDateISO(animal.quarantine_start_date),
         quarantine_incident_details: animal.quarantine_incident_details || '',
         quarantine_approval_status: animal.quarantine_approval_status || 'requested',
         protocol_document_url: animal.protocol_document_url || '',
@@ -201,10 +205,17 @@ const AnimalForm: React.FC = () => {
   };
 
   const isFormValid = () => {
-    return formData.name.trim().length >= 2 && 
-           !errors.name && 
+    return formData.name.trim().length >= 2 &&
+           !errors.name &&
            !errors.age;
   };
+
+  const quarantineEndDateError = (
+    formData.status === 'bite_quarantine' &&
+    !!formData.quarantine_start_date &&
+    !!formData.quarantine_end_date &&
+    formData.quarantine_end_date < formData.quarantine_start_date
+  ) ? 'End date cannot be before start date' : '';
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -399,6 +410,11 @@ const AnimalForm: React.FC = () => {
       return;
     }
 
+    if (quarantineEndDateError) {
+      toast.showError(quarantineEndDateError);
+      return;
+    }
+
     // Check if status changed to bite_quarantine
     if (formData.status === 'bite_quarantine' && originalStatus !== 'bite_quarantine') {
       // Show modal to get context and date
@@ -434,6 +450,9 @@ const AnimalForm: React.FC = () => {
           : undefined,
         quarantine_incident_details: formData.status === 'bite_quarantine'
           ? formData.quarantine_incident_details
+          : undefined,
+        quarantine_end_date: formData.status === 'bite_quarantine'
+          ? (formData.quarantine_end_date || undefined)
           : undefined,
       };
       
@@ -732,8 +751,20 @@ const AnimalForm: React.FC = () => {
                 id="quarantine_start_date"
                 type="date"
                 value={formData.quarantine_start_date}
-                onChange={(value) => setFormData({ ...formData, quarantine_start_date: value })}
-                helperText={`Quarantine will end: ${calculateQuarantineEndDate(formData.quarantine_start_date, 'long')}`}
+                onChange={(value) => setFormData({
+                  ...formData,
+                  quarantine_start_date: value,
+                  quarantine_end_date: calculateQuarantineEndDateISO(value),
+                })}
+              />
+              <FormField
+                label="Quarantine End Date"
+                id="quarantine_end_date"
+                type="date"
+                value={formData.quarantine_end_date}
+                onChange={(value) => setFormData({ ...formData, quarantine_end_date: value })}
+                error={quarantineEndDateError}
+                helperText="Defaults to 10 days after the start date (skipping weekends). Adjust if a vet or authority specifies a different date."
               />
               <FormField
                 label="Incident Details"

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -207,7 +207,8 @@ const AnimalForm: React.FC = () => {
   const isFormValid = () => {
     return formData.name.trim().length >= 2 &&
            !errors.name &&
-           !errors.age;
+           !errors.age &&
+           !quarantineEndDateError;
   };
 
   const quarantineEndDateError = (

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -211,12 +211,18 @@ const AnimalForm: React.FC = () => {
            !quarantineEndDateError;
   };
 
-  const quarantineEndDateError = (
-    formData.status === 'bite_quarantine' &&
-    !!formData.quarantine_start_date &&
-    !!formData.quarantine_end_date &&
-    formData.quarantine_end_date < formData.quarantine_start_date
-  ) ? 'End date cannot be before start date' : '';
+  const quarantineEndDateError = (() => {
+    if (formData.status !== 'bite_quarantine' || !formData.quarantine_end_date) {
+      return '';
+    }
+    if (!formData.quarantine_start_date) {
+      return 'Quarantine end date requires a start date';
+    }
+    if (formData.quarantine_end_date < formData.quarantine_start_date) {
+      return 'End date cannot be before start date';
+    }
+    return '';
+  })();
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/frontend/src/pages/BulkEditAnimalsPage.test.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.test.tsx
@@ -69,8 +69,8 @@ describe('BulkEditAnimalsPage', () => {
   it('shows the stored quarantine end date, not a recomputed one, in card view', async () => {
     renderPage();
 
-    // Computed default from a 2026-06-22 Monday start would be 2026-07-06 (10 days,
-    // no weekend roll needed) — very different from the stored override below, so this
+    // The computed default (10 days after the 2026-06-22 start, rolled forward past any
+    // weekend) lands in early July — different from the stored override below, so this
     // assertion would fail if the code still computed the fallback instead of reading
     // the stored field.
     expect(await screen.findByText('Jul 15, 2026')).toBeInTheDocument();

--- a/frontend/src/pages/BulkEditAnimalsPage.test.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import BulkEditAnimalsPage from './BulkEditAnimalsPage';
+import { animalsApi, groupsApi } from '../api/client';
+import type { Animal, Group } from '../api/client';
+import type { AxiosResponse } from 'axios';
+import { ToastProvider } from '../contexts/ToastContext';
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  animalsApi: {
+    getAllForAdmin: vi.fn(),
+  },
+  groupsApi: {
+    getAll: vi.fn(),
+  },
+}));
+
+const quarantinedAnimal: Animal = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Mixed',
+  age: 3,
+  description: '',
+  image_url: '',
+  status: 'bite_quarantine',
+  quarantine_start_date: '2026-06-22T00:00:00Z',
+  quarantine_end_date: '2026-07-15T12:00:00Z', // manually overridden by staff (noon UTC avoids timezone-shift to previous day)
+  is_returned: false,
+};
+
+const mockGroup: Group = {
+  id: 1,
+  name: 'Test Group',
+  description: '',
+  image_url: '',
+  hero_image_url: '',
+  has_protocols: false,
+  groupme_enabled: false,
+};
+
+describe('BulkEditAnimalsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(animalsApi.getAllForAdmin).mockResolvedValue({
+      data: [quarantinedAnimal],
+    } as AxiosResponse<Animal[]>);
+
+    vi.mocked(groupsApi.getAll).mockResolvedValue({
+      data: [mockGroup],
+    } as AxiosResponse<Group[]>);
+  });
+
+  const renderPage = () => {
+    return render(
+      <BrowserRouter>
+        <ToastProvider>
+          <BulkEditAnimalsPage />
+        </ToastProvider>
+      </BrowserRouter>
+    );
+  };
+
+  it('shows the stored quarantine end date, not a recomputed one, in card view', async () => {
+    renderPage();
+
+    // Computed default from a 2026-06-22 Monday start would be 2026-07-06 (10 days,
+    // no weekend roll needed) — very different from the stored override below, so this
+    // assertion would fail if the code still computed the fallback instead of reading
+    // the stored field.
+    expect(await screen.findByText('Jul 15, 2026')).toBeInTheDocument();
+    expect(screen.queryByText('Jul 6, 2026')).not.toBeInTheDocument();
+  });
+
+  it('shows the stored quarantine end date, not a recomputed one, in table view', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Rex');
+
+    await user.click(screen.getByRole('button', { name: 'Table view' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Jul 15, 2026')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Jul 6, 2026')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -711,7 +711,9 @@ const BulkEditAnimalsPage: React.FC = () => {
                         <div className="info-item full-width">
                           <div className="info-label">Quarantine End</div>
                           <div className="info-value quarantine-date">
-                            {calculateQuarantineEndDate(animal.quarantine_start_date)}
+                            {animal.quarantine_end_date
+                              ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+                              : calculateQuarantineEndDate(animal.quarantine_start_date)}
                           </div>
                         </div>
                       )}
@@ -813,7 +815,9 @@ const BulkEditAnimalsPage: React.FC = () => {
                       <td>{calculateDaysSince(animal.last_status_change)}</td>
                       <td>
                         {animal.status === 'bite_quarantine'
-                          ? calculateQuarantineEndDate(animal.quarantine_start_date)
+                          ? (animal.quarantine_end_date
+                              ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+                              : calculateQuarantineEndDate(animal.quarantine_start_date))
                           : '-'
                         }
                       </td>

--- a/frontend/src/pages/BulkEditAnimalsPage.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { animalsApi, groupsApi } from '../api/client';
 import type { Animal, Group } from '../api/client';
 import { useToast } from '../hooks/useToast';
-import { formatDateShort, calculateQuarantineEndDate, calculateDaysSince, calculateAge, formatAge } from '../utils/dateUtils';
+import { formatDateShort, formatQuarantineEndDate, calculateDaysSince, calculateAge, formatAge } from '../utils/dateUtils';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { useDebounce } from '../hooks/useDebounce';
@@ -711,9 +711,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                         <div className="info-item full-width">
                           <div className="info-label">Quarantine End</div>
                           <div className="info-value quarantine-date">
-                            {animal.quarantine_end_date
-                              ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-                              : calculateQuarantineEndDate(animal.quarantine_start_date)}
+                            {formatQuarantineEndDate(animal)}
                           </div>
                         </div>
                       )}
@@ -814,12 +812,7 @@ const BulkEditAnimalsPage: React.FC = () => {
                       <td>{calculateDaysSince(animal.arrival_date)}</td>
                       <td>{calculateDaysSince(animal.last_status_change)}</td>
                       <td>
-                        {animal.status === 'bite_quarantine'
-                          ? (animal.quarantine_end_date
-                              ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-                              : calculateQuarantineEndDate(animal.quarantine_start_date))
-                          : '-'
-                        }
+                        {animal.status === 'bite_quarantine' ? formatQuarantineEndDate(animal) : '-'}
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import GroupPage from './GroupPage';
+import { groupsApi, animalsApi, authApi } from '../api/client';
+import type { Animal, Group, GroupMembership } from '../api/client';
+import type { AxiosResponse } from 'axios';
+import { AuthProvider } from '../contexts/AuthContext';
+import { ToastProvider } from '../contexts/ToastContext';
+
+// Mock the API client. GroupPage's 'animals' view only needs group/membership/animal
+// data plus the site-wide group switcher list and the length-of-stay preference; the
+// activity/members/documents view APIs are intentionally left unmocked since this test
+// never navigates to those tabs.
+vi.mock('../api/client', () => ({
+  authApi: {
+    getCurrentUser: vi.fn(),
+    getEmailPreferences: vi.fn(),
+  },
+  groupsApi: {
+    getById: vi.fn(),
+    getMembership: vi.fn(),
+    getAll: vi.fn(),
+  },
+  animalsApi: {
+    getAll: vi.fn(),
+  },
+}));
+
+// Mock useParams/useSearchParams so the page loads group id=1 directly into the
+// 'animals' view (its default view is 'activity', which pulls in a much larger set
+// of APIs this test doesn't care about).
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ id: '1' }),
+    useSearchParams: () => [new URLSearchParams('view=animals'), vi.fn()],
+  };
+});
+
+const mockGroup: Group = {
+  id: 1,
+  name: 'Test Group',
+  description: 'A test group',
+  image_url: '',
+  hero_image_url: '',
+  has_protocols: false,
+  groupme_enabled: false,
+};
+
+const mockMembership: GroupMembership = {
+  user_id: 1,
+  group_id: 1,
+  is_member: true,
+  is_group_admin: false,
+  is_site_admin: false,
+};
+
+const quarantinedAnimal: Animal = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Mixed',
+  age: 3,
+  description: '',
+  image_url: '',
+  status: 'bite_quarantine',
+  quarantine_start_date: '2026-06-22T00:00:00Z',
+  quarantine_end_date: '2026-07-15T12:00:00Z', // manually overridden by staff (noon UTC avoids timezone-shift to previous day)
+  is_returned: false,
+};
+
+describe('GroupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(authApi.getCurrentUser).mockResolvedValue({
+      data: {
+        id: 1,
+        username: 'testuser',
+        email: 'test@example.com',
+        phone_number: '',
+        hide_email: false,
+        hide_phone_number: false,
+        is_admin: false,
+      },
+    } as AxiosResponse);
+
+    vi.mocked(authApi.getEmailPreferences).mockResolvedValue({
+      data: { show_length_of_stay: false },
+    } as AxiosResponse);
+
+    vi.mocked(groupsApi.getById).mockResolvedValue({
+      data: mockGroup,
+    } as AxiosResponse<Group>);
+
+    vi.mocked(groupsApi.getMembership).mockResolvedValue({
+      data: mockMembership,
+    } as AxiosResponse<GroupMembership>);
+
+    vi.mocked(groupsApi.getAll).mockResolvedValue({
+      data: [mockGroup],
+    } as AxiosResponse<Group[]>);
+
+    vi.mocked(animalsApi.getAll).mockResolvedValue({
+      data: [quarantinedAnimal],
+    } as AxiosResponse<Animal[]>);
+  });
+
+  const renderGroupPage = () => {
+    return render(
+      <BrowserRouter>
+        <AuthProvider>
+          <ToastProvider>
+            <GroupPage />
+          </ToastProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+  };
+
+  it('shows the stored quarantine end date, not a recomputed one, on the animals tab', async () => {
+    renderGroupPage();
+
+    // Computed default from a 2026-06-22 Monday start would be Jul 6, 2026 (10 days,
+    // no weekend roll needed) — very different from the stored override below, so this
+    // assertion would fail if the code still computed the fallback instead of reading
+    // the stored field.
+    expect(await screen.findByText(/Ends: Jul 15, 2026/)).toBeInTheDocument();
+    expect(screen.queryByText(/Ends: Jul 6, 2026/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -124,8 +124,8 @@ describe('GroupPage', () => {
   it('shows the stored quarantine end date, not a recomputed one, on the animals tab', async () => {
     renderGroupPage();
 
-    // Computed default from a 2026-06-22 Monday start would be Jul 6, 2026 (10 days,
-    // no weekend roll needed) — very different from the stored override below, so this
+    // The computed default (10 days after the 2026-06-22 start, rolled forward past any
+    // weekend) lands in early July — different from the stored override below, so this
     // assertion would fail if the code still computed the fallback instead of reading
     // the stored field.
     expect(await screen.findByText(/Ends: Jul 15, 2026/)).toBeInTheDocument();

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -12,7 +12,7 @@ import SkeletonLoader from '../components/SkeletonLoader';
 import ErrorState from '../components/ErrorState';
 import Modal from '../components/Modal';
 import ScriptsList from '../components/ScriptsList';
-import { calculateAge, formatAge, calculateQuarantineEndDate } from '../utils/dateUtils';
+import { calculateAge, formatAge, formatQuarantineEndDate } from '../utils/dateUtils';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { formatDisplayName } from '../utils/formatName';
@@ -1050,9 +1050,7 @@ const GroupPage: React.FC = () => {
                             <div className="quarantine-meta">
                               {animal.quarantine_start_date && (
                                 <span className="quarantine-end-text">
-                                  Ends: {animal.quarantine_end_date
-                                    ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-                                    : calculateQuarantineEndDate(animal.quarantine_start_date, 'short')}
+                                  Ends: {formatQuarantineEndDate(animal, 'short')}
                                 </span>
                               )}
                               <QuarantineApprovalBadge status={animal.quarantine_approval_status} />

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1050,7 +1050,9 @@ const GroupPage: React.FC = () => {
                             <div className="quarantine-meta">
                               {animal.quarantine_start_date && (
                                 <span className="quarantine-end-text">
-                                  Ends: {calculateQuarantineEndDate(animal.quarantine_start_date, 'short')}
+                                  Ends: {animal.quarantine_end_date
+                                    ? new Date(animal.quarantine_end_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+                                    : calculateQuarantineEndDate(animal.quarantine_start_date, 'short')}
                                 </span>
                               )}
                               <QuarantineApprovalBadge status={animal.quarantine_approval_status} />

--- a/frontend/src/utils/dateUtils.test.ts
+++ b/frontend/src/utils/dateUtils.test.ts
@@ -9,6 +9,8 @@ import {
   calculateAge,
   formatAge,
   computeEstimatedBirthDate,
+  formatCalendarDate,
+  formatQuarantineEndDate,
 } from './dateUtils';
 
 describe('dateUtils', () => {
@@ -147,6 +149,52 @@ describe('dateUtils', () => {
 
     it('skips Sunday and returns Monday', () => {
       expect(calculateQuarantineEndDateISO('2024-05-16')).toBe('2024-05-27');
+    });
+  });
+
+  describe('formatCalendarDate', () => {
+    it('returns "-" for undefined', () => {
+      expect(formatCalendarDate(undefined)).toBe('-');
+    });
+
+    it('returns "-" for invalid date string', () => {
+      expect(formatCalendarDate('not-a-date')).toBe('-');
+    });
+
+    it('formats a bare YYYY-MM-DD string', () => {
+      expect(formatCalendarDate('2026-07-15', 'long')).toBe('July 15, 2026');
+    });
+
+    it('formats a UTC-midnight ISO timestamp without shifting to the previous day', () => {
+      // Regression guard: new Date('2026-07-15T00:00:00Z').toLocaleDateString()
+      // renders 'July 14' in any timezone behind UTC. formatCalendarDate must
+      // treat the date portion as the calendar date regardless of timezone.
+      expect(formatCalendarDate('2026-07-15T00:00:00Z', 'long')).toBe('July 15, 2026');
+    });
+
+    it('formats in short form by default', () => {
+      expect(formatCalendarDate('2026-07-15T00:00:00Z')).toMatch(/Jul\s+15,\s+2026/);
+    });
+  });
+
+  describe('formatQuarantineEndDate', () => {
+    it('shows the stored end date when present, not a recomputed one', () => {
+      const result = formatQuarantineEndDate({
+        quarantine_start_date: '2026-06-22T00:00:00Z',
+        quarantine_end_date: '2026-07-15T00:00:00Z',
+      }, 'long');
+      expect(result).toBe('July 15, 2026');
+    });
+
+    it('falls back to the computed default when no end date is stored', () => {
+      const result = formatQuarantineEndDate({
+        quarantine_start_date: '2024-06-03T12:00:00Z', // Monday
+      }, 'long');
+      expect(result).toBe('June 13, 2024');
+    });
+
+    it('returns "-" when neither date is present', () => {
+      expect(formatQuarantineEndDate({})).toBe('-');
     });
   });
 

--- a/frontend/src/utils/dateUtils.test.ts
+++ b/frontend/src/utils/dateUtils.test.ts
@@ -4,6 +4,7 @@ import {
   formatDateLong,
   formatRelativeTime,
   calculateQuarantineEndDate,
+  calculateQuarantineEndDateISO,
   calculateDaysSince,
   calculateAge,
   formatAge,
@@ -124,6 +125,28 @@ describe('dateUtils', () => {
     it('returns long format when requested', () => {
       const result = calculateQuarantineEndDate('2024-06-03T12:00:00Z', 'long');
       expect(result).toMatch(/June\s+13,\s+2024/);
+    });
+  });
+
+  describe('calculateQuarantineEndDateISO', () => {
+    it('returns "" for undefined', () => {
+      expect(calculateQuarantineEndDateISO(undefined)).toBe('');
+    });
+
+    it('returns "" for invalid date string', () => {
+      expect(calculateQuarantineEndDateISO('bad-date')).toBe('');
+    });
+
+    it('adds 10 days to a start date that lands on a weekday', () => {
+      expect(calculateQuarantineEndDateISO('2024-06-03')).toBe('2024-06-13');
+    });
+
+    it('skips Saturday and returns Monday', () => {
+      expect(calculateQuarantineEndDateISO('2024-05-15')).toBe('2024-05-27');
+    });
+
+    it('skips Sunday and returns Monday', () => {
+      expect(calculateQuarantineEndDateISO('2024-05-16')).toBe('2024-05-27');
     });
   });
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -31,16 +31,25 @@ export function formatRelativeTime(dateString: string, cutoffDays = 30): string 
   return formatDateShort(dateString);
 }
 
+// Parses a calendar-date string as local midnight for that date, ignoring any
+// time-of-day/timezone component. Accepts a bare YYYY-MM-DD string or a full
+// ISO timestamp (e.g. the UTC-midnight timestamps the backend stores quarantine
+// dates as) — either way, only the date portion is meaningful, so a UTC-midnight
+// timestamp isn't shifted to the previous calendar day for users in timezones
+// west of UTC.
+function parseDateOnly(dateString?: string): Date | null {
+  if (!dateString) return null;
+  const dateOnlyMatch = dateString.match(/^(\d{4}-\d{2}-\d{2})/);
+  const normalised = dateOnlyMatch ? `${dateOnlyMatch[1]}T00:00:00` : dateString;
+  const date = new Date(normalised);
+  return isNaN(date.getTime()) ? null : date;
+}
+
 // Shared computation for calculateQuarantineEndDate / calculateQuarantineEndDateISO:
 // 10 days after the start date, shifted forward if it falls on a weekend.
 function addQuarantineDays(startDateString?: string): Date | null {
-  if (!startDateString) return null;
-
-  const normalised = /^\d{4}-\d{2}-\d{2}$/.test(startDateString)
-    ? startDateString + 'T00:00:00'
-    : startDateString;
-  const startDate = new Date(normalised);
-  if (isNaN(startDate.getTime())) return null;
+  const startDate = parseDateOnly(startDateString);
+  if (!startDate) return null;
   const endDate = new Date(startDate);
   endDate.setDate(endDate.getDate() + 10);
 
@@ -72,6 +81,32 @@ export function calculateQuarantineEndDateISO(startDateString?: string): string 
   const m = String(endDate.getMonth() + 1).padStart(2, '0');
   const d = String(endDate.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
+}
+
+// Formats a calendar-date string (see parseDateOnly) for display. Use for dates
+// that represent a day rather than a precise instant — e.g. quarantine
+// start/end dates — so they never appear shifted to the previous day.
+export function formatCalendarDate(dateString?: string, format: 'short' | 'long' = 'short'): string {
+  const date = parseDateOnly(dateString);
+  if (!date) return '-';
+  return date.toLocaleDateString('en-US', format === 'long'
+    ? { year: 'numeric', month: 'long', day: 'numeric' }
+    : { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Returns the quarantine end date to display for an animal: the stored
+// quarantine_end_date (a staff override, or a previously-computed default) when
+// present, else the default computed from quarantine_start_date. Every page
+// that shows the quarantine end date should use this so a staff override is
+// shown consistently everywhere, not just on the pages that read the field.
+export function formatQuarantineEndDate(
+  animal: { quarantine_start_date?: string; quarantine_end_date?: string },
+  format: 'short' | 'long' = 'short'
+): string {
+  if (animal.quarantine_end_date) {
+    return formatCalendarDate(animal.quarantine_end_date, format);
+  }
+  return calculateQuarantineEndDate(animal.quarantine_start_date, format);
 }
 
 export function calculateDaysSince(dateString?: string): number {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -31,16 +31,16 @@ export function formatRelativeTime(dateString: string, cutoffDays = 30): string 
   return formatDateShort(dateString);
 }
 
-// Calculates the quarantine end date: 10 days after the start date,
-// shifted forward if it falls on a weekend.
-export function calculateQuarantineEndDate(startDateString?: string, format: 'short' | 'long' = 'short'): string {
-  if (!startDateString) return '-';
+// Shared computation for calculateQuarantineEndDate / calculateQuarantineEndDateISO:
+// 10 days after the start date, shifted forward if it falls on a weekend.
+function addQuarantineDays(startDateString?: string): Date | null {
+  if (!startDateString) return null;
 
   const normalised = /^\d{4}-\d{2}-\d{2}$/.test(startDateString)
     ? startDateString + 'T00:00:00'
     : startDateString;
   const startDate = new Date(normalised);
-  if (isNaN(startDate.getTime())) return '-';
+  if (isNaN(startDate.getTime())) return null;
   const endDate = new Date(startDate);
   endDate.setDate(endDate.getDate() + 10);
 
@@ -48,9 +48,30 @@ export function calculateQuarantineEndDate(startDateString?: string, format: 'sh
     endDate.setDate(endDate.getDate() + 1);
   }
 
+  return endDate;
+}
+
+// Calculates the quarantine end date: 10 days after the start date,
+// shifted forward if it falls on a weekend.
+export function calculateQuarantineEndDate(startDateString?: string, format: 'short' | 'long' = 'short'): string {
+  const endDate = addQuarantineDays(startDateString);
+  if (!endDate) return '-';
+
   return endDate.toLocaleDateString('en-US', format === 'long'
     ? { year: 'numeric', month: 'long', day: 'numeric' }
     : { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Same computation as calculateQuarantineEndDate, but returns YYYY-MM-DD for use as the
+// value of an <input type="date"> (e.g. pre-filling the editable quarantine end date field).
+export function calculateQuarantineEndDateISO(startDateString?: string): string {
+  const endDate = addQuarantineDays(startDateString);
+  if (!endDate) return '';
+
+  const y = endDate.getFullYear();
+  const m = String(endDate.getMonth() + 1).padStart(2, '0');
+  const d = String(endDate.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 export function calculateDaysSince(dateString?: string): number {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -97,15 +97,12 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 				}
 				updates["quarantine_start_date"] = startDate
 				// Use provided quarantine end date if available and valid, otherwise compute the default
-				if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
-					if req.QuarantineEndDate.Time.Before(startDate) {
-						c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
-						return
-					}
-					updates["quarantine_end_date"] = *req.QuarantineEndDate.Time
-				} else {
-					updates["quarantine_end_date"] = *models.ComputeQuarantineEndDate(&startDate)
+				endDate, err := resolveQuarantineEndDate(&startDate, req.QuarantineEndDate)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+					return
 				}
+				updates["quarantine_end_date"] = *endDate
 				// Always start clean, then apply provided value if any
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
@@ -147,22 +144,24 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			}
 			// Update quarantine start date independently — both fields can change in one request
 			resolvedStart := animal.QuarantineStartDate
-			startChanged := false
-			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+			startChanged := req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil
+			if startChanged {
 				updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
 				resolvedStart = req.QuarantineStartDate.Time
-				startChanged = true
 			}
 			// An explicit end date is honored (validated against the resolved start date);
 			// otherwise a start-date change recomputes the default, discarding any prior override.
-			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
-				if resolvedStart != nil && req.QuarantineEndDate.Time.Before(*resolvedStart) {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+			// Neither provided: leave the stored end date untouched.
+			endExplicit := req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil
+			if endExplicit || startChanged {
+				endDate, err := resolveQuarantineEndDate(resolvedStart, req.QuarantineEndDate)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
-				updates["quarantine_end_date"] = *req.QuarantineEndDate.Time
-			} else if startChanged && resolvedStart != nil {
-				updates["quarantine_end_date"] = *models.ComputeQuarantineEndDate(resolvedStart)
+				if endDate != nil {
+					updates["quarantine_end_date"] = *endDate
+				}
 			}
 			if req.QuarantineIncidentDetails != nil {
 				updates["quarantine_incident_details"] = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -75,6 +75,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			case "available":
 				updates["foster_start_date"] = nil
 				updates["quarantine_start_date"] = nil
+				updates["quarantine_end_date"] = nil
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
@@ -82,6 +83,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			case "foster":
 				updates["foster_start_date"] = now
 				updates["quarantine_start_date"] = nil
+				updates["quarantine_end_date"] = nil
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
@@ -89,10 +91,20 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			case "bite_quarantine":
 				enteredQuarantine = true
 				// Use provided quarantine start date if available, otherwise use current time
+				startDate := now
 				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
-					updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
+					startDate = *req.QuarantineStartDate.Time
+				}
+				updates["quarantine_start_date"] = startDate
+				// Use provided quarantine end date if available and valid, otherwise compute the default
+				if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
+					if req.QuarantineEndDate.Time.Before(startDate) {
+						c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+						return
+					}
+					updates["quarantine_end_date"] = *req.QuarantineEndDate.Time
 				} else {
-					updates["quarantine_start_date"] = now
+					updates["quarantine_end_date"] = *models.ComputeQuarantineEndDate(&startDate)
 				}
 				// Always start clean, then apply provided value if any
 				updates["quarantine_approval_status"] = ""
@@ -116,6 +128,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 				// No dedicated date field for vet care, so clear the same fields as "available"
 				updates["foster_start_date"] = nil
 				updates["quarantine_start_date"] = nil
+				updates["quarantine_end_date"] = nil
 				updates["quarantine_approval_status"] = ""
 				updates["quarantine_approval_date"] = nil
 				updates["archived_date"] = nil
@@ -133,8 +146,23 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 				}
 			}
 			// Update quarantine start date independently — both fields can change in one request
+			resolvedStart := animal.QuarantineStartDate
+			startChanged := false
 			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
+				resolvedStart = req.QuarantineStartDate.Time
+				startChanged = true
+			}
+			// An explicit end date is honored (validated against the resolved start date);
+			// otherwise a start-date change recomputes the default, discarding any prior override.
+			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
+				if resolvedStart != nil && req.QuarantineEndDate.Time.Before(*resolvedStart) {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+					return
+				}
+				updates["quarantine_end_date"] = *req.QuarantineEndDate.Time
+			} else if startChanged && resolvedStart != nil {
+				updates["quarantine_end_date"] = *models.ComputeQuarantineEndDate(resolvedStart)
 			}
 			if req.QuarantineIncidentDetails != nil {
 				updates["quarantine_incident_details"] = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -634,3 +634,167 @@ func TestUpdateAnimalAdmin_ApprovalClearedOnTransitionToAvailable(t *testing.T) 
 		t.Error("Expected approval_date to be nil after leaving quarantine, got non-nil")
 	}
 }
+
+func TestUpdateAnimalAdmin_BiteQuarantine_DefaultEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC) // Monday
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	expectedEnd := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if got.QuarantineEndDate == nil || !got.QuarantineEndDate.Equal(expectedEnd) {
+		t.Errorf("Expected QuarantineEndDate %v, got %v", expectedEnd, got.QuarantineEndDate)
+	}
+}
+
+func TestUpdateAnimalAdmin_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 5, 0, 0, 0, 0, time.UTC)
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+		QuarantineEndDate: NullableTime{
+			Time:  &endDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAnimalAdmin_EditEndDateOnly_WhileInQuarantine(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	defaultEnd := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   defaultEnd,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	overrideEnd := time.Date(2025, 11, 24, 0, 0, 0, 0, time.UTC)
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "bite_quarantine",
+		QuarantineEndDate: NullableTime{
+			Time:  &overrideEnd,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineEndDate == nil || !got.QuarantineEndDate.Equal(overrideEnd) {
+		t.Errorf("Expected QuarantineEndDate override %v, got %v", overrideEnd, got.QuarantineEndDate)
+	}
+	if got.QuarantineStartDate == nil || !got.QuarantineStartDate.Equal(startDate) {
+		t.Errorf("Expected QuarantineStartDate to remain %v, got %v", startDate, got.QuarantineStartDate)
+	}
+}
+
+func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   endDate,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineEndDate != nil {
+		t.Errorf("Expected QuarantineEndDate to be cleared, got %v", got.QuarantineEndDate)
+	}
+}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -393,6 +393,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				// Clear specific status dates and approval when leaving quarantine
 				animal.FosterStartDate = nil
 				animal.QuarantineStartDate = nil
+				animal.QuarantineEndDate = nil
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
@@ -400,6 +401,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 			case "foster":
 				animal.FosterStartDate = &now
 				animal.QuarantineStartDate = nil
+				animal.QuarantineEndDate = nil
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
@@ -410,6 +412,16 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 					animal.QuarantineStartDate = req.QuarantineStartDate.Time
 				} else {
 					animal.QuarantineStartDate = &now
+				}
+				// Use provided quarantine end date if available and valid, otherwise compute the default
+				if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
+					if req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
+						c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+						return
+					}
+					animal.QuarantineEndDate = req.QuarantineEndDate.Time
+				} else {
+					animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
 				}
 				// Always start clean, then apply provided value if any
 				animal.QuarantineApprovalStatus = ""
@@ -433,6 +445,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				// No dedicated date field for vet care, so clear the same fields as "available"
 				animal.FosterStartDate = nil
 				animal.QuarantineStartDate = nil
+				animal.QuarantineEndDate = nil
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
 				animal.ArchivedDate = nil
@@ -451,8 +464,21 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				}
 			}
 			// Update quarantine start date independently — both fields can change in one request
+			startChanged := false
 			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
+				startChanged = true
+			}
+			// An explicit end date is honored (validated against the resolved start date);
+			// otherwise a start-date change recomputes the default, discarding any prior override.
+			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
+				if animal.QuarantineStartDate != nil && req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+					return
+				}
+				animal.QuarantineEndDate = req.QuarantineEndDate.Time
+			} else if startChanged {
+				animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
 			}
 			if req.QuarantineIncidentDetails != nil {
 				animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -264,15 +264,12 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				animal.QuarantineStartDate = &now
 			}
 			// Use provided quarantine end date if available and valid, otherwise compute the default
-			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
-				if req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
-					return
-				}
-				animal.QuarantineEndDate = req.QuarantineEndDate.Time
-			} else {
-				animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
+			endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
 			}
+			animal.QuarantineEndDate = endDate
 			// Set bite quarantine permission status if provided
 			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
 				animal.QuarantineApprovalStatus = *req.QuarantineApprovalStatus
@@ -414,15 +411,12 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 					animal.QuarantineStartDate = &now
 				}
 				// Use provided quarantine end date if available and valid, otherwise compute the default
-				if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
-					if req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
-						c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
-						return
-					}
-					animal.QuarantineEndDate = req.QuarantineEndDate.Time
-				} else {
-					animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
+				endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+					return
 				}
+				animal.QuarantineEndDate = endDate
 				// Always start clean, then apply provided value if any
 				animal.QuarantineApprovalStatus = ""
 				animal.QuarantineApprovalDate = nil
@@ -464,21 +458,21 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				}
 			}
 			// Update quarantine start date independently — both fields can change in one request
-			startChanged := false
-			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+			startChanged := req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil
+			if startChanged {
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
-				startChanged = true
 			}
 			// An explicit end date is honored (validated against the resolved start date);
 			// otherwise a start-date change recomputes the default, discarding any prior override.
-			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
-				if animal.QuarantineStartDate != nil && req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+			// Neither provided: leave the stored end date untouched.
+			endExplicit := req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil
+			if endExplicit || startChanged {
+				endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
-				animal.QuarantineEndDate = req.QuarantineEndDate.Time
-			} else if startChanged {
-				animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
+				animal.QuarantineEndDate = endDate
 			}
 			if req.QuarantineIncidentDetails != nil {
 				animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -44,8 +44,8 @@ func buildQuarantineEmail(animal *models.Animal) (string, string) {
 		start = animal.QuarantineStartDate.Format(dateLayout)
 	}
 	end := ""
-	if e := animal.QuarantineEndDate(); e != nil {
-		end = e.Format(dateLayout)
+	if animal.QuarantineEndDate != nil {
+		end = animal.QuarantineEndDate.Format(dateLayout)
 	}
 	title := fmt.Sprintf("🚨 Bite Quarantine: %s", animal.Name)
 	body := fmt.Sprintf(
@@ -262,6 +262,16 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				animal.QuarantineStartDate = req.QuarantineStartDate.Time
 			} else {
 				animal.QuarantineStartDate = &now
+			}
+			// Use provided quarantine end date if available and valid, otherwise compute the default
+			if req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil {
+				if req.QuarantineEndDate.Time.Before(*animal.QuarantineStartDate) {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine end date cannot be before start date"})
+					return
+				}
+				animal.QuarantineEndDate = req.QuarantineEndDate.Time
+			} else {
+				animal.QuarantineEndDate = models.ComputeQuarantineEndDate(animal.QuarantineStartDate)
 			}
 			// Set bite quarantine permission status if provided
 			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -16,9 +16,11 @@ import (
 
 func TestBuildQuarantineEmailBody(t *testing.T) {
 	start := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
 	a := &models.Animal{
 		Name:                      "Rex",
 		QuarantineStartDate:       &start,
+		QuarantineEndDate:         &end,
 		QuarantineIncidentDetails: "Bit a volunteer on the hand during leashing.",
 	}
 	title, body := buildQuarantineEmail(a)
@@ -30,6 +32,9 @@ func TestBuildQuarantineEmailBody(t *testing.T) {
 	}
 	if !strings.Contains(body, "June 22, 2026") {
 		t.Errorf("body missing formatted start date: %q", body)
+	}
+	if !strings.Contains(body, "July 2, 2026") {
+		t.Errorf("body missing formatted end date: %q", body)
 	}
 	if !strings.Contains(body, "Bit a volunteer on the hand during leashing.") {
 		t.Errorf("body missing incident details: %q", body)

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -109,9 +109,17 @@ func isValidApprovalStatus(s *string) bool {
 // computed default (models.ComputeQuarantineEndDate). Used by CreateAnimal,
 // UpdateAnimal, and UpdateAnimalAdmin so the resolution rule stays identical
 // across all three write paths.
+//
+// An explicit end date requires a known start date to validate against — a nil
+// start (e.g. a CSV-imported animal that reached bite_quarantine status without
+// ever setting a quarantine start date) is rejected rather than silently stored
+// unvalidated.
 func resolveQuarantineEndDate(start *time.Time, reqEnd NullableTime) (*time.Time, error) {
 	if reqEnd.Valid && reqEnd.Time != nil {
-		if start != nil && quarantineEndBeforeStart(*reqEnd.Time, *start) {
+		if start == nil {
+			return nil, fmt.Errorf("quarantine end date requires a quarantine start date")
+		}
+		if quarantineEndBeforeStart(*reqEnd.Time, *start) {
 			return nil, fmt.Errorf("quarantine end date cannot be before start date")
 		}
 		return reqEnd.Time, nil

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -81,6 +81,7 @@ type AnimalRequest struct {
 	GroupID                   uint         `json:"group_id,omitempty"`
 	ArrivalDate               NullableTime `json:"arrival_date,omitempty"` // Date animal entered shelter
 	QuarantineStartDate       NullableTime `json:"quarantine_start_date,omitempty"`
+	QuarantineEndDate         NullableTime `json:"quarantine_end_date,omitempty"`
 	QuarantineApprovalStatus  *string      `json:"quarantine_approval_status,omitempty"`  // nil = not provided; "" | "requested" | "granted" when set
 	QuarantineIncidentDetails *string      `json:"quarantine_incident_details,omitempty"` // nil = not provided; set when entering bite quarantine
 	IsReturned                *bool        `json:"is_returned,omitempty"`                 // Pointer to distinguish null from false

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -101,6 +102,35 @@ func isValidApprovalStatus(s *string) bool {
 		return true
 	}
 	return *s == "" || *s == "requested" || *s == "granted"
+}
+
+// resolveQuarantineEndDate returns the quarantine end date to store: an explicit
+// override from reqEnd when provided (validated against start), otherwise the
+// computed default (models.ComputeQuarantineEndDate). Used by CreateAnimal,
+// UpdateAnimal, and UpdateAnimalAdmin so the resolution rule stays identical
+// across all three write paths.
+func resolveQuarantineEndDate(start *time.Time, reqEnd NullableTime) (*time.Time, error) {
+	if reqEnd.Valid && reqEnd.Time != nil {
+		if start != nil && quarantineEndBeforeStart(*reqEnd.Time, *start) {
+			return nil, fmt.Errorf("quarantine end date cannot be before start date")
+		}
+		return reqEnd.Time, nil
+	}
+	return models.ComputeQuarantineEndDate(start), nil
+}
+
+// quarantineEndBeforeStart compares end and start by calendar day (UTC), not by
+// exact instant. Start defaults to time.Now() (a real timestamp) when omitted,
+// while a date-only end date parses to UTC midnight — comparing exact instants
+// would wrongly reject a same-day end date submitted alongside a defaulted start.
+func quarantineEndBeforeStart(end, start time.Time) bool {
+	end = end.UTC()
+	start = start.UTC()
+	ey, em, ed := end.Date()
+	sy, sm, sd := start.Date()
+	endDay := time.Date(ey, em, ed, 0, 0, 0, 0, time.UTC)
+	startDay := time.Date(sy, sm, sd, 0, 0, 0, 0, time.UTC)
+	return endDay.Before(startDay)
 }
 
 // checkGroupAccess verifies if the user has access to a specific group

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -299,4 +299,17 @@ func TestResolveQuarantineEndDate(t *testing.T) {
 			t.Errorf("expected nil, got %v", result)
 		}
 	})
+
+	t.Run("nil start with an explicit end date is rejected rather than stored unvalidated", func(t *testing.T) {
+		// Reachable today via CSV-imported animals that land in bite_quarantine
+		// status without ever setting a quarantine start date.
+		end := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
+		_, err := resolveQuarantineEndDate(nil, NullableTime{Time: &end, Valid: true})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if err.Error() != "quarantine end date requires a quarantine start date" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
+	})
 }

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -224,3 +224,79 @@ func TestNullableTime_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveQuarantineEndDate covers the shared "explicit override, validated
+// against start; else computed default" rule used by CreateAnimal, UpdateAnimal,
+// and UpdateAnimalAdmin.
+func TestResolveQuarantineEndDate(t *testing.T) {
+	t.Run("no explicit end date returns the computed default", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC) // Monday
+		result, err := resolveQuarantineEndDate(&start, NullableTime{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC) // Thursday, 10 days later
+		if result == nil || !result.Equal(expected) {
+			t.Errorf("expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("explicit end date after start is honored verbatim", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
+		result, err := resolveQuarantineEndDate(&start, NullableTime{Time: &end, Valid: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(end) {
+			t.Errorf("expected %v, got %v", end, result)
+		}
+	})
+
+	t.Run("explicit end date before start's calendar day is rejected", func(t *testing.T) {
+		start := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 11, 5, 0, 0, 0, 0, time.UTC)
+		_, err := resolveQuarantineEndDate(&start, NullableTime{Time: &end, Valid: true})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if err.Error() != "quarantine end date cannot be before start date" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
+	})
+
+	t.Run("explicit end date same calendar day as start is accepted even with a later time-of-day start", func(t *testing.T) {
+		// Regression: start defaults to time.Now() (a real timestamp), while a
+		// date-only end date parses to UTC midnight. Comparing exact instants
+		// would wrongly reject a same-day end date; comparison must be by
+		// calendar day.
+		start := time.Date(2026, 7, 2, 14, 30, 0, 0, time.UTC) // 2:30pm
+		end := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)     // midnight, same day
+		result, err := resolveQuarantineEndDate(&start, NullableTime{Time: &end, Valid: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(end) {
+			t.Errorf("expected %v, got %v", end, result)
+		}
+	})
+
+	t.Run("explicit end date on the calendar day before start, even with an earlier time-of-day, is rejected", func(t *testing.T) {
+		start := time.Date(2026, 7, 2, 23, 0, 0, 0, time.UTC)  // 11pm
+		end := time.Date(2026, 7, 1, 1, 0, 0, 0, time.UTC)     // 1am, previous calendar day
+		_, err := resolveQuarantineEndDate(&start, NullableTime{Time: &end, Valid: true})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("nil start with no explicit end date returns nil", func(t *testing.T) {
+		result, err := resolveQuarantineEndDate(nil, NullableTime{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -2118,3 +2118,123 @@ func TestCreateAnimal_DefaultApprovalStatusWhenOmitted(t *testing.T) {
 		t.Error("Expected approval_date to be nil when status defaulted via GORM, got non-nil")
 	}
 }
+
+func TestCreateAnimal_BiteQuarantine_DefaultEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC) // Monday
+	animalReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(animalReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	var created models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	expectedEnd := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC) // Thursday, 10 days later
+	if created.QuarantineEndDate == nil {
+		t.Fatal("Expected QuarantineEndDate to be set")
+	} else if !created.QuarantineEndDate.Equal(expectedEnd) {
+		t.Errorf("Expected QuarantineEndDate %v, got %v", expectedEnd, *created.QuarantineEndDate)
+	}
+}
+
+func TestCreateAnimal_BiteQuarantine_ExplicitEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC) // vet-extended end date
+	animalReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+		QuarantineEndDate: NullableTime{
+			Time:  &endDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(animalReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	var created models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if created.QuarantineEndDate == nil {
+		t.Fatal("Expected QuarantineEndDate to be set")
+	} else if !created.QuarantineEndDate.Equal(endDate) {
+		t.Errorf("Expected QuarantineEndDate %v, got %v", endDate, *created.QuarantineEndDate)
+	}
+}
+
+func TestCreateAnimal_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	startDate := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 5, 0, 0, 0, 0, time.UTC) // before start
+	animalReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+		QuarantineEndDate: NullableTime{
+			Time:  &endDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(animalReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -2238,3 +2238,334 @@ func TestCreateAnimal_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, w.Code, w.Body.String())
 	}
 }
+
+func TestUpdateAnimal_BiteQuarantine_DefaultEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC) // Monday
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var updated models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	expectedEnd := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if updated.QuarantineEndDate == nil {
+		t.Fatal("Expected QuarantineEndDate to be set")
+	} else if !updated.QuarantineEndDate.Equal(expectedEnd) {
+		t.Errorf("Expected QuarantineEndDate %v, got %v", expectedEnd, *updated.QuarantineEndDate)
+	}
+}
+
+func TestUpdateAnimal_BiteQuarantine_ExplicitEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+		QuarantineEndDate: NullableTime{
+			Time:  &endDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var updated models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if updated.QuarantineEndDate == nil {
+		t.Fatal("Expected QuarantineEndDate to be set")
+	} else if !updated.QuarantineEndDate.Equal(endDate) {
+		t.Errorf("Expected QuarantineEndDate %v, got %v", endDate, *updated.QuarantineEndDate)
+	}
+}
+
+func TestUpdateAnimal_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 5, 0, 0, 0, 0, time.UTC)
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &startDate,
+			Valid: true,
+		},
+		QuarantineEndDate: NullableTime{
+			Time:  &endDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAnimal_EditEndDateOnly_WhileInQuarantine(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	defaultEnd := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   defaultEnd,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	overrideEnd := time.Date(2025, 11, 24, 0, 0, 0, 0, time.UTC) // vet extended quarantine
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineEndDate: NullableTime{
+			Time:  &overrideEnd,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineEndDate == nil || !got.QuarantineEndDate.Equal(overrideEnd) {
+		t.Errorf("Expected QuarantineEndDate override %v, got %v", overrideEnd, got.QuarantineEndDate)
+	}
+	if got.QuarantineStartDate == nil || !got.QuarantineStartDate.Equal(startDate) {
+		t.Errorf("Expected QuarantineStartDate to remain %v, got %v", startDate, got.QuarantineStartDate)
+	}
+}
+
+func TestUpdateAnimal_ChangeStartDate_RecomputesEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	originalStart := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	overrideEnd := time.Date(2025, 11, 24, 0, 0, 0, 0, time.UTC) // previously overridden
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": originalStart,
+		"quarantine_end_date":   overrideEnd,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	newStart := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC) // Monday, one week later
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &newStart,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	expectedEnd := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC) // 10 days after new start (Thursday)
+	if got.QuarantineEndDate == nil || !got.QuarantineEndDate.Equal(expectedEnd) {
+		t.Errorf("Expected recomputed QuarantineEndDate %v, got %v", expectedEnd, got.QuarantineEndDate)
+	}
+}
+
+func TestUpdateAnimal_EditUnrelatedField_KeepsEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	overrideEnd := time.Date(2025, 11, 24, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   overrideEnd,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:         "Rex",
+		Species:      "Dog",
+		Status:       "bite_quarantine",
+		TrainerNotes: "Needs a muzzle for vet visits.",
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineEndDate == nil || !got.QuarantineEndDate.Equal(overrideEnd) {
+		t.Errorf("Expected QuarantineEndDate to remain %v, got %v", overrideEnd, got.QuarantineEndDate)
+	}
+}
+
+func TestUpdateAnimal_LeaveQuarantine_ClearsEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   endDate,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "available",
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := db.First(&got, animal.ID).Error; err != nil {
+		t.Fatalf("Failed to reload animal: %v", err)
+	}
+	if got.QuarantineEndDate != nil {
+		t.Errorf("Expected QuarantineEndDate to be cleared, got %v", got.QuarantineEndDate)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -87,6 +87,7 @@ type Animal struct {
 	ArrivalDate                    *time.Time          `json:"arrival_date"`                                                    // When animal first became available
 	FosterStartDate                *time.Time          `json:"foster_start_date"`                                               // When animal went to foster
 	QuarantineStartDate            *time.Time          `json:"quarantine_start_date"`                                           // When bite quarantine started
+	QuarantineEndDate              *time.Time          `json:"quarantine_end_date"`                                             // Computed default (start + 10 days, weekend-adjusted), or manually overridden by staff
 	QuarantineApprovalStatus       string              `gorm:"default:'requested'" json:"quarantine_approval_status"`           // Bite quarantine permission: "requested" (default), "granted", or "" (legacy — displayed as Not Requested)
 	QuarantineApprovalDate         *time.Time          `json:"quarantine_approval_date"`                                        // When approval status last changed (nil when not requested)
 	QuarantineIncidentDetails      string              `json:"quarantine_incident_details"`                                     // Bite incident context; set on entering BQ, cleared on leaving. Shown atop the detail page.
@@ -171,15 +172,17 @@ func (a *Animal) CurrentStatusDuration() int {
 	return calendarDaysSince(*a.LastStatusChange)
 }
 
-// QuarantineEndDate calculates when the 10-day bite quarantine ends
-// The quarantine cannot end on Saturday or Sunday, so it adjusts forward to Monday
-func (a *Animal) QuarantineEndDate() *time.Time {
-	if a.QuarantineStartDate == nil {
+// ComputeQuarantineEndDate calculates the default 10-day bite quarantine end date from a
+// start date. The quarantine cannot end on Saturday or Sunday, so it adjusts forward to
+// Monday. Returns nil when start is nil. This produces the *default* QuarantineEndDate
+// value — staff can override the stored field afterward.
+func ComputeQuarantineEndDate(start *time.Time) *time.Time {
+	if start == nil {
 		return nil
 	}
 
 	// Calculate 10 days from start date
-	endDate := a.QuarantineStartDate.AddDate(0, 0, 10)
+	endDate := start.AddDate(0, 0, 10)
 
 	// Check if end date falls on weekend and adjust to next Monday
 	for endDate.Weekday() == time.Saturday || endDate.Weekday() == time.Sunday {

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -131,7 +131,7 @@ func TestAnimal_CurrentStatusDuration(t *testing.T) {
 	}
 }
 
-func TestAnimal_QuarantineEndDate(t *testing.T) {
+func TestComputeQuarantineEndDate(t *testing.T) {
 	tests := []struct {
 		name                string
 		quarantineStartDate *time.Time
@@ -232,10 +232,7 @@ func TestAnimal_QuarantineEndDate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			animal := &Animal{
-				QuarantineStartDate: tt.quarantineStartDate,
-			}
-			result := animal.QuarantineEndDate()
+			result := ComputeQuarantineEndDate(tt.quarantineStartDate)
 			tt.checkResult(t, result)
 		})
 	}
@@ -351,7 +348,7 @@ func TestAnimal_MethodsWithRealData(t *testing.T) {
 			t.Errorf("Expected status duration to be 5 days, got %d", statusDuration)
 		}
 
-		endDate := animal.QuarantineEndDate()
+		endDate := ComputeQuarantineEndDate(animal.QuarantineStartDate)
 		if endDate == nil {
 			t.Fatal("Expected quarantine end date to be set")
 		}


### PR DESCRIPTION
## Summary
- Staff can now view and manually override the computed bite-quarantine end date on the animal edit form; it defaults to 10 days after the start date (rolled forward past weekends) but a vet/authority-specified date can be entered directly.
- The override is authoritative everywhere the end date is shown: the edit form, the animal detail page, the group's animal list, and the bulk-edit page (cards + table). Changing the quarantine start date resets the override back to the computed default.
- Backend: new nullable `quarantine_end_date` column on `Animal`, enforced across all three write paths (create, update, admin update) with one consistent rule — explicit value validated (>= start date) and stored, otherwise recomputed from the start date.
- No new notifications are sent when the end date is edited after the fact (silent correction, same as incident details), and there's no audit trail — matches the existing pattern for incident-detail corrections.

## Test plan
- [x] Backend: `go test ./internal/...` — all quarantine-related tests pass (pre-existing, unrelated `TestCreateGroup/accepts_valid_GroupMe_bot_id` failure confirmed on main before this branch)
- [x] Frontend: `npx vitest run` — 320/320 passing
- [x] `npx tsc --noEmit` clean
- [x] Manual design/implementation review via spec + 8-task plan, each task independently reviewed, plus a final whole-branch review

🤖 Generated with [Claude Code](https://claude.com/claude-code)