### PR TITLE
Fix deleted-comments toggle scoping to the current animal

### DIFF
--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AnimalDetailPage from './AnimalDetailPage';
 import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, authApi } from '../api/client';
-import type { Animal } from '../api/client';
+import type { Animal, AnimalComment } from '../api/client';
 import type { AxiosResponse } from 'axios';
 import { AuthProvider } from '../contexts/AuthContext';
 import { ToastProvider } from '../contexts/ToastContext';
+
+let mockRouteParams = { groupId: '1', id: '1' };
 
 // Mock the API client
 vi.mock('../api/client', () => ({
@@ -34,7 +36,7 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
-    useParams: () => ({ groupId: '1', id: '1' }),
+    useParams: () => mockRouteParams,
   };
 });
 
@@ -57,9 +59,24 @@ const mockAnimal = (overrides: Partial<Animal>) => {
   } as AxiosResponse<Animal>);
 };
 
+const mockDeletedComment = (overrides: Partial<AnimalComment>): AnimalComment => ({
+  id: 1,
+  animal_id: 1,
+  user_id: 1,
+  content: 'deleted comment',
+  image_url: '',
+  is_edited: false,
+  created_at: '2026-06-22T00:00:00Z',
+  updated_at: '2026-06-22T00:00:00Z',
+  deleted_at: '2026-06-23T00:00:00Z',
+  ...overrides,
+});
+
 describe('AnimalDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    mockRouteParams = { groupId: '1', id: '1' };
 
     vi.mocked(authApi.getCurrentUser).mockResolvedValue({
       data: {
@@ -148,5 +165,63 @@ describe('AnimalDetailPage', () => {
     renderDetailPage();
 
     expect(await screen.findByText(/End: June 13, 2024/)).toBeInTheDocument();
+  });
+
+  describe('admin deleted comments scoping', () => {
+    beforeEach(() => {
+      localStorage.setItem('token', 'test-token');
+      vi.mocked(authApi.getCurrentUser).mockResolvedValue({
+        data: {
+          id: 1,
+          username: 'admin',
+          email: 'admin@example.com',
+          phone_number: '',
+          hide_email: false,
+          hide_phone_number: false,
+          is_admin: true,
+        },
+      } as AxiosResponse);
+      mockAnimal({ status: 'available' });
+    });
+
+    it('does not show the deleted-comments toggle when only a different animal in the group has deleted comments', async () => {
+      vi.mocked(animalCommentsApi.getDeleted).mockResolvedValue({
+        data: [mockDeletedComment({ animal_id: 2 })],
+      } as AxiosResponse);
+
+      renderDetailPage();
+
+      await screen.findByRole('heading', { name: 'Rex' });
+      expect(screen.queryByText(/Show Deleted Comments/)).not.toBeInTheDocument();
+    });
+
+    it('resets the show-deleted toggle when navigating to a different animal', async () => {
+      vi.mocked(animalCommentsApi.getDeleted).mockResolvedValue({
+        data: [
+          mockDeletedComment({ id: 1, animal_id: 1 }),
+          mockDeletedComment({ id: 2, animal_id: 2 }),
+        ],
+      } as AxiosResponse);
+
+      const { rerender } = renderDetailPage();
+
+      const toggle = await screen.findByLabelText(/Show Deleted Comments/);
+      fireEvent.click(toggle);
+      expect(await screen.findByText('🗑️ Deleted Comments (Admin Review)')).toBeInTheDocument();
+
+      mockRouteParams = { groupId: '1', id: '2' };
+      rerender(
+        <BrowserRouter>
+          <AuthProvider>
+            <ToastProvider>
+              <AnimalDetailPage />
+            </ToastProvider>
+          </AuthProvider>
+        </BrowserRouter>
+      );
+
+      await screen.findByText(/Show Deleted Comments \(1\)/);
+      expect(screen.queryByText('🗑️ Deleted Comments (Admin Review)')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -180,6 +180,10 @@ const AnimalDetailPage: React.FC = () => {
   }, [groupId, id, loadAnimalData, loadGroupData, loadTags, isAdmin, loadDeletedComments]);
 
   useEffect(() => {
+    setShowDeleted(false);
+  }, [id]);
+
+  useEffect(() => {
     if (groupId && id) {
       const tagFilterString = filterTags.join(',');
       loadComments(Number(groupId), Number(id), tagFilterString, 0, sortOrder);

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback, Suspense, lazy } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useMemo, Suspense, lazy } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, scriptsApi } from '../api/client';
 import type { Animal, AnimalComment, CommentTag, CommentHistory, Group, GroupMembership, SessionMetadata, Script } from '../api/client';
@@ -36,6 +36,10 @@ const AnimalDetailPage: React.FC = () => {
   const [comments, setComments] = useState<AnimalComment[]>([]);
   const [deletedComments, setDeletedComments] = useState<AnimalComment[]>([]);
   const [showDeleted, setShowDeleted] = useState(false);
+  const animalDeletedComments = useMemo(
+    () => deletedComments.filter(dc => dc.animal_id === Number(id)),
+    [deletedComments, id]
+  );
   const [availableTags, setAvailableTags] = useState<CommentTag[]>([]);
   const [filterTags, setFilterTags] = useState<string[]>([]); // Tags selected for filtering
   const [loading, setLoading] = useState(true);
@@ -751,7 +755,7 @@ const AnimalDetailPage: React.FC = () => {
           )}
 
           {/* Admin: Show Deleted Comments Toggle - HIGH VISIBILITY */}
-          {isAdmin && deletedComments && deletedComments.length > 0 && (
+          {isAdmin && animalDeletedComments.length > 0 && (
             <div style={{
               background: 'linear-gradient(135deg, rgba(239, 68, 68, 0.08) 0%, rgba(239, 68, 68, 0.04) 100%)',
               border: '2px solid #ef4444',
@@ -769,17 +773,17 @@ const AnimalDetailPage: React.FC = () => {
                   style={{ width: '20px', height: '20px', cursor: 'pointer', accentColor: '#ef4444' }}
                 />
                 <span style={{ fontWeight: 700, color: '#ef4444', fontSize: '1.05rem' }}>
-                  🗑️ Show Deleted Comments ({deletedComments.length})
+                  🗑️ Show Deleted Comments ({animalDeletedComments.length})
                 </span>
               </label>
             </div>
           )}
 
           {/* Deleted Comments Section */}
-          {showDeleted && deletedComments && deletedComments.length > 0 && (
+          {showDeleted && animalDeletedComments.length > 0 && (
             <div className="deleted-comments-section">
               <h3>🗑️ Deleted Comments (Admin Review)</h3>
-              {deletedComments.filter(dc => dc.animal_id === Number(id)).map((comment) => (
+              {animalDeletedComments.map((comment) => (
                 <div key={comment.id} className="comment-card deleted-comment">
                   <div className="deleted-badge">🗑️ DELETED</div>
                   <div className="comment-header">


### PR DESCRIPTION
## Summary
- The "Show Deleted Comments" admin toggle on an animal's detail page was gated on the group-wide `deletedComments` array instead of the current animal's comments, so it appeared (with a misleading count) on any animal's page as soon as another animal in the same group had a deleted comment.
- Fixed by deriving a memoized `animalDeletedComments` filtered by the current animal id, and using it consistently for the toggle condition, count, and rendered list.
- Also fixed a related scope leak found in code review: the toggle's checked state wasn't reset when navigating between animals (same route, no remount), so a different animal's deleted-comments panel could render pre-expanded. Reset `showDeleted` on animal id change.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Added regression tests in `AnimalDetailPage.test.tsx`:
  - toggle does not show when only a different animal in the group has deleted comments
  - toggle resets to collapsed when navigating to a different animal
- [x] Full frontend suite: 338/338 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)