### PR TITLE
fix: move quarantine permission badge inside the quarantine info box

### DIFF
--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -477,18 +477,16 @@ const AnimalDetailPage: React.FC = () => {
                   <p className="quarantine-dates">
                     End: {formatQuarantineEndDate(animal, 'long')}
                   </p>
-                  {animal.status === 'bite_quarantine' && animal.quarantine_incident_details && (
+                  {animal.quarantine_incident_details && (
                     <div className="quarantine-incident">
                       <p className="quarantine-incident-label"><strong>Incident Details</strong></p>
                       <p className="quarantine-incident-text">{animal.quarantine_incident_details}</p>
                     </div>
                   )}
-                </div>
-              )}
-              {animal.status === 'bite_quarantine' && (
-                <div className="quarantine-permission-row">
-                  <span className="quarantine-permission-label" aria-hidden="true">Permission:</span>
-                  <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
+                  <div className="quarantine-permission-row">
+                    <span className="quarantine-permission-label" aria-hidden="true">Permission:</span>
+                    <QuarantineApprovalBadge status={animal.quarantine_approval_status} />
+                  </div>
                 </div>
               )}
               {animal.description && (


### PR DESCRIPTION
## Summary
- The **Permission** badge was rendered outside the red Bite Quarantine box, leaving it visually disconnected from the quarantine details
- Moved `quarantine-permission-row` inside the `quarantine-info` div so it appears within the box alongside the dates and incident details
- Removed a redundant `animal.status === 'bite_quarantine'` guard on the incident details section (already implied by the outer condition)

## Test plan
- [ ] View an animal in `bite_quarantine` status — Permission badge should appear inside the red box
- [ ] Verify the badge renders correctly for all approval statuses (Requested, Approved, Denied)
- [ ] Confirm animals without a `quarantine_start_date` still hide the box entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)