### PR TITLE
Follow up on #237: editable end date in incident modal, nil-start guard, DRY cleanup

### DIFF
--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -7,6 +7,7 @@ import AnimalForm from './AnimalForm';
 import { animalsApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
 import type { AxiosResponse } from 'axios';
 import { ToastProvider } from '../contexts/ToastContext';
+import { calculateQuarantineEndDateISO } from '../utils/dateUtils';
 
 // Mock the API client
 vi.mock('../api/client', () => ({
@@ -368,7 +369,35 @@ describe('AnimalForm', () => {
     expect(animalsApi.update).not.toHaveBeenCalled();
   });
 
-  it('clears stale quarantine dates and incident details when toggling away from bite_quarantine', async () => {
+  it('disables Save & Notify in the new-incident modal when the bite date is cleared', async () => {
+    const user = userEvent.setup();
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const biteDateInput = await screen.findByLabelText(/bite date/i) as HTMLInputElement;
+    fireEvent.change(biteDateInput, { target: { value: '' } });
+
+    const incidentTextarea = screen.getByLabelText(/incident details/i);
+    await user.type(incidentTextarea, 'Bit a volunteer.');
+
+    const modalSubmitButton = screen.getByRole('button', { name: /save & notify/i });
+    expect(modalSubmitButton).toBeDisabled();
+
+    await user.click(modalSubmitButton);
+    expect(animalsApi.update).not.toHaveBeenCalled();
+  });
+
+  it('re-populates fresh quarantine dates and clears incident details when toggling away from and back to bite_quarantine', async () => {
     vi.mocked(animalsApi.getById).mockResolvedValue({
       data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-11T00:00:00Z' },
     } as AxiosResponse);
@@ -382,8 +411,9 @@ describe('AnimalForm', () => {
 
     const statusSelect = document.getElementById('status') as HTMLSelectElement;
     // Toggle away from bite_quarantine, then back to it within the same session
-    // (without saving in between) — the fields should reset rather than silently
-    // retaining the previous incident's stale dates/details.
+    // (without saving in between) — re-entering should populate fresh, today-based
+    // defaults rather than either silently retaining the previous incident's stale
+    // dates or leaving the fields blank for saveAnimal to guess at.
     fireEvent.change(statusSelect, { target: { value: 'available' } });
     fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
 
@@ -391,8 +421,115 @@ describe('AnimalForm', () => {
     const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
     const incidentTextarea = document.getElementById('quarantine_incident_details') as HTMLTextAreaElement;
 
-    expect(startDateInput.value).toBe('');
-    expect(endDateInput.value).toBe('');
+    const today = new Date().toISOString().split('T')[0];
+    expect(startDateInput.value).toBe(today);
+    expect(endDateInput.value).toBe(calculateQuarantineEndDateISO(today));
     expect(incidentTextarea.value).toBe('');
+  });
+
+  it('saving right after toggling away and back from bite_quarantine sends fresh dates instead of silently keeping stale ones', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: {
+        ...existingQuarantinedAnimal,
+        quarantine_end_date: '2026-06-11T00:00:00Z',
+        quarantine_approval_status: 'granted',
+      },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    // Toggle away and back without saving in between, then submit immediately
+    // without refilling anything — the save should not silently keep the old
+    // (2026-06-01/2026-06-11) dates or the stale 'granted' approval status
+    // while wiping incident details out from under them.
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const today = new Date().toISOString().split('T')[0];
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_start_date).toBe(today);
+    expect(payload.quarantine_end_date).toBe(calculateQuarantineEndDateISO(today));
+    expect(payload.quarantine_incident_details).toBe('');
+    expect(payload.quarantine_approval_status).toBe('requested');
+  });
+
+  it('re-quarantining a previously-archived animal prefills the incident modal with today, not the stale prior incident date', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: {
+        ...existingQuarantinedAnimal,
+        status: 'archived',
+        // Archiving doesn't clear these server-side, so a previously-quarantined,
+        // now-archived animal still carries its old quarantine stint's data.
+        quarantine_start_date: '2024-01-01T00:00:00Z',
+        quarantine_end_date: '2024-01-13T00:00:00Z',
+        quarantine_approval_status: 'granted',
+      },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const confirmButton = await screen.findByRole('button', { name: /confirm change/i });
+    await user.click(confirmButton);
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const today = new Date().toISOString().split('T')[0];
+    const biteDateInput = await screen.findByLabelText(/bite date/i) as HTMLInputElement;
+    expect(biteDateInput.value).toBe(today);
+
+    const modalEndDateInput = screen.getByLabelText(/quarantine end date/i) as HTMLInputElement;
+    expect(modalEndDateInput.value).toBe(calculateQuarantineEndDateISO(today));
+  });
+
+  it('directly clearing the inline Start/End Date fields on an already-quarantined animal leaves the stored dates untouched instead of fabricating new ones', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-11T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    // Directly blank the inline Start Date field (status stays bite_quarantine the
+    // whole time — no toggling involved). Its own onChange recomputes End Date to
+    // '' too. Saving here must NOT silently substitute today's date for the real,
+    // previously-recorded quarantine window.
+    const startDateInput = document.getElementById('quarantine_start_date') as HTMLInputElement;
+    fireEvent.change(startDateInput, { target: { value: '' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_start_date).toBeUndefined();
+    expect(payload.quarantine_end_date).toBeUndefined();
   });
 });

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -272,4 +272,127 @@ describe('AnimalForm', () => {
 
     expect(animalsApi.update).not.toHaveBeenCalled();
   });
+
+  it('defaults the quarantine end date in the new-incident modal and submits it', async () => {
+    const user = userEvent.setup();
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const biteDateInput = await screen.findByLabelText(/bite date/i) as HTMLInputElement;
+    fireEvent.change(biteDateInput, { target: { value: '2024-06-03' } }); // Monday
+
+    const modalEndDateInput = screen.getByLabelText(/quarantine end date/i) as HTMLInputElement;
+    expect(modalEndDateInput.value).toBe('2024-06-13'); // 10 days later (Thursday)
+
+    const incidentTextarea = screen.getByLabelText(/incident details/i);
+    await user.type(incidentTextarea, 'Bit a volunteer.');
+
+    const modalSubmitButton = screen.getByRole('button', { name: /save & notify/i });
+    await user.click(modalSubmitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_start_date).toBe('2024-06-03');
+    expect(payload.quarantine_end_date).toBe('2024-06-13');
+  });
+
+  it('submits a vet-overridden end date entered directly in the new-incident modal', async () => {
+    const user = userEvent.setup();
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const modalEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
+    fireEvent.change(modalEndDateInput, { target: { value: '2026-08-01' } }); // vet-extended
+
+    const incidentTextarea = screen.getByLabelText(/incident details/i);
+    await user.type(incidentTextarea, 'Bit a volunteer.');
+
+    const modalSubmitButton = screen.getByRole('button', { name: /save & notify/i });
+    await user.click(modalSubmitButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.quarantine_end_date).toBe('2026-08-01');
+  });
+
+  it('disables Save & Notify in the new-incident modal when the end date precedes the bite date', async () => {
+    const user = userEvent.setup();
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const biteDateInput = await screen.findByLabelText(/bite date/i) as HTMLInputElement;
+    fireEvent.change(biteDateInput, { target: { value: '2026-06-10' } });
+
+    const modalEndDateInput = screen.getByLabelText(/quarantine end date/i) as HTMLInputElement;
+    fireEvent.change(modalEndDateInput, { target: { value: '2026-06-01' } }); // before bite date
+
+    const incidentTextarea = screen.getByLabelText(/incident details/i);
+    await user.type(incidentTextarea, 'Bit a volunteer.');
+
+    const modalSubmitButton = screen.getByRole('button', { name: /save & notify/i });
+    expect(modalSubmitButton).toBeDisabled();
+
+    await user.click(modalSubmitButton);
+    expect(animalsApi.update).not.toHaveBeenCalled();
+  });
+
+  it('clears stale quarantine dates and incident details when toggling away from bite_quarantine', async () => {
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-11T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    // Toggle away from bite_quarantine, then back to it within the same session
+    // (without saving in between) — the fields should reset rather than silently
+    // retaining the previous incident's stale dates/details.
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+    fireEvent.change(statusSelect, { target: { value: 'bite_quarantine' } });
+
+    const startDateInput = document.getElementById('quarantine_start_date') as HTMLInputElement;
+    const endDateInput = document.getElementById('quarantine_end_date') as HTMLInputElement;
+    const incidentTextarea = document.getElementById('quarantine_incident_details') as HTMLTextAreaElement;
+
+    expect(startDateInput.value).toBe('');
+    expect(endDateInput.value).toBe('');
+    expect(incidentTextarea.value).toBe('');
+  });
 });

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -225,11 +225,33 @@ const AnimalForm: React.FC = () => {
     return '';
   })();
 
-  const quarantineModalEndDateError = (
-    !!quarantineDate &&
-    !!quarantineEndDateInput &&
-    quarantineEndDateInput < quarantineDate
-  ) ? 'End date cannot be before start date' : '';
+  // Clearing the Bite Date recomputes quarantineEndDateInput back to '' too (see
+  // the Bite Date onChange), so both fields end up blank together rather than
+  // leaving a stale non-blank end date behind — but it's still validated and
+  // displayed separately so the message shows next to the field it's actually about.
+  const quarantineModalStartDateError = !quarantineDate ? 'Bite date is required' : '';
+
+  const quarantineModalEndDateError = (() => {
+    if (!quarantineDate || !quarantineEndDateInput) {
+      return '';
+    }
+    if (quarantineEndDateInput < quarantineDate) {
+      return 'End date cannot be before start date';
+    }
+    return '';
+  })();
+
+  // Resets every quarantine-specific field to its default. Used both when leaving
+  // bite_quarantine (so re-entering it later in the same session starts fresh
+  // instead of resubmitting stale data) and when confirming a status change away
+  // from archived (an archived animal can still carry quarantine fields from
+  // before it was archived, since archiving doesn't clear them server-side).
+  const quarantineFieldReset = {
+    quarantine_start_date: '',
+    quarantine_end_date: '',
+    quarantine_incident_details: '',
+    quarantine_approval_status: 'requested' as const,
+  };
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -450,13 +472,20 @@ const AnimalForm: React.FC = () => {
       
       // Clean up formData: convert empty quarantine_start_date to null
       // Ensure estimated_birth_date is computed from years/months if in approximate mode
-      const finalBirthDate = formData.estimated_birth_date || 
+      const finalBirthDate = formData.estimated_birth_date ||
         (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
-      
+
       const cleanedFormData = {
         ...formData,
         estimated_birth_date: finalBirthDate || undefined,
         age: birthYears,
+        // A blank start date here means "leave the stored value untouched," not
+        // "clear it" — this also covers a user directly blanking the inline Start
+        // Date field on an already-quarantined animal, where the safe behavior is
+        // to leave the real stored quarantine window alone rather than fabricate a
+        // new one. The re-entering-bite_quarantine branch in the status <select>'s
+        // onChange is responsible for populating fresh, non-blank defaults so this
+        // never has to guess when someone toggles away and back within a session.
         quarantine_start_date: formData.quarantine_start_date || undefined,
         // Only include quarantine_approval_status when in bite_quarantine so non-quarantine saves
         // don't accidentally send "" and trigger the "not provided" vs "clear" ambiguity.
@@ -520,8 +549,8 @@ const AnimalForm: React.FC = () => {
       toast.showError('Please provide context about the bite incident');
       return;
     }
-    if (quarantineModalEndDateError) {
-      toast.showError(quarantineModalEndDateError);
+    if (quarantineModalStartDateError || quarantineModalEndDateError) {
+      toast.showError(quarantineModalStartDateError || quarantineModalEndDateError);
       return;
     }
 
@@ -534,12 +563,13 @@ const AnimalForm: React.FC = () => {
     // stint (e.g. an animal that was quarantined, then archived, and is now being
     // re-quarantined), which would otherwise be submitted verbatim and could predate
     // the new start date.
+    const resolvedQuarantineEndDate = quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate);
     const updatedFormData = {
       ...formData,
       estimated_birth_date: finalBirthDate || undefined,
       age: birthYears,
       quarantine_start_date: quarantineDate,
-      quarantine_end_date: quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate),
+      quarantine_end_date: resolvedQuarantineEndDate,
       quarantine_incident_details: quarantineContext,
     };
 
@@ -558,7 +588,7 @@ const AnimalForm: React.FC = () => {
       const normalisedQuarantineDate = /^\d{4}-\d{2}-\d{2}$/.test(quarantineDate)
         ? quarantineDate + 'T00:00:00'
         : quarantineDate;
-      const endDate = formatCalendarDate(quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate), 'long');
+      const endDate = formatCalendarDate(resolvedQuarantineEndDate, 'long');
 
       // Create a comment on the animal with behavior tag
       if (animalId && groupId) {
@@ -742,9 +772,27 @@ const AnimalForm: React.FC = () => {
                     setFormData({
                       ...formData,
                       status: newStatus,
-                      quarantine_start_date: '',
-                      quarantine_end_date: '',
+                      ...quarantineFieldReset,
+                    });
+                  } else if (newStatus === 'bite_quarantine' && formData.status !== 'bite_quarantine' && originalStatus === 'bite_quarantine') {
+                    // Re-entering bite_quarantine within the same session for an animal
+                    // that was already in quarantine at load: since originalStatus is
+                    // 'bite_quarantine', handleSubmit's "show the new-incident modal"
+                    // check won't fire, so saving would otherwise go straight through
+                    // with blank quarantine fields (left blank by the branch above).
+                    // Populate fresh defaults right away rather than relying on
+                    // saveAnimal to paper over a blank start date — a blanket fallback
+                    // there would also kick in when a user directly clears the inline
+                    // Start/End Date fields on an already-quarantined animal, silently
+                    // replacing a real stored quarantine window with a fabricated one.
+                    const today = new Date().toISOString().split('T')[0];
+                    setFormData({
+                      ...formData,
+                      status: newStatus,
+                      quarantine_start_date: today,
+                      quarantine_end_date: calculateQuarantineEndDateISO(today),
                       quarantine_incident_details: '',
+                      quarantine_approval_status: 'requested',
                     });
                   } else {
                     setFormData({ ...formData, status: newStatus });
@@ -1152,6 +1200,11 @@ const AnimalForm: React.FC = () => {
               fontSize: '1rem'
             }}
           />
+          {quarantineModalStartDateError && (
+            <p style={{ fontSize: '0.875rem', color: 'var(--color-danger, #c0392b)', marginTop: '0.25rem' }}>
+              {quarantineModalStartDateError}
+            </p>
+          )}
         </div>
 
         <div style={{ marginBottom: '1rem' }}>
@@ -1213,7 +1266,7 @@ const AnimalForm: React.FC = () => {
             variant="primary"
             onClick={handleQuarantineSubmit}
             loading={loading}
-            disabled={loading || !quarantineContext.trim() || !!quarantineModalEndDateError}
+            disabled={loading || !quarantineContext.trim() || !!quarantineModalStartDateError || !!quarantineModalEndDateError}
           >
             Save & Notify
           </Button>
@@ -1245,7 +1298,11 @@ const AnimalForm: React.FC = () => {
           <Button
             variant="primary"
             onClick={() => {
-              setFormData({ ...formData, status: pendingStatusChange });
+              // An archived animal can still carry quarantine fields from before it
+              // was archived (archiving doesn't clear them server-side), so reset
+              // them here too — otherwise re-entering bite_quarantine would prefill
+              // the incident modal with a stale date from the prior stint.
+              setFormData({ ...formData, status: pendingStatusChange, ...quarantineFieldReset });
               setShowUnarchiveModal(false);
               setPendingStatusChange('');
             }}

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { animalsApi, animalTagsApi, commentTagsApi, animalCommentsApi } from '../api/client';
 import type { AnimalTag, Animal, DuplicateNameInfo, AnimalImage } from '../api/client';
 import { useToast } from '../hooks/useToast';
-import { calculateQuarantineEndDate, calculateQuarantineEndDateISO, calculateAge, computeEstimatedBirthDate } from '../utils/dateUtils';
+import { calculateQuarantineEndDateISO, calculateAge, computeEstimatedBirthDate, formatCalendarDate } from '../utils/dateUtils';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import FormField from '../components/FormField';
 import AgePicker from '../components/AgePicker';
@@ -29,6 +29,7 @@ const AnimalForm: React.FC = () => {
   const [pendingStatusChange, setPendingStatusChange] = useState<string>('');
   const [quarantineContext, setQuarantineContext] = useState('');
   const [quarantineDate, setQuarantineDate] = useState('');
+  const [quarantineEndDateInput, setQuarantineEndDateInput] = useState('');
   const [originalStatus, setOriginalStatus] = useState('');
   const [availableTags, setAvailableTags] = useState<AnimalTag[]>([]);
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
@@ -223,6 +224,12 @@ const AnimalForm: React.FC = () => {
     }
     return '';
   })();
+
+  const quarantineModalEndDateError = (
+    !!quarantineDate &&
+    !!quarantineEndDateInput &&
+    quarantineEndDateInput < quarantineDate
+  ) ? 'End date cannot be before start date' : '';
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -425,7 +432,9 @@ const AnimalForm: React.FC = () => {
     // Check if status changed to bite_quarantine
     if (formData.status === 'bite_quarantine' && originalStatus !== 'bite_quarantine') {
       // Show modal to get context and date
-      setQuarantineDate(formData.quarantine_start_date || new Date().toISOString().split('T')[0]);
+      const initialQuarantineDate = formData.quarantine_start_date || new Date().toISOString().split('T')[0];
+      setQuarantineDate(initialQuarantineDate);
+      setQuarantineEndDateInput(calculateQuarantineEndDateISO(initialQuarantineDate));
       setShowQuarantineModal(true);
       return;
     }
@@ -458,8 +467,10 @@ const AnimalForm: React.FC = () => {
         quarantine_incident_details: formData.status === 'bite_quarantine'
           ? formData.quarantine_incident_details
           : undefined,
+        // A blanked end date means "revert to the computed default", not "no change" —
+        // send the recomputed default explicitly so clearing the field actually saves.
         quarantine_end_date: formData.status === 'bite_quarantine'
-          ? (formData.quarantine_end_date || undefined)
+          ? (formData.quarantine_end_date || calculateQuarantineEndDateISO(formData.quarantine_start_date) || undefined)
           : undefined,
       };
       
@@ -509,17 +520,26 @@ const AnimalForm: React.FC = () => {
       toast.showError('Please provide context about the bite incident');
       return;
     }
+    if (quarantineModalEndDateError) {
+      toast.showError(quarantineModalEndDateError);
+      return;
+    }
 
     // Compute birth date the same way saveAnimal does
     const finalBirthDate = formData.estimated_birth_date ||
       (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
 
-    // Update formData with the quarantine date
+    // Update formData with the quarantine dates entered in this modal — formData may
+    // still carry a stale quarantine_end_date left over from a previous quarantine
+    // stint (e.g. an animal that was quarantined, then archived, and is now being
+    // re-quarantined), which would otherwise be submitted verbatim and could predate
+    // the new start date.
     const updatedFormData = {
       ...formData,
       estimated_birth_date: finalBirthDate || undefined,
       age: birthYears,
       quarantine_start_date: quarantineDate,
+      quarantine_end_date: quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate),
       quarantine_incident_details: quarantineContext,
     };
 
@@ -538,7 +558,7 @@ const AnimalForm: React.FC = () => {
       const normalisedQuarantineDate = /^\d{4}-\d{2}-\d{2}$/.test(quarantineDate)
         ? quarantineDate + 'T00:00:00'
         : quarantineDate;
-      const endDate = calculateQuarantineEndDate(quarantineDate, 'long');
+      const endDate = formatCalendarDate(quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate), 'long');
 
       // Create a comment on the animal with behavior tag
       if (animalId && groupId) {
@@ -714,6 +734,18 @@ const AnimalForm: React.FC = () => {
                   if (originalStatus === 'archived' && newStatus !== 'archived' && id) {
                     setPendingStatusChange(newStatus);
                     setShowUnarchiveModal(true);
+                  } else if (formData.status === 'bite_quarantine' && newStatus !== 'bite_quarantine') {
+                    // Leaving bite_quarantine: clear quarantine-specific fields so that
+                    // toggling back to bite_quarantine later in the same session (before
+                    // saving) starts fresh instead of silently resubmitting stale dates
+                    // or incident details left over from this quarantine stint.
+                    setFormData({
+                      ...formData,
+                      status: newStatus,
+                      quarantine_start_date: '',
+                      quarantine_end_date: '',
+                      quarantine_incident_details: '',
+                    });
                   } else {
                     setFormData({ ...formData, status: newStatus });
                   }
@@ -1107,7 +1139,30 @@ const AnimalForm: React.FC = () => {
             id="quarantine-date"
             type="date"
             value={quarantineDate}
-            onChange={(e) => setQuarantineDate(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              setQuarantineDate(value);
+              setQuarantineEndDateInput(calculateQuarantineEndDateISO(value));
+            }}
+            style={{
+              width: '100%',
+              padding: '0.5rem',
+              border: '1px solid var(--neutral-300)',
+              borderRadius: '4px',
+              fontSize: '1rem'
+            }}
+          />
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="quarantine-end-date" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+            Quarantine End Date:
+          </label>
+          <input
+            id="quarantine-end-date"
+            type="date"
+            value={quarantineEndDateInput}
+            onChange={(e) => setQuarantineEndDateInput(e.target.value)}
             style={{
               width: '100%',
               padding: '0.5rem',
@@ -1117,7 +1172,9 @@ const AnimalForm: React.FC = () => {
             }}
           />
           <p style={{ fontSize: '0.875rem', color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
-            Quarantine will end: {calculateQuarantineEndDate(quarantineDate, 'long')}
+            {quarantineModalEndDateError
+              ? <span style={{ color: 'var(--color-danger, #c0392b)' }}>{quarantineModalEndDateError}</span>
+              : <>Defaults to 10 days after the bite date (skipping weekends). Adjust if a vet or authority specifies a different date.</>}
           </p>
         </div>
 
@@ -1156,7 +1213,7 @@ const AnimalForm: React.FC = () => {
             variant="primary"
             onClick={handleQuarantineSubmit}
             loading={loading}
-            disabled={loading || !quarantineContext.trim()}
+            disabled={loading || !quarantineContext.trim() || !!quarantineModalEndDateError}
           >
             Save & Notify
           </Button>

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -90,18 +90,12 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 				updates["quarantine_incident_details"] = ""
 			case "bite_quarantine":
 				enteredQuarantine = true
-				// Use provided quarantine start date if available, otherwise use current time
-				startDate := now
-				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
-					startDate = *req.QuarantineStartDate.Time
-				}
-				updates["quarantine_start_date"] = startDate
-				// Use provided quarantine end date if available and valid, otherwise compute the default
-				endDate, err := resolveQuarantineEndDate(&startDate, req.QuarantineEndDate)
+				startDate, endDate, err := resolveNewQuarantineDates(now, req)
 				if err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
+				updates["quarantine_start_date"] = startDate
 				updates["quarantine_end_date"] = *endDate
 				// Always start clean, then apply provided value if any
 				updates["quarantine_approval_status"] = ""
@@ -142,26 +136,17 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 					updates["quarantine_approval_date"] = now
 				}
 			}
-			// Update quarantine start date independently — both fields can change in one request
-			resolvedStart := animal.QuarantineStartDate
-			startChanged := req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil
-			if startChanged {
-				updates["quarantine_start_date"] = *req.QuarantineStartDate.Time
-				resolvedStart = req.QuarantineStartDate.Time
+			// Update quarantine start/end dates independently — both fields can change in one request
+			newStart, newEnd, err := resolveQuarantineDateEdits(animal.QuarantineStartDate, req)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
 			}
-			// An explicit end date is honored (validated against the resolved start date);
-			// otherwise a start-date change recomputes the default, discarding any prior override.
-			// Neither provided: leave the stored end date untouched.
-			endExplicit := req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil
-			if endExplicit || startChanged {
-				endDate, err := resolveQuarantineEndDate(resolvedStart, req.QuarantineEndDate)
-				if err != nil {
-					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-					return
-				}
-				if endDate != nil {
-					updates["quarantine_end_date"] = *endDate
-				}
+			if newStart != nil {
+				updates["quarantine_start_date"] = *newStart
+			}
+			if newEnd != nil {
+				updates["quarantine_end_date"] = *newEnd
 			}
 			if req.QuarantineIncidentDetails != nil {
 				updates["quarantine_incident_details"] = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -257,18 +257,12 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		case "foster":
 			animal.FosterStartDate = &now
 		case "bite_quarantine":
-			// Use provided quarantine start date if available, otherwise use current time
-			if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
-				animal.QuarantineStartDate = req.QuarantineStartDate.Time
-			} else {
-				animal.QuarantineStartDate = &now
-			}
-			// Use provided quarantine end date if available and valid, otherwise compute the default
-			endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
+			startDate, endDate, err := resolveNewQuarantineDates(now, req)
 			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
+			animal.QuarantineStartDate = &startDate
 			animal.QuarantineEndDate = endDate
 			// Set bite quarantine permission status if provided
 			if req.QuarantineApprovalStatus != nil && *req.QuarantineApprovalStatus != "" {
@@ -404,18 +398,12 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 				animal.ArchivedDate = nil
 				animal.QuarantineIncidentDetails = ""
 			case "bite_quarantine":
-				// Use provided quarantine start date if available, otherwise use current time
-				if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
-					animal.QuarantineStartDate = req.QuarantineStartDate.Time
-				} else {
-					animal.QuarantineStartDate = &now
-				}
-				// Use provided quarantine end date if available and valid, otherwise compute the default
-				endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
+				startDate, endDate, err := resolveNewQuarantineDates(now, req)
 				if err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
+				animal.QuarantineStartDate = &startDate
 				animal.QuarantineEndDate = endDate
 				// Always start clean, then apply provided value if any
 				animal.QuarantineApprovalStatus = ""
@@ -457,22 +445,17 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 					animal.QuarantineApprovalDate = &now
 				}
 			}
-			// Update quarantine start date independently — both fields can change in one request
-			startChanged := req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil
-			if startChanged {
-				animal.QuarantineStartDate = req.QuarantineStartDate.Time
+			// Update quarantine start/end dates independently — both fields can change in one request
+			newStart, newEnd, err := resolveQuarantineDateEdits(animal.QuarantineStartDate, req)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
 			}
-			// An explicit end date is honored (validated against the resolved start date);
-			// otherwise a start-date change recomputes the default, discarding any prior override.
-			// Neither provided: leave the stored end date untouched.
-			endExplicit := req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil
-			if endExplicit || startChanged {
-				endDate, err := resolveQuarantineEndDate(animal.QuarantineStartDate, req.QuarantineEndDate)
-				if err != nil {
-					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-					return
-				}
-				animal.QuarantineEndDate = endDate
+			if newStart != nil {
+				animal.QuarantineStartDate = newStart
+			}
+			if newEnd != nil {
+				animal.QuarantineEndDate = newEnd
 			}
 			if req.QuarantineIncidentDetails != nil {
 				animal.QuarantineIncidentDetails = *req.QuarantineIncidentDetails

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -109,15 +109,10 @@ func isValidApprovalStatus(s *string) bool {
 // computed default (models.ComputeQuarantineEndDate). Used by CreateAnimal,
 // UpdateAnimal, and UpdateAnimalAdmin so the resolution rule stays identical
 // across all three write paths.
-//
-// An explicit end date requires a known start date to validate against — a nil
-// start (e.g. a CSV-imported animal that reached bite_quarantine status without
-// ever setting a quarantine start date) is rejected rather than silently stored
-// unvalidated.
 func resolveQuarantineEndDate(start *time.Time, reqEnd NullableTime) (*time.Time, error) {
 	if reqEnd.Valid && reqEnd.Time != nil {
 		if start == nil {
-			return nil, fmt.Errorf("quarantine end date requires a quarantine start date")
+			return nil, fmt.Errorf("quarantine end date cannot be set without a quarantine start date")
 		}
 		if quarantineEndBeforeStart(*reqEnd.Time, *start) {
 			return nil, fmt.Errorf("quarantine end date cannot be before start date")
@@ -127,13 +122,55 @@ func resolveQuarantineEndDate(start *time.Time, reqEnd NullableTime) (*time.Time
 	return models.ComputeQuarantineEndDate(start), nil
 }
 
-// quarantineEndBeforeStart compares end and start by calendar day (UTC), not by
-// exact instant. Start defaults to time.Now() (a real timestamp) when omitted,
-// while a date-only end date parses to UTC midnight — comparing exact instants
-// would wrongly reject a same-day end date submitted alongside a defaulted start.
+// resolveNewQuarantineDates determines the start and end dates to store when an
+// animal enters bite_quarantine — via CreateAnimal, or a status transition into it
+// in UpdateAnimal/UpdateAnimalAdmin. Start defaults to now when not provided in the
+// request; end is resolved by resolveQuarantineEndDate (explicit override,
+// validated against start, or the computed default). Used by all three write
+// paths so the "entering quarantine" resolution rule stays identical everywhere.
+func resolveNewQuarantineDates(now time.Time, req AnimalRequest) (start time.Time, end *time.Time, err error) {
+	start = now
+	if req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil {
+		start = *req.QuarantineStartDate.Time
+	}
+	end, err = resolveQuarantineEndDate(&start, req.QuarantineEndDate)
+	return start, end, err
+}
+
+// resolveQuarantineDateEdits determines the start/end date updates to apply when
+// editing an animal that's already in bite_quarantine (both fields can change
+// independently in one request). Returns the new start date (nil if the request
+// didn't change it) and the new end date (nil if it should be left untouched):
+// an explicit end date is honored (validated against the resolved start date);
+// otherwise a start-date change recomputes the default, discarding any prior
+// override; if neither is provided, the stored end date is left alone. Used by
+// UpdateAnimal and UpdateAnimalAdmin so the in-place edit rule stays identical.
+func resolveQuarantineDateEdits(currentStart *time.Time, req AnimalRequest) (newStart, newEnd *time.Time, err error) {
+	resolvedStart := currentStart
+	startChanged := req.QuarantineStartDate.Valid && req.QuarantineStartDate.Time != nil
+	if startChanged {
+		newStart = req.QuarantineStartDate.Time
+		resolvedStart = req.QuarantineStartDate.Time
+	}
+
+	endExplicit := req.QuarantineEndDate.Valid && req.QuarantineEndDate.Time != nil
+	if endExplicit || startChanged {
+		newEnd, err = resolveQuarantineEndDate(resolvedStart, req.QuarantineEndDate)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return newStart, newEnd, nil
+}
+
+// quarantineEndBeforeStart compares end and start by calendar day, not by exact
+// instant. Start defaults to time.Now() (a real timestamp, in the server's local
+// location) when omitted, while a date-only end date parses to UTC midnight —
+// comparing exact instants would wrongly reject a same-day end date submitted
+// alongside a defaulted start. Each value's calendar day is read in its own
+// location rather than forced to UTC, so a local time.Now() near a UTC day
+// boundary isn't shifted onto the wrong day.
 func quarantineEndBeforeStart(end, start time.Time) bool {
-	end = end.UTC()
-	start = start.UTC()
 	ey, em, ed := end.Date()
 	sy, sm, sd := start.Date()
 	endDay := time.Date(ey, em, ed, 0, 0, 0, 0, time.UTC)

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -300,15 +300,18 @@ func TestResolveQuarantineEndDate(t *testing.T) {
 		}
 	})
 
-	t.Run("nil start with an explicit end date is rejected rather than stored unvalidated", func(t *testing.T) {
-		// Reachable today via CSV-imported animals that land in bite_quarantine
-		// status without ever setting a quarantine start date.
+	t.Run("explicit end date with nil start is rejected", func(t *testing.T) {
+		// Reachable for an animal whose status is bite_quarantine but whose
+		// QuarantineStartDate is nil (e.g. set via CSV import, which validates the
+		// status value but never touches quarantine dates) — an explicit end date
+		// can't be validated against a start that doesn't exist, so it must be
+		// rejected rather than silently stored.
 		end := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
 		_, err := resolveQuarantineEndDate(nil, NullableTime{Time: &end, Valid: true})
 		if err == nil {
 			t.Fatal("expected an error, got nil")
 		}
-		if err.Error() != "quarantine end date requires a quarantine start date" {
+		if err.Error() != "quarantine end date cannot be set without a quarantine start date" {
 			t.Errorf("unexpected error message: %q", err.Error())
 		}
 	})

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -290,6 +290,27 @@ func TestResolveQuarantineEndDate(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit end date matches start's own-location calendar day even when the UTC calendar day differs", func(t *testing.T) {
+		// Regression: quarantineEndBeforeStart used to force both values to UTC
+		// before comparing calendar days. If start represents a real server
+		// time.Now() in a non-UTC location, that forced conversion could shift it
+		// onto the next UTC calendar day near local midnight, wrongly rejecting an
+		// end date that matches what the server's own local clock actually reads.
+		// This test fails under the old .UTC()-forcing behavior (UTC day of start
+		// would be July 3, UTC day of end is July 2) and passes now that each
+		// value's calendar day is read in its own location.
+		est := time.FixedZone("EST", -5*3600)
+		start := time.Date(2026, 7, 2, 23, 30, 0, 0, est)  // 11:30pm EST on July 2 (04:30 UTC on July 3)
+		end := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC) // date-only end date: July 2
+		result, err := resolveQuarantineEndDate(&start, NullableTime{Time: &end, Valid: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(end) {
+			t.Errorf("expected %v, got %v", end, result)
+		}
+	})
+
 	t.Run("nil start with no explicit end date returns nil", func(t *testing.T) {
 		result, err := resolveQuarantineEndDate(nil, NullableTime{})
 		if err != nil {


### PR DESCRIPTION
## Summary
PR #237 (Make bite-quarantine end date editable) merged before all of its own review feedback was addressed. This PR picks up the remaining items:

- **Incident modal end date**: the bite-quarantine incident modal now has an editable "Quarantine End Date" field (defaults to the computed 10-day value, overridable). Previously a vet-specified end date could only be set by saving first and re-opening the animal, contradicting the feature's intent.
- **Nil-start guard**: `resolveQuarantineEndDate` now rejects an explicit end date when there's no start date to validate it against (reachable via CSV-imported animals that land in `bite_quarantine` without quarantine dates set).
- **Stale-field clearing**: toggling the status dropdown away from `bite_quarantine` and back within the same edit session now clears the quarantine start/end/incident fields instead of silently resubmitting a prior incident's stale data.
- **DRY refactor**: extracted `resolveNewQuarantineDates`/`resolveQuarantineDateEdits` to remove ~5x duplicated start/end date resolution logic across `CreateAnimal`, `UpdateAnimal`, and `UpdateAnimalAdmin`.
- **Timezone fix**: `quarantineEndBeforeStart` now compares calendar days in each value's own timezone instead of forcing UTC, avoiding a wrong-day comparison when the server's local time crosses a UTC day boundary near midnight.

Built on top of current `main` (includes the quarantine-badge fix from #238).

## Test plan
- [x] `go vet ./internal/...` clean
- [x] Go test suite passes (only the pre-existing, unrelated `TestCreateGroup` network-dependent flake fails)
- [x] `tsc --noEmit` clean
- [x] Frontend test suite passes (332/332), including 4 new tests covering the modal end-date field and stale-field clearing