### PR TITLE
Persist BQ episode history on the animal record

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -189,6 +189,15 @@ export interface AnimalNameHistory {
   changed_by: number;
 }
 
+export interface AnimalBQIncident {
+  id: number;
+  animal_id: number;
+  incident_details: string;
+  start_date: string;
+  end_date: string | null;
+  created_at: string;
+}
+
 export interface Animal {
   id: number;
   group_id: number;
@@ -220,6 +229,7 @@ export interface Animal {
   protocol_document_user_id?: number;
   tags?: AnimalTag[];
   name_history?: AnimalNameHistory[];
+  bq_incidents?: AnimalBQIncident[];
   scripts?: Script[];
 }
 

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -1171,6 +1171,55 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
+/* Bite Quarantine History Section */
+.bq-history-section {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+}
+
+.bq-history-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.bq-history-count {
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+.bq-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.bq-history-item {
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-primary);
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.bq-history-dates {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.bq-history-details {
+  margin: 0.35rem 0 0 0;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
 /* Name History Section */
 .name-history-section {
   margin-top: 1.5rem;

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -512,6 +512,31 @@ const AnimalDetailPage: React.FC = () => {
                 </div>
               )}
 
+              {/* BQ History Section */}
+              {animal.bq_incidents && animal.bq_incidents.length > 0 && (
+                <details className="bq-history-section">
+                  <summary className="bq-history-summary">
+                    <strong>Bite Quarantine History</strong>
+                    <span className="bq-history-count">({animal.bq_incidents.length})</span>
+                  </summary>
+                  <div className="bq-history-list">
+                    {[...animal.bq_incidents]
+                      .sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime())
+                      .map((episode) => (
+                        <div key={episode.id} className="bq-history-item">
+                          <p className="bq-history-dates">
+                            {formatCalendarDate(episode.start_date, 'long')}
+                            {episode.end_date && ` – ${formatCalendarDate(episode.end_date, 'long')}`}
+                          </p>
+                          {episode.incident_details && (
+                            <p className="bq-history-details">{episode.incident_details}</p>
+                          )}
+                        </div>
+                      ))}
+                  </div>
+                </details>
+              )}
+
               {/* Name History Section */}
               {animal.name_history && animal.name_history.length > 0 && (
                 <div className="name-history-section">

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -1176,7 +1176,7 @@ const AnimalForm: React.FC = () => {
         size="medium"
       >
         <p style={{ marginBottom: '1rem' }}>
-          Please provide details about the bite incident. This information will be shown on the animal's page while in quarantine, saved as a behavior comment, and emailed to the group.
+          Please provide details about the bite incident. This information will be shown on the animal's page while in quarantine, saved to the animal's BQ history, and emailed to the group.
         </p>
         
         <div style={{ marginBottom: '1rem' }}>

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -167,6 +167,7 @@ func RunMigrations(db *gorm.DB) error {
 		&models.AnimalImage{},
 		&models.AnimalVideo{},
 		&models.AnimalNameHistory{},
+		&models.AnimalBQIncident{},
 		&models.GroupDocument{},
 	)
 	if err != nil {

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -65,6 +65,8 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		}
 		now := time.Now()
 		enteredQuarantine := false
+		leftQuarantine := req.Status != "" && req.Status != animal.Status && animal.Status == "bite_quarantine"
+		var bqStartDate time.Time
 		if req.Status != "" && req.Status != animal.Status {
 			// Track status change
 			updates["status"] = req.Status
@@ -95,6 +97,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
+				bqStartDate = startDate
 				updates["quarantine_start_date"] = startDate
 				updates["quarantine_end_date"] = *endDate
 				// Always start clean, then apply provided value if any
@@ -174,7 +177,26 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		}
 
 		if enteredQuarantine {
+			incidentDetails := ""
+			if req.QuarantineIncidentDetails != nil {
+				incidentDetails = *req.QuarantineIncidentDetails
+			}
+			db.Create(&models.AnimalBQIncident{
+				AnimalID:        animal.ID,
+				IncidentDetails: incidentDetails,
+				StartDate:       bqStartDate,
+			})
 			sendQuarantineNotificationEmail(db, emailService, &animal)
+		}
+		if leftQuarantine {
+			db.Model(&models.AnimalBQIncident{}).
+				Where("animal_id = ? AND end_date IS NULL", animal.ID).
+				Update("end_date", now)
+		}
+		if !enteredQuarantine && !leftQuarantine && animal.Status == "bite_quarantine" && req.QuarantineIncidentDetails != nil {
+			db.Model(&models.AnimalBQIncident{}).
+				Where("animal_id = ? AND end_date IS NULL", animal.ID).
+				Update("incident_details", *req.QuarantineIncidentDetails)
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -67,6 +67,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		enteredQuarantine := false
 		leftQuarantine := req.Status != "" && req.Status != animal.Status && animal.Status == "bite_quarantine"
 		var bqStartDate time.Time
+		var bqStartDateEdit *time.Time
 		if req.Status != "" && req.Status != animal.Status {
 			// Track status change
 			updates["status"] = req.Status
@@ -147,6 +148,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			}
 			if newStart != nil {
 				updates["quarantine_start_date"] = *newStart
+				bqStartDateEdit = newStart
 			}
 			if newEnd != nil {
 				updates["quarantine_end_date"] = *newEnd
@@ -181,22 +183,37 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			if req.QuarantineIncidentDetails != nil {
 				incidentDetails = *req.QuarantineIncidentDetails
 			}
-			db.Create(&models.AnimalBQIncident{
+			if err := db.Create(&models.AnimalBQIncident{
 				AnimalID:        animal.ID,
 				IncidentDetails: incidentDetails,
 				StartDate:       bqStartDate,
-			})
+			}).Error; err != nil {
+				logger.Error("Failed to record BQ incident", err)
+			}
 			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 		if leftQuarantine {
-			db.Model(&models.AnimalBQIncident{}).
+			if err := db.Model(&models.AnimalBQIncident{}).
 				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("end_date", now)
+				Update("end_date", now).Error; err != nil {
+				logger.Error("Failed to close BQ incident", err)
+			}
 		}
-		if !enteredQuarantine && !leftQuarantine && animal.Status == "bite_quarantine" && req.QuarantineIncidentDetails != nil {
-			db.Model(&models.AnimalBQIncident{}).
-				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("incident_details", *req.QuarantineIncidentDetails)
+		if !enteredQuarantine && !leftQuarantine && animal.Status == "bite_quarantine" {
+			incidentUpdates := map[string]interface{}{}
+			if req.QuarantineIncidentDetails != nil {
+				incidentUpdates["incident_details"] = *req.QuarantineIncidentDetails
+			}
+			if bqStartDateEdit != nil {
+				incidentUpdates["start_date"] = *bqStartDateEdit
+			}
+			if len(incidentUpdates) > 0 {
+				if err := db.Model(&models.AnimalBQIncident{}).
+					Where("animal_id = ? AND end_date IS NULL", animal.ID).
+					Updates(incidentUpdates).Error; err != nil {
+					logger.Error("Failed to update BQ incident", err)
+				}
+			}
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -928,3 +928,58 @@ func TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails(t *testing.T) {
 		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Updated details.")
 	}
 }
+
+// TestUpdateAnimalAdmin_MidBQ_EditStartDate_SyncsIncidentRow verifies that
+// editing the quarantine start date while still in BQ updates the active
+// incident row's StartDate, so the permanent history stays accurate.
+func TestUpdateAnimalAdmin_MidBQ_EditStartDate_SyncsIncidentRow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	originalStart := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": originalStart,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Original details.",
+		StartDate:       originalStart,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	correctedStart := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &correctedStart,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if !incident.StartDate.Equal(correctedStart) {
+		t.Errorf("StartDate = %v, want %v", incident.StartDate, correctedStart)
+	}
+}

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -798,3 +798,133 @@ func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsEndDate(t *testing.T) {
 		t.Errorf("Expected QuarantineEndDate to be cleared, got %v", got.QuarantineEndDate)
 	}
 }
+
+// TestUpdateAnimalAdmin_BQEntry_CreatesIncidentRow verifies that the admin
+// handler creates an AnimalBQIncident row when transitioning to bite_quarantine.
+func TestUpdateAnimalAdmin_BQEntry_CreatesIncidentRow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	details := "Bit a volunteer."
+	updateReq := AnimalRequest{
+		Name:                      "Rex",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("Expected active AnimalBQIncident row: %v", err)
+	}
+	if incident.IncidentDetails != "Bit a volunteer." {
+		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Bit a volunteer.")
+	}
+}
+
+// TestUpdateAnimalAdmin_BQExit_StampsEndDate verifies that the admin handler
+// stamps EndDate on the active incident row when the animal leaves BQ.
+func TestUpdateAnimalAdmin_BQExit_StampsEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Bit a volunteer.",
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Bit a volunteer.",
+		StartDate:       animal.CreatedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updateReq := AnimalRequest{Name: "Rex", Status: "available"}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil {
+		t.Error("Expected EndDate to be stamped, got nil")
+	}
+}
+
+// TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails verifies that editing
+// incident details while in BQ via the admin handler updates the incident row.
+func TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Original details.",
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Original details.",
+		StartDate:       animal.CreatedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updated := "Updated details."
+	updateReq := AnimalRequest{
+		Name:                      "Rex",
+		QuarantineIncidentDetails: &updated,
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.IncidentDetails != "Updated details." {
+		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Updated details.")
+	}
+}

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -288,11 +288,14 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if animal.Status == "bite_quarantine" {
-			db.WithContext(ctx).Create(&models.AnimalBQIncident{
+			if err := db.WithContext(ctx).Create(&models.AnimalBQIncident{
 				AnimalID:        animal.ID,
 				IncidentDetails: animal.QuarantineIncidentDetails,
 				StartDate:       *animal.QuarantineStartDate,
-			})
+			}).Error; err != nil {
+				// Log error but don't fail the create
+				c.Error(err)
+			}
 			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -377,6 +377,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		enteredQuarantine := false
 		leftQuarantine := newStatus != "" && newStatus != oldStatus && oldStatus == "bite_quarantine"
 		midBQEdit := false
+		var midBQStartDate *time.Time
 		if newStatus != "" && newStatus != oldStatus {
 			animal.LastStatusChange = &now
 			enteredQuarantine = newStatus == "bite_quarantine" && oldStatus != "bite_quarantine"
@@ -461,6 +462,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 			}
 			if newStart != nil {
 				animal.QuarantineStartDate = newStart
+				midBQStartDate = newStart
 			}
 			if newEnd != nil {
 				animal.QuarantineEndDate = newEnd
@@ -504,22 +506,40 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if enteredQuarantine {
-			db.WithContext(ctx).Create(&models.AnimalBQIncident{
+			if err := db.WithContext(ctx).Create(&models.AnimalBQIncident{
 				AnimalID:        animal.ID,
 				IncidentDetails: animal.QuarantineIncidentDetails,
 				StartDate:       *animal.QuarantineStartDate,
-			})
+			}).Error; err != nil {
+				// Log error but don't fail the update
+				c.Error(err)
+			}
 			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 		if leftQuarantine {
-			db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
+			if err := db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
 				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("end_date", now)
+				Update("end_date", now).Error; err != nil {
+				// Log error but don't fail the update
+				c.Error(err)
+			}
 		}
-		if midBQEdit && req.QuarantineIncidentDetails != nil {
-			db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
-				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("incident_details", *req.QuarantineIncidentDetails)
+		if midBQEdit {
+			incidentUpdates := map[string]interface{}{}
+			if req.QuarantineIncidentDetails != nil {
+				incidentUpdates["incident_details"] = *req.QuarantineIncidentDetails
+			}
+			if midBQStartDate != nil {
+				incidentUpdates["start_date"] = *midBQStartDate
+			}
+			if len(incidentUpdates) > 0 {
+				if err := db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
+					Where("animal_id = ? AND end_date IS NULL", animal.ID).
+					Updates(incidentUpdates).Error; err != nil {
+					// Log error but don't fail the update
+					c.Error(err)
+				}
+			}
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -288,6 +288,11 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if animal.Status == "bite_quarantine" {
+			db.WithContext(ctx).Create(&models.AnimalBQIncident{
+				AnimalID:        animal.ID,
+				IncidentDetails: animal.QuarantineIncidentDetails,
+				StartDate:       *animal.QuarantineStartDate,
+			})
 			sendQuarantineNotificationEmail(db, emailService, &animal)
 		}
 
@@ -370,6 +375,8 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		newStatus := req.Status
 		now := time.Now()
 		enteredQuarantine := false
+		leftQuarantine := newStatus != "" && newStatus != oldStatus && oldStatus == "bite_quarantine"
+		midBQEdit := false
 		if newStatus != "" && newStatus != oldStatus {
 			animal.LastStatusChange = &now
 			enteredQuarantine = newStatus == "bite_quarantine" && oldStatus != "bite_quarantine"
@@ -435,6 +442,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 			}
 			animal.Status = newStatus
 		} else if animal.Status == "bite_quarantine" {
+			midBQEdit = true
 			// Update approval status only when explicitly provided (nil = not sent = no change)
 			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != animal.QuarantineApprovalStatus {
 				if *req.QuarantineApprovalStatus == "" {
@@ -496,7 +504,22 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		}
 
 		if enteredQuarantine {
+			db.WithContext(ctx).Create(&models.AnimalBQIncident{
+				AnimalID:        animal.ID,
+				IncidentDetails: animal.QuarantineIncidentDetails,
+				StartDate:       *animal.QuarantineStartDate,
+			})
 			sendQuarantineNotificationEmail(db, emailService, &animal)
+		}
+		if leftQuarantine {
+			db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
+				Where("animal_id = ? AND end_date IS NULL", animal.ID).
+				Update("end_date", now)
+		}
+		if midBQEdit && req.QuarantineIncidentDetails != nil {
+			db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
+				Where("animal_id = ? AND end_date IS NULL", animal.ID).
+				Update("incident_details", *req.QuarantineIncidentDetails)
 		}
 
 		// If an image_url was provided, link any unlinked images with this URL to this animal

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -180,7 +180,7 @@ func GetAnimal(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		var animal models.Animal
-		if err := db.WithContext(ctx).Preload("Tags").Preload("NameHistory").Preload("Scripts").Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
+		if err := db.WithContext(ctx).Preload("Tags").Preload("NameHistory").Preload("Scripts").Preload("BQIncidents", "end_date IS NOT NULL").Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
 			return
 		}

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -166,6 +166,184 @@ func TestUpdateAnimal_LeaveQuarantine_ClearsIncident(t *testing.T) {
 	}
 }
 
+// TestCreateAnimal_BQEntry_CreatesIncidentRow verifies that creating an animal
+// directly in bite_quarantine writes an AnimalBQIncident row.
+func TestCreateAnimal_BQEntry_CreatesIncidentRow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+
+	details := "Bit a volunteer."
+	reqBody := AnimalRequest{
+		Name:                      "Rex",
+		Species:                   "Dog",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("end_date IS NULL").First(&incident).Error; err != nil {
+		t.Fatalf("Expected an active AnimalBQIncident row, got none: %v", err)
+	}
+	if incident.IncidentDetails != "Bit a volunteer." {
+		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Bit a volunteer.")
+	}
+}
+
+// TestUpdateAnimal_BQEntry_CreatesIncidentRow verifies that transitioning an
+// animal to bite_quarantine writes an AnimalBQIncident row.
+func TestUpdateAnimal_BQEntry_CreatesIncidentRow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	details := "Bit a volunteer."
+	reqBody := AnimalRequest{
+		Name:                      "Rex",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &details,
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("Expected an active AnimalBQIncident row: %v", err)
+	}
+	if incident.IncidentDetails != "Bit a volunteer." {
+		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Bit a volunteer.")
+	}
+}
+
+// TestUpdateAnimal_BQExit_StampsEndDate verifies that leaving bite_quarantine
+// stamps EndDate on the active AnimalBQIncident row.
+func TestUpdateAnimal_BQExit_StampsEndDate(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Seed animal in BQ with an active incident row.
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Bit a volunteer.",
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Bit a volunteer.",
+		StartDate:       animal.CreatedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	reqBody := AnimalRequest{Name: "Rex", Status: "available"}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil {
+		t.Error("Expected EndDate to be stamped after leaving BQ, got nil")
+	}
+}
+
+// TestUpdateAnimal_MidBQ_UpdatesIncidentDetails verifies that editing incident
+// details while already in bite_quarantine updates the active incident row.
+func TestUpdateAnimal_MidBQ_UpdatesIncidentDetails(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Seed animal in BQ with an active incident row.
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                      "bite_quarantine",
+		"quarantine_incident_details": "Original details.",
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Original details.",
+		StartDate:       animal.CreatedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updated := "Updated details."
+	reqBody := AnimalRequest{
+		Name:                      "Rex",
+		Status:                    "bite_quarantine",
+		QuarantineIncidentDetails: &updated,
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.IncidentDetails != "Updated details." {
+		t.Errorf("IncidentDetails = %q, want %q", incident.IncidentDetails, "Updated details.")
+	}
+}
+
 // TestCreateAnimal_BiteQuarantine_StoresIncidentDetails verifies that creating
 // an animal directly with status "bite_quarantine" stores the provided
 // incident details.

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -386,3 +386,55 @@ func TestCreateAnimal_BiteQuarantine_StoresIncidentDetails(t *testing.T) {
 		t.Errorf("incident not stored on create: %q", got.QuarantineIncidentDetails)
 	}
 }
+
+// TestGetAnimal_ReturnsBQHistory verifies that ended BQ episodes are
+// returned in the bq_incidents field of the animal detail response.
+func TestGetAnimal_ReturnsBQHistory(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	// Create an ended BQ incident.
+	endDate := animal.CreatedAt.Add(10 * 24 * time.Hour)
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Bit a volunteer.",
+		StartDate:       animal.CreatedAt,
+		EndDate:         &endDate,
+	}).Error; err != nil {
+		t.Fatalf("seed ended incident: %v", err)
+	}
+	// Also create an active one that must NOT appear.
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Active, no end.",
+		StartDate:       endDate,
+	}).Error; err != nil {
+		t.Fatalf("seed active incident: %v", err)
+	}
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	handler := GetAnimal(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var got models.Animal
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(got.BQIncidents) != 1 {
+		t.Fatalf("Expected 1 ended BQ incident in response, got %d", len(got.BQIncidents))
+	}
+	if got.BQIncidents[0].IncidentDetails != "Bit a volunteer." {
+		t.Errorf("IncidentDetails = %q, want %q", got.BQIncidents[0].IncidentDetails, "Bit a volunteer.")
+	}
+}

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -438,3 +438,61 @@ func TestGetAnimal_ReturnsBQHistory(t *testing.T) {
 		t.Errorf("IncidentDetails = %q, want %q", got.BQIncidents[0].IncidentDetails, "Bit a volunteer.")
 	}
 }
+
+// TestUpdateAnimal_MidBQ_EditStartDate_SyncsIncidentRow verifies that editing
+// the quarantine start date while still in BQ updates the active incident
+// row's StartDate, so the permanent history stays accurate.
+func TestUpdateAnimal_MidBQ_EditStartDate_SyncsIncidentRow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	originalStart := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": originalStart,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:        animal.ID,
+		IncidentDetails: "Original details.",
+		StartDate:       originalStart,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	correctedStart := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
+	reqBody := AnimalRequest{
+		Name:   "Rex",
+		Status: "bite_quarantine",
+		QuarantineStartDate: NullableTime{
+			Time:  &correctedStart,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ? AND end_date IS NULL", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if !incident.StartDate.Equal(correctedStart) {
+		t.Errorf("StartDate = %v, want %v", incident.StartDate, correctedStart)
+	}
+}

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -40,6 +40,7 @@ func setupAnimalTestDB(t *testing.T) *gorm.DB {
 		&models.Animal{},
 		&models.AnimalTag{},
 		&models.AnimalNameHistory{},
+		&models.AnimalBQIncident{},
 		&models.AnimalImage{},
 		&models.AnimalVideo{},
 	)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -105,6 +105,7 @@ type Animal struct {
 	ProtocolDocumentBlobExtension  string              `json:"-"`                                                               // File extension (e.g., ".pdf", ".docx") for blob storage
 	Tags                           []AnimalTag         `gorm:"many2many:animal_animal_tags;" json:"tags,omitempty"`             // Tags associated with this animal
 	NameHistory                    []AnimalNameHistory `gorm:"foreignKey:AnimalID" json:"name_history,omitempty"`               // History of name changes for this animal
+	BQIncidents                    []AnimalBQIncident  `gorm:"foreignKey:AnimalID" json:"bq_incidents,omitempty"`               // Bite-quarantine incidents for this animal
 	Images                         []AnimalImage       `gorm:"foreignKey:AnimalID" json:"images,omitempty"`                     // Images uploaded for this animal
 	Scripts                        []Script            `gorm:"many2many:animal_scripts;" json:"scripts,omitempty"`              // Scripts linked to this animal's protocol
 }
@@ -439,6 +440,17 @@ type AnimalNameHistory struct {
 	OldName   string    `gorm:"not null" json:"old_name"`
 	NewName   string    `gorm:"not null" json:"new_name"`
 	ChangedBy uint      `gorm:"not null" json:"changed_by"` // User ID who made the change
+}
+
+// AnimalBQIncident records one bite-quarantine episode for an animal.
+// EndDate is nil while the episode is active; it is stamped when the animal leaves BQ.
+type AnimalBQIncident struct {
+	ID              uint       `gorm:"primaryKey" json:"id"`
+	CreatedAt       time.Time  `json:"created_at"`
+	AnimalID        uint       `gorm:"not null;index" json:"animal_id"`
+	IncidentDetails string     `json:"incident_details"`
+	StartDate       time.Time  `gorm:"not null" json:"start_date"`
+	EndDate         *time.Time `json:"end_date"`
 }
 
 // UserGroup represents the many-to-many relationship between users and groups


### PR DESCRIPTION
## Summary

- Adds `animal_bq_incidents` table to permanently record each bite-quarantine episode (incident details, start date, end date)
- Both handler paths (`animal_crud.go` group-admin and `animal_admin.go` site-admin) create a row on BQ entry, update `incident_details` on mid-BQ edits, and stamp `end_date` when the animal leaves BQ
- `GetAnimal` preloads ended episodes; frontend shows a collapsible **BQ History** section on the animal detail page (newest-first, only visible when history exists)
- Fixes misleading form helper text: "saved as a behavior comment" → "saved to the animal's BQ history"

## Motivation

Previously, `quarantine_incident_details` was cleared from the animal record when BQ ended — no permanent record survived. Mid-BQ edits to the field only updated the live display text; no comment or history entry was ever written (despite what the form said). This PR closes that gap.

## Test plan

- [ ] Place an animal in bite quarantine — verify a row appears in `animal_bq_incidents`
- [ ] Edit incident details while animal is still in BQ — verify the row updates
- [ ] Move animal back to available — verify `end_date` is stamped on the row and the animal detail page shows a "Bite Quarantine History" section
- [ ] Confirm the history section is absent for animals with no past BQ episodes
- [ ] Run `make test` — all BQ-related tests pass (8 new tests across `animal_crud_email_test.go` and `animal_admin_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)