### PR TITLE
Confirm BQ exit date via modal instead of auto-stamping it

### DIFF
--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -599,7 +599,12 @@ describe('AnimalForm', () => {
     const submitButton = screen.getByRole('button', { name: /update animal/i });
     await user.click(submitButton);
 
-    const today = new Date().toISOString().split('T')[0];
+    // Computed via local Date getters, not toISOString() (UTC) — matching
+    // production's bqExitDefaultEndDate. Using toISOString() here would make
+    // this test pass even if the local-date fix in production regressed back
+    // to UTC, since the two only diverge for non-UTC callers.
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     const exitEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
     expect(exitEndDateInput.value).toBe(today);
   });

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import AnimalForm from './AnimalForm';
@@ -531,5 +531,170 @@ describe('AnimalForm', () => {
     const payload = (animalsApi.update as Mock).mock.calls[0][2];
     expect(payload.quarantine_start_date).toBeUndefined();
     expect(payload.quarantine_end_date).toBeUndefined();
+  });
+
+  it('shows the BQ exit confirmation modal instead of saving immediately when leaving bite_quarantine', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    expect(await screen.findByText(/confirm bite quarantine exit/i)).toBeInTheDocument();
+    expect(animalsApi.update).not.toHaveBeenCalled();
+  });
+
+  it('defaults the BQ exit modal to the stored end date when closing out late', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2020-01-13T00:00:00Z' }, // long past
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const exitEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
+    expect(exitEndDateInput.value).toBe('2020-01-13');
+  });
+
+  it('defaults the BQ exit modal to today when leaving quarantine early', async () => {
+    const user = userEvent.setup();
+    const farFutureEndDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: farFutureEndDate },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const today = new Date().toISOString().split('T')[0];
+    const exitEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
+    expect(exitEndDateInput.value).toBe(today);
+  });
+
+  it('confirming the BQ exit modal submits the status change with the confirmed end date', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+    vi.mocked(animalsApi.update).mockResolvedValue({ data: { id: 1 } } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const exitEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
+    fireEvent.change(exitEndDateInput, { target: { value: '2026-06-10' } });
+
+    const confirmButton = screen.getByRole('button', { name: /confirm & save/i });
+    await user.click(confirmButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+
+    const payload = (animalsApi.update as Mock).mock.calls[0][2];
+    expect(payload.status).toBe('available');
+    expect(payload.quarantine_end_date).toBe('2026-06-10');
+  });
+
+  it('cancelling the BQ exit modal does not save and leaves the form open', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await screen.findByText(/confirm bite quarantine exit/i);
+
+    // Scoped to the modal dialog: the form's own "Cancel" (navigate away) button
+    // is also present in the DOM while the modal is open and shares the same name.
+    const dialog = screen.getByRole('dialog', { name: /confirm bite quarantine exit/i });
+    const cancelButton = within(dialog).getByRole('button', { name: /^cancel$/i });
+    await user.click(cancelButton);
+
+    expect(screen.queryByText(/confirm bite quarantine exit/i)).not.toBeInTheDocument();
+    expect(animalsApi.update).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('blocks confirming the BQ exit modal when the end date precedes the quarantine start date', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_start_date: '2026-06-01T00:00:00Z', quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    const exitEndDateInput = await screen.findByLabelText(/quarantine end date/i) as HTMLInputElement;
+    fireEvent.change(exitEndDateInput, { target: { value: '2026-05-01' } }); // before start date
+
+    const confirmButton = screen.getByRole('button', { name: /confirm & save/i });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(confirmButton);
+    expect(animalsApi.update).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/AnimalForm.test.tsx
+++ b/frontend/src/pages/AnimalForm.test.tsx
@@ -637,6 +637,35 @@ describe('AnimalForm', () => {
     expect(payload.quarantine_end_date).toBe('2026-06-10');
   });
 
+  it('confirming the BQ exit modal also syncs tag assignments, matching the normal save path', async () => {
+    const user = userEvent.setup();
+    vi.mocked(animalsApi.getById).mockResolvedValue({
+      data: { ...existingQuarantinedAnimal, quarantine_end_date: '2026-06-15T00:00:00Z' },
+    } as AxiosResponse);
+    vi.mocked(animalsApi.update).mockResolvedValue({ data: { id: 1 } } as AxiosResponse);
+
+    renderAnimalForm();
+
+    await waitFor(() => {
+      const nameInput = document.getElementById('name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Rex');
+    });
+
+    const statusSelect = document.getElementById('status') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'available' } });
+
+    const submitButton = screen.getByRole('button', { name: /update animal/i });
+    await user.click(submitButton);
+
+    await screen.findByLabelText(/quarantine end date/i);
+
+    const confirmButton = screen.getByRole('button', { name: /confirm & save/i });
+    await user.click(confirmButton);
+
+    await waitFor(() => expect(animalsApi.update).toHaveBeenCalled());
+    expect(animalTagsApi.assignToAnimal).toHaveBeenCalled();
+  });
+
   it('cancelling the BQ exit modal does not save and leaves the form open', async () => {
     const user = userEvent.setup();
     vi.mocked(animalsApi.getById).mockResolvedValue({

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -31,6 +31,10 @@ const AnimalForm: React.FC = () => {
   const [quarantineDate, setQuarantineDate] = useState('');
   const [quarantineEndDateInput, setQuarantineEndDateInput] = useState('');
   const [originalStatus, setOriginalStatus] = useState('');
+  const [originalQuarantineStartDate, setOriginalQuarantineStartDate] = useState('');
+  const [originalQuarantineEndDate, setOriginalQuarantineEndDate] = useState('');
+  const [showBQExitModal, setShowBQExitModal] = useState(false);
+  const [bqExitEndDate, setBqExitEndDate] = useState('');
   const [availableTags, setAvailableTags] = useState<AnimalTag[]>([]);
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
   const [duplicateInfo, setDuplicateInfo] = useState<DuplicateNameInfo | null>(null);
@@ -75,6 +79,10 @@ const AnimalForm: React.FC = () => {
   const handleQuarantineModalClose = useCallback(() => {
     setShowQuarantineModal(false);
     setQuarantineContext('');
+  }, []);
+
+  const handleBQExitModalClose = useCallback(() => {
+    setShowBQExitModal(false);
   }, []);
 
   const handleUnarchiveModalClose = useCallback(() => {
@@ -135,6 +143,8 @@ const AnimalForm: React.FC = () => {
         setBirthMonths(0);
       }
       setOriginalStatus(animal.status);
+      setOriginalQuarantineStartDate(animal.quarantine_start_date ? animal.quarantine_start_date.split('T')[0] : '');
+      setOriginalQuarantineEndDate(animal.quarantine_end_date ? animal.quarantine_end_date.split('T')[0] : '');
       // Set selected tags
       if (animal.tags) {
         setSelectedTagIds(animal.tags.map(tag => tag.id));
@@ -236,6 +246,33 @@ const AnimalForm: React.FC = () => {
       return '';
     }
     if (quarantineEndDateInput < quarantineDate) {
+      return 'End date cannot be before start date';
+    }
+    return '';
+  })();
+
+  // Smart default for the BQ exit modal: if the stored end date has already
+  // passed, staff are closing out late and that stored date is still correct;
+  // if it's still in the future, the quarantine was cut short and today is the
+  // real closing date. ISO YYYY-MM-DD strings compare correctly as plain strings.
+  const bqExitDefaultEndDate = (() => {
+    const today = new Date().toISOString().split('T')[0];
+    if (originalQuarantineEndDate && originalQuarantineEndDate <= today) {
+      return originalQuarantineEndDate;
+    }
+    return today;
+  })();
+
+  // Compares against originalQuarantineStartDate (captured at load) rather than
+  // formData.quarantine_start_date: leaving bite_quarantine already clears
+  // formData.quarantine_start_date via quarantineFieldReset in the status
+  // <select>'s onChange (so a later re-entry into bite_quarantine starts fresh),
+  // so by the time this modal is open that field is blank and can't be used here.
+  const bqExitEndDateError = (() => {
+    if (!bqExitEndDate || !originalQuarantineStartDate) {
+      return '';
+    }
+    if (bqExitEndDate < originalQuarantineStartDate) {
       return 'End date cannot be before start date';
     }
     return '';
@@ -451,6 +488,13 @@ const AnimalForm: React.FC = () => {
       return;
     }
 
+    // Check if status changed away from bite_quarantine
+    if (originalStatus === 'bite_quarantine' && formData.status !== 'bite_quarantine') {
+      setBqExitEndDate(bqExitDefaultEndDate);
+      setShowBQExitModal(true);
+      return;
+    }
+
     // Check if status changed to bite_quarantine
     if (formData.status === 'bite_quarantine' && originalStatus !== 'bite_quarantine') {
       // Show modal to get context and date
@@ -631,6 +675,40 @@ const AnimalForm: React.FC = () => {
     }
   };
 
+
+  const handleBQExitSubmit = async () => {
+    if (!groupId || !id) return;
+    if (bqExitEndDateError) {
+      toast.showError(bqExitEndDateError);
+      return;
+    }
+
+    const finalBirthDate = formData.estimated_birth_date ||
+      (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
+
+    const payload = {
+      ...formData,
+      estimated_birth_date: finalBirthDate || undefined,
+      age: birthYears,
+      quarantine_start_date: undefined,
+      quarantine_incident_details: undefined,
+      quarantine_approval_status: undefined,
+      quarantine_end_date: bqExitEndDate,
+    };
+
+    setLoading(true);
+    try {
+      await animalsApi.update(parseInt(groupId), parseInt(id), payload);
+      toast.showSuccess('Animal updated successfully!');
+      setShowBQExitModal(false);
+      navigate(`/groups/${groupId}`);
+    } catch (error: unknown) {
+      const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to save animal. Please try again.';
+      toast.showError(errorMsg);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleDelete = async () => {
     try {
@@ -1269,6 +1347,60 @@ const AnimalForm: React.FC = () => {
             disabled={loading || !quarantineContext.trim() || !!quarantineModalStartDateError || !!quarantineModalEndDateError}
           >
             Save & Notify
+          </Button>
+        </div>
+      </Modal>
+
+      {/* BQ Exit Confirmation Modal */}
+      <Modal
+        isOpen={showBQExitModal}
+        onClose={handleBQExitModalClose}
+        title="Confirm Bite Quarantine Exit"
+        size="medium"
+      >
+        <p style={{ marginBottom: '1rem' }}>
+          Confirm the date this bite-quarantine episode actually ended. This is saved to the animal's BQ history.
+        </p>
+
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label htmlFor="bq-exit-end-date" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+            Quarantine End Date:
+          </label>
+          <input
+            id="bq-exit-end-date"
+            type="date"
+            value={bqExitEndDate}
+            onChange={(e) => setBqExitEndDate(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '0.5rem',
+              border: '1px solid var(--neutral-300)',
+              borderRadius: '4px',
+              fontSize: '1rem'
+            }}
+          />
+          {bqExitEndDateError && (
+            <p style={{ fontSize: '0.875rem', color: 'var(--color-danger, #c0392b)', marginTop: '0.25rem' }}>
+              {bqExitEndDateError}
+            </p>
+          )}
+        </div>
+
+        <div className="modal__actions" style={{ marginTop: '1.5rem', display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+          <Button
+            variant="secondary"
+            onClick={handleBQExitModalClose}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleBQExitSubmit}
+            loading={loading}
+            disabled={loading || !bqExitEndDate || !!bqExitEndDateError}
+          >
+            Confirm & Save
           </Button>
         </div>
       </Modal>

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -12,6 +12,24 @@ import Modal from '../components/Modal';
 import ImageEditor from '../components/ImageEditor';
 import './Form.css';
 
+// Resolves the birth date to submit: an explicitly-set estimated_birth_date wins,
+// otherwise it's computed from the years/months picker (when in approximate mode).
+// Shared by every save path (normal save, quarantine-entry modal, BQ-exit modal) so
+// the same animal edit always resolves birth date the same way regardless of which
+// path it's saved through.
+function resolveFinalBirthDate(estimatedBirthDate: string, birthYears: number, birthMonths: number): string | undefined {
+  return estimatedBirthDate ||
+    (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined) ||
+    undefined;
+}
+
+// Extracts a user-facing message from a failed animal-save request, falling back to
+// a generic message when the API didn't return one. Shared by every save path so a
+// future change to the API's error response shape only needs updating here.
+function extractSaveErrorMessage(error: unknown, fallback: string): string {
+  return (error as { response?: { data?: { error?: string } } }).response?.data?.error || fallback;
+}
+
 const AnimalForm: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
   const navigate = useNavigate();
@@ -256,7 +274,14 @@ const AnimalForm: React.FC = () => {
   // if it's still in the future, the quarantine was cut short and today is the
   // real closing date. ISO YYYY-MM-DD strings compare correctly as plain strings.
   const bqExitDefaultEndDate = (() => {
-    const today = new Date().toISOString().split('T')[0];
+    // Local calendar date, not new Date().toISOString() (UTC) — this modal's
+    // whole purpose is getting the closing date right, so a UTC-vs-local
+    // mismatch near midnight would defeat the point for non-UTC staff.
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, '0');
+    const d = String(now.getDate()).padStart(2, '0');
+    const today = `${y}-${m}-${d}`;
     if (originalQuarantineEndDate && originalQuarantineEndDate <= today) {
       return originalQuarantineEndDate;
     }
@@ -515,13 +540,11 @@ const AnimalForm: React.FC = () => {
       let animalId = id ? parseInt(id) : null;
       
       // Clean up formData: convert empty quarantine_start_date to null
-      // Ensure estimated_birth_date is computed from years/months if in approximate mode
-      const finalBirthDate = formData.estimated_birth_date ||
-        (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
+      const finalBirthDate = resolveFinalBirthDate(formData.estimated_birth_date, birthYears, birthMonths);
 
       const cleanedFormData = {
         ...formData,
-        estimated_birth_date: finalBirthDate || undefined,
+        estimated_birth_date: finalBirthDate,
         age: birthYears,
         // A blank start date here means "leave the stored value untouched," not
         // "clear it" — this also covers a user directly blanking the inline Start
@@ -580,7 +603,7 @@ const AnimalForm: React.FC = () => {
       
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to save animal. Please try again.';
+      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);
@@ -598,9 +621,7 @@ const AnimalForm: React.FC = () => {
       return;
     }
 
-    // Compute birth date the same way saveAnimal does
-    const finalBirthDate = formData.estimated_birth_date ||
-      (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
+    const finalBirthDate = resolveFinalBirthDate(formData.estimated_birth_date, birthYears, birthMonths);
 
     // Update formData with the quarantine dates entered in this modal — formData may
     // still carry a stale quarantine_end_date left over from a previous quarantine
@@ -610,7 +631,7 @@ const AnimalForm: React.FC = () => {
     const resolvedQuarantineEndDate = quarantineEndDateInput || calculateQuarantineEndDateISO(quarantineDate);
     const updatedFormData = {
       ...formData,
-      estimated_birth_date: finalBirthDate || undefined,
+      estimated_birth_date: finalBirthDate,
       age: birthYears,
       quarantine_start_date: quarantineDate,
       quarantine_end_date: resolvedQuarantineEndDate,
@@ -668,7 +689,7 @@ const AnimalForm: React.FC = () => {
       setShowQuarantineModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to save animal. Please try again.';
+      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);
@@ -683,12 +704,11 @@ const AnimalForm: React.FC = () => {
       return;
     }
 
-    const finalBirthDate = formData.estimated_birth_date ||
-      (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
+    const finalBirthDate = resolveFinalBirthDate(formData.estimated_birth_date, birthYears, birthMonths);
 
     const payload = {
       ...formData,
-      estimated_birth_date: finalBirthDate || undefined,
+      estimated_birth_date: finalBirthDate,
       age: birthYears,
       quarantine_start_date: undefined,
       quarantine_incident_details: undefined,
@@ -699,11 +719,23 @@ const AnimalForm: React.FC = () => {
     setLoading(true);
     try {
       await animalsApi.update(parseInt(groupId), parseInt(id), payload);
+
+      // Assign tags to the animal, same as the normal save path — a user may
+      // have edited tags in the same session as confirming the BQ exit.
+      if (selectedTagIds.length >= 0) {
+        try {
+          await animalTagsApi.assignToAnimal(parseInt(groupId), parseInt(id), selectedTagIds);
+        } catch (error) {
+          console.error('Failed to assign tags:', error);
+          toast.showWarning('Animal saved but failed to update tags');
+        }
+      }
+
       toast.showSuccess('Animal updated successfully!');
       setShowBQExitModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to save animal. Please try again.';
+      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);

--- a/frontend/src/pages/AnimalForm.tsx
+++ b/frontend/src/pages/AnimalForm.tsx
@@ -19,14 +19,14 @@ import './Form.css';
 // path it's saved through.
 function resolveFinalBirthDate(estimatedBirthDate: string, birthYears: number, birthMonths: number): string | undefined {
   return estimatedBirthDate ||
-    (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined) ||
-    undefined;
+    (birthYears > 0 || birthMonths > 0 ? computeEstimatedBirthDate(birthYears, birthMonths) : undefined);
 }
 
-// Extracts a user-facing message from a failed animal-save request, falling back to
-// a generic message when the API didn't return one. Shared by every save path so a
-// future change to the API's error response shape only needs updating here.
-function extractSaveErrorMessage(error: unknown, fallback: string): string {
+// Extracts a user-facing message from a failed API request, falling back to a
+// generic message when the API didn't return one. Shared across every request in
+// this form (save, image/document upload, delete) so a future change to the API's
+// error response shape only needs updating here.
+function extractApiErrorMessage(error: unknown, fallback: string): string {
   return (error as { response?: { data?: { error?: string } } }).response?.data?.error || fallback;
 }
 
@@ -366,7 +366,7 @@ const AnimalForm: React.FC = () => {
       }, 100);
     } catch (err: unknown) {
       console.error('Upload error:', err);
-      const errorMsg = (err as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to upload image. Please try again.';
+      const errorMsg = extractApiErrorMessage(err, 'Failed to upload image. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setUploading(false);
@@ -414,7 +414,7 @@ const AnimalForm: React.FC = () => {
         toast.showSuccess('Protocol document uploaded successfully!');
       } catch (error: unknown) {
         console.error('Upload error:', error);
-        const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to upload document. Please try again.';
+        const errorMsg = extractApiErrorMessage(error, 'Failed to upload document. Please try again.');
         toast.showError(errorMsg);
       } finally {
         setUploadingDocument(false);
@@ -603,7 +603,7 @@ const AnimalForm: React.FC = () => {
       
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
+      const errorMsg = extractApiErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);
@@ -689,7 +689,7 @@ const AnimalForm: React.FC = () => {
       setShowQuarantineModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
+      const errorMsg = extractApiErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);
@@ -716,15 +716,17 @@ const AnimalForm: React.FC = () => {
       quarantine_end_date: bqExitEndDate,
     };
 
+    const animalId = parseInt(id);
+
     setLoading(true);
     try {
-      await animalsApi.update(parseInt(groupId), parseInt(id), payload);
+      await animalsApi.update(parseInt(groupId), animalId, payload);
 
       // Assign tags to the animal, same as the normal save path — a user may
       // have edited tags in the same session as confirming the BQ exit.
-      if (selectedTagIds.length >= 0) {
+      if (animalId && selectedTagIds.length >= 0) {
         try {
-          await animalTagsApi.assignToAnimal(parseInt(groupId), parseInt(id), selectedTagIds);
+          await animalTagsApi.assignToAnimal(parseInt(groupId), animalId, selectedTagIds);
         } catch (error) {
           console.error('Failed to assign tags:', error);
           toast.showWarning('Animal saved but failed to update tags');
@@ -735,7 +737,7 @@ const AnimalForm: React.FC = () => {
       setShowBQExitModal(false);
       navigate(`/groups/${groupId}`);
     } catch (error: unknown) {
-      const errorMsg = extractSaveErrorMessage(error, 'Failed to save animal. Please try again.');
+      const errorMsg = extractApiErrorMessage(error, 'Failed to save animal. Please try again.');
       toast.showError(errorMsg);
     } finally {
       setLoading(false);
@@ -750,7 +752,7 @@ const AnimalForm: React.FC = () => {
         navigate(`/groups/${groupId}`);
       }
     } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to delete animal. Please try again.';
+      const errorMsg = extractApiErrorMessage(error, 'Failed to delete animal. Please try again.');
       toast.showError(errorMsg);
     }
     setShowDeleteModal(false);

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -66,6 +66,15 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		now := time.Now()
 		enteredQuarantine := false
 		leftQuarantine := req.Status != "" && req.Status != animal.Status && animal.Status == "bite_quarantine"
+		var incidentEndDateAtExit *time.Time
+		if leftQuarantine {
+			resolvedEndDate, err := resolveBQExitEndDate(req.QuarantineEndDate, animal.QuarantineEndDate, animal.QuarantineStartDate, now)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			incidentEndDateAtExit = resolvedEndDate
+		}
 		var bqStartDate time.Time
 		var bqStartDateEdit *time.Time
 		if req.Status != "" && req.Status != animal.Status {
@@ -195,7 +204,7 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		if leftQuarantine {
 			if err := db.Model(&models.AnimalBQIncident{}).
 				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("end_date", now).Error; err != nil {
+				Update("end_date", incidentEndDateAtExit).Error; err != nil {
 				logger.Error("Failed to close BQ incident", err)
 			}
 		}

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -938,6 +938,63 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T
 	}
 }
 
+// TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds verifies
+// that an animal which reached bite_quarantine status without a QuarantineStartDate
+// on record (e.g. via CSV import, which sets status directly without touching
+// quarantine dates) can still leave bite_quarantine when the exit modal sends an
+// explicit confirmed end date — there's no start date to validate against, so the
+// exit must not be blocked.
+func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	confirmedEndDate := time.Date(2025, 11, 6, 0, 0, 0, 0, time.UTC)
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status": "bite_quarantine",
+		// quarantine_start_date intentionally left unset, matching an animal
+		// imported via CSV directly into bite_quarantine status.
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID: animal.ID,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &confirmedEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
+		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	}
+}
+
 // TestUpdateAnimalAdmin_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving verifies
 // that an explicit exit end date before the quarantine start date is rejected with a
 // 400 and that the animal's status is NOT changed — validation must happen before

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -940,10 +940,14 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T
 
 // TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds verifies
 // that an animal which reached bite_quarantine status without a QuarantineStartDate
-// on record (e.g. via CSV import, which sets status directly without touching
-// quarantine dates) can still leave bite_quarantine when the exit modal sends an
-// explicit confirmed end date — there's no start date to validate against, so the
-// exit must not be blocked.
+// on record can still leave bite_quarantine when the exit modal sends an explicit
+// confirmed end date — there's no start date to validate against, so the exit must
+// not be blocked. Deliberately seeds no AnimalBQIncident row: a real CSV-imported
+// animal (the actual motivating case for a nil start date — see
+// animal_import_export.go, which sets status directly without ever creating an
+// incident row) has none, so this asserts the request succeeds even when there's no
+// incident to close, not just that a pre-existing incident's EndDate resolves
+// correctly.
 func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testing.T) {
 	db := setupAnimalTestDB(t)
 	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
@@ -957,11 +961,6 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *
 		// imported via CSV directly into bite_quarantine status.
 	}).Error; err != nil {
 		t.Fatalf("seed BQ status: %v", err)
-	}
-	if err := db.Create(&models.AnimalBQIncident{
-		AnimalID: animal.ID,
-	}).Error; err != nil {
-		t.Fatalf("seed incident row: %v", err)
 	}
 
 	updateReq := AnimalRequest{
@@ -986,12 +985,12 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *
 		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
 	}
 
-	var incident models.AnimalBQIncident
-	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
-		t.Fatalf("reload incident row: %v", err)
+	var reloaded models.Animal
+	if err := db.First(&reloaded, animal.ID).Error; err != nil {
+		t.Fatalf("reload animal: %v", err)
 	}
-	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
-		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	if reloaded.Status != "available" {
+		t.Errorf("Expected status to change to available, got %q", reloaded.Status)
 	}
 }
 

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -880,6 +880,184 @@ func TestUpdateAnimalAdmin_BQExit_StampsEndDate(t *testing.T) {
 	}
 }
 
+// TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_UsesProvidedValue verifies that when
+// the request provides an explicit quarantine_end_date while leaving bite_quarantine
+// (the modal-confirmed path), it's used to close the incident verbatim instead of
+// the animal's previously stored end date.
+func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	storedEndDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	confirmedEndDate := time.Date(2025, 11, 6, 0, 0, 0, 0, time.UTC) // vet-cleared early
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   storedEndDate,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &confirmedEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
+		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	}
+}
+
+// TestUpdateAnimalAdmin_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving verifies
+// that an explicit exit end date before the quarantine start date is rejected with a
+// 400 and that the animal's status is NOT changed — validation must happen before
+// the animal record is updated, not after.
+func TestUpdateAnimalAdmin_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	storedEndDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	invalidEndDate := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC) // before start date
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   storedEndDate,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	updateReq := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &invalidEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Expected 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var reloaded models.Animal
+	if err := db.First(&reloaded, animal.ID).Error; err != nil {
+		t.Fatalf("reload animal: %v", err)
+	}
+	if reloaded.Status != "bite_quarantine" {
+		t.Errorf("Expected status to remain bite_quarantine after a rejected request, got %q", reloaded.Status)
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate != nil {
+		t.Errorf("Expected incident to remain open after a rejected request, got EndDate %v", incident.EndDate)
+	}
+}
+
+// TestUpdateAnimalAdmin_LeaveQuarantine_EarlyExit_CapsEndDateAtNow verifies that when
+// an animal leaves bite_quarantine before its stored end date has arrived (no
+// explicit end date provided), the closed incident is stamped with now, not the
+// future stored date.
+func TestUpdateAnimalAdmin_LeaveQuarantine_EarlyExit_CapsEndDateAtNow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Now().Add(-2 * 24 * time.Hour)
+	futureEndDate := time.Now().Add(7 * 24 * time.Hour) // stored end date still a week out
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   futureEndDate,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	beforeRequest := time.Now()
+	updateReq := AnimalRequest{Name: "Rex", Status: "available"}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimalAdmin(db, nil)
+	handler(c)
+	afterRequest := time.Now()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil {
+		t.Fatal("Expected EndDate to be stamped, got nil")
+	}
+	if incident.EndDate.Before(beforeRequest) || incident.EndDate.After(afterRequest) {
+		t.Errorf("Expected EndDate to be capped at now (between %v and %v), got %v (stored future end date was %v)", beforeRequest, afterRequest, *incident.EndDate, futureEndDate)
+	}
+}
+
 // TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails verifies that editing
 // incident details while in BQ via the admin handler updates the incident row.
 func TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails(t *testing.T) {

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -379,6 +379,15 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		now := time.Now()
 		enteredQuarantine := false
 		leftQuarantine := newStatus != "" && newStatus != oldStatus && oldStatus == "bite_quarantine"
+		var incidentEndDateAtExit *time.Time
+		if leftQuarantine {
+			resolvedEndDate, err := resolveBQExitEndDate(req.QuarantineEndDate, animal.QuarantineEndDate, animal.QuarantineStartDate, now)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			incidentEndDateAtExit = resolvedEndDate
+		}
 		midBQEdit := false
 		var midBQStartDate *time.Time
 		if newStatus != "" && newStatus != oldStatus {
@@ -522,7 +531,7 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 		if leftQuarantine {
 			if err := db.WithContext(ctx).Model(&models.AnimalBQIncident{}).
 				Where("animal_id = ? AND end_date IS NULL", animal.ID).
-				Update("end_date", now).Error; err != nil {
+				Update("end_date", incidentEndDateAtExit).Error; err != nil {
 				// Log error but don't fail the update
 				c.Error(err)
 			}

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -351,6 +351,65 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T) {
 	}
 }
 
+// TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds verifies that an
+// animal which reached bite_quarantine status without a QuarantineStartDate on record
+// (e.g. via CSV import, which sets status directly without touching quarantine dates)
+// can still leave bite_quarantine when the exit modal sends an explicit confirmed end
+// date — there's no start date to validate against, so the exit must not be blocked.
+func TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	confirmedEndDate := time.Date(2025, 11, 6, 0, 0, 0, 0, time.UTC)
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status": "bite_quarantine",
+		// quarantine_start_date intentionally left unset, matching an animal
+		// imported via CSV directly into bite_quarantine status.
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID: animal.ID,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	reqBody := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &confirmedEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
+		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	}
+}
+
 // TestUpdateAnimal_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving verifies that
 // an explicit exit end date before the quarantine start date is rejected with a 400
 // and that the animal's status is NOT changed — validation must happen before the

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -353,9 +353,13 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T) {
 
 // TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds verifies that an
 // animal which reached bite_quarantine status without a QuarantineStartDate on record
-// (e.g. via CSV import, which sets status directly without touching quarantine dates)
 // can still leave bite_quarantine when the exit modal sends an explicit confirmed end
 // date — there's no start date to validate against, so the exit must not be blocked.
+// Deliberately seeds no AnimalBQIncident row: a real CSV-imported animal (the actual
+// motivating case for a nil start date — see animal_import_export.go, which sets
+// status directly without ever creating an incident row) has none, so this asserts
+// the request succeeds even when there's no incident to close, not just that a
+// pre-existing incident's EndDate resolves correctly.
 func TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testing.T) {
 	db := setupAnimalTestDB(t)
 	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
@@ -369,11 +373,6 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testi
 		// imported via CSV directly into bite_quarantine status.
 	}).Error; err != nil {
 		t.Fatalf("seed BQ status: %v", err)
-	}
-	if err := db.Create(&models.AnimalBQIncident{
-		AnimalID: animal.ID,
-	}).Error; err != nil {
-		t.Fatalf("seed incident row: %v", err)
 	}
 
 	reqBody := AnimalRequest{
@@ -401,12 +400,12 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testi
 		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
 	}
 
-	var incident models.AnimalBQIncident
-	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
-		t.Fatalf("reload incident row: %v", err)
+	var reloaded models.Animal
+	if err := db.First(&reloaded, animal.ID).Error; err != nil {
+		t.Fatalf("reload animal: %v", err)
 	}
-	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
-		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	if reloaded.Status != "available" {
+		t.Errorf("Expected status to change to available, got %q", reloaded.Status)
 	}
 }
 

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -290,6 +290,136 @@ func TestUpdateAnimal_BQExit_StampsEndDate(t *testing.T) {
 	}
 }
 
+// TestUpdateAnimal_BQExit_ExplicitEndDate_UsesProvidedValue verifies that when the
+// request provides an explicit quarantine_end_date while leaving bite_quarantine
+// (the modal-confirmed path), it's used to close the incident verbatim instead of
+// the animal's previously stored end date.
+func TestUpdateAnimal_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	storedEndDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	confirmedEndDate := time.Date(2025, 11, 6, 0, 0, 0, 0, time.UTC) // vet-cleared early
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   storedEndDate,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	reqBody := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &confirmedEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil || !incident.EndDate.Equal(confirmedEndDate) {
+		t.Errorf("Expected EndDate %v, got %v", confirmedEndDate, incident.EndDate)
+	}
+}
+
+// TestUpdateAnimal_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving verifies that
+// an explicit exit end date before the quarantine start date is rejected with a 400
+// and that the animal's status is NOT changed — validation must happen before the
+// animal record is saved, not after.
+func TestUpdateAnimal_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "admin", "admin@example.com", true)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	storedEndDate := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+	invalidEndDate := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC) // before start date
+
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   storedEndDate,
+	}).Error; err != nil {
+		t.Fatalf("seed BQ status: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	reqBody := AnimalRequest{
+		Name:   "Rex",
+		Status: "available",
+		QuarantineEndDate: NullableTime{
+			Time:  &invalidEndDate,
+			Valid: true,
+		},
+	}
+	jsonData, _ := json.Marshal(reqBody)
+
+	c, w := setupAnimalTestContext(user.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Expected 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var reloaded models.Animal
+	if err := db.First(&reloaded, animal.ID).Error; err != nil {
+		t.Fatalf("reload animal: %v", err)
+	}
+	if reloaded.Status != "bite_quarantine" {
+		t.Errorf("Expected status to remain bite_quarantine after a rejected request, got %q", reloaded.Status)
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate != nil {
+		t.Errorf("Expected incident to remain open after a rejected request, got EndDate %v", incident.EndDate)
+	}
+}
+
 // TestUpdateAnimal_MidBQ_UpdatesIncidentDetails verifies that editing incident
 // details while already in bite_quarantine updates the active incident row.
 func TestUpdateAnimal_MidBQ_UpdatesIncidentDetails(t *testing.T) {

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -165,21 +165,24 @@ func resolveQuarantineDateEdits(currentStart *time.Time, req AnimalRequest) (new
 
 // resolveBQExitEndDate determines the end date to stamp on the AnimalBQIncident row
 // being closed when an animal exits bite_quarantine. An explicit end date from the
-// request — typically confirmed by staff via the exit-confirmation modal — is
-// validated against the quarantine's start date (same rule as resolveQuarantineEndDate)
-// and used verbatim. Otherwise, the animal's stored/computed QuarantineEndDate is used,
-// capped at now: an early exit (before that date arrives) stamps the incident with
-// the real closing moment instead of a future date, while a late closure (after that
-// date has already passed) stamps it with the originally-intended date rather than
-// the moment someone got around to closing it out. If there was no stored end date
-// either, now is used. Used by UpdateAnimal and UpdateAnimalAdmin so the "closing"
-// rule for a BQ incident stays identical across both write paths.
+// request — typically confirmed by staff via the exit-confirmation modal — is used
+// verbatim, validated against the quarantine's start date only when a start date is
+// actually on record. Unlike resolveQuarantineEndDate (used when entering quarantine,
+// where a missing start date signals a genuine input error), a nil start date here
+// doesn't block the exit: some animals reach bite_quarantine status without ever
+// getting a QuarantineStartDate (e.g. CSV import), and refusing to let staff close
+// out quarantine for those animals — permanently stuck, since there's no other path
+// out — would be worse than accepting the confirmed date without a start-date check.
+// If there's no explicit end date, the animal's stored/computed QuarantineEndDate is
+// used, capped at now: an early exit (before that date arrives) stamps the incident
+// with the real closing moment instead of a future date, while a late closure (after
+// that date has already passed) stamps it with the originally-intended date rather
+// than the moment someone got around to closing it out. If there was no stored end
+// date either, now is used. Used by UpdateAnimal and UpdateAnimalAdmin so the
+// "closing" rule for a BQ incident stays identical across both write paths.
 func resolveBQExitEndDate(explicitEnd NullableTime, storedEnd *time.Time, storedStart *time.Time, now time.Time) (*time.Time, error) {
 	if explicitEnd.Valid && explicitEnd.Time != nil {
-		if storedStart == nil {
-			return nil, fmt.Errorf("quarantine end date cannot be set without a quarantine start date")
-		}
-		if quarantineEndBeforeStart(*explicitEnd.Time, *storedStart) {
+		if storedStart != nil && quarantineEndBeforeStart(*explicitEnd.Time, *storedStart) {
 			return nil, fmt.Errorf("quarantine end date cannot be before start date")
 		}
 		return explicitEnd.Time, nil

--- a/internal/handlers/animal_helpers.go
+++ b/internal/handlers/animal_helpers.go
@@ -163,6 +163,33 @@ func resolveQuarantineDateEdits(currentStart *time.Time, req AnimalRequest) (new
 	return newStart, newEnd, nil
 }
 
+// resolveBQExitEndDate determines the end date to stamp on the AnimalBQIncident row
+// being closed when an animal exits bite_quarantine. An explicit end date from the
+// request — typically confirmed by staff via the exit-confirmation modal — is
+// validated against the quarantine's start date (same rule as resolveQuarantineEndDate)
+// and used verbatim. Otherwise, the animal's stored/computed QuarantineEndDate is used,
+// capped at now: an early exit (before that date arrives) stamps the incident with
+// the real closing moment instead of a future date, while a late closure (after that
+// date has already passed) stamps it with the originally-intended date rather than
+// the moment someone got around to closing it out. If there was no stored end date
+// either, now is used. Used by UpdateAnimal and UpdateAnimalAdmin so the "closing"
+// rule for a BQ incident stays identical across both write paths.
+func resolveBQExitEndDate(explicitEnd NullableTime, storedEnd *time.Time, storedStart *time.Time, now time.Time) (*time.Time, error) {
+	if explicitEnd.Valid && explicitEnd.Time != nil {
+		if storedStart == nil {
+			return nil, fmt.Errorf("quarantine end date cannot be set without a quarantine start date")
+		}
+		if quarantineEndBeforeStart(*explicitEnd.Time, *storedStart) {
+			return nil, fmt.Errorf("quarantine end date cannot be before start date")
+		}
+		return explicitEnd.Time, nil
+	}
+	if storedEnd != nil && !storedEnd.After(now) {
+		return storedEnd, nil
+	}
+	return &now, nil
+}
+
 // quarantineEndBeforeStart compares end and start by calendar day, not by exact
 // instant. Start defaults to time.Now() (a real timestamp, in the server's local
 // location) when omitted, while a date-only end date parses to UTC midnight —

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -368,15 +368,19 @@ func TestResolveBQExitEndDate(t *testing.T) {
 		}
 	})
 
-	t.Run("explicit end date with nil stored start is rejected", func(t *testing.T) {
+	t.Run("explicit end date with nil stored start is accepted verbatim", func(t *testing.T) {
+		// Some animals reach bite_quarantine without a QuarantineStartDate on
+		// record (e.g. CSV import). There's no start date to validate against,
+		// but that must not block the exit — an animal in this state would
+		// otherwise have no way to ever leave bite_quarantine status.
 		explicit := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
 		now := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
-		_, err := resolveBQExitEndDate(NullableTime{Time: &explicit, Valid: true}, nil, nil, now)
-		if err == nil {
-			t.Fatal("expected an error, got nil")
+		result, err := resolveBQExitEndDate(NullableTime{Time: &explicit, Valid: true}, nil, nil, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if err.Error() != "quarantine end date cannot be set without a quarantine start date" {
-			t.Errorf("unexpected error message: %q", err.Error())
+		if result == nil || !result.Equal(explicit) {
+			t.Errorf("expected %v, got %v", explicit, result)
 		}
 	})
 

--- a/internal/handlers/animal_helpers_test.go
+++ b/internal/handlers/animal_helpers_test.go
@@ -338,3 +338,83 @@ func TestResolveQuarantineEndDate(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveBQExitEndDate(t *testing.T) {
+	t.Run("explicit end date after start is honored verbatim", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+		stored := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+		explicit := time.Date(2025, 11, 6, 0, 0, 0, 0, time.UTC) // early exit, confirmed by staff
+		now := time.Date(2025, 11, 6, 12, 0, 0, 0, time.UTC)
+		result, err := resolveBQExitEndDate(NullableTime{Time: &explicit, Valid: true}, &stored, &start, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(explicit) {
+			t.Errorf("expected %v, got %v", explicit, result)
+		}
+	})
+
+	t.Run("explicit end date before start's calendar day is rejected", func(t *testing.T) {
+		start := time.Date(2025, 11, 10, 0, 0, 0, 0, time.UTC)
+		stored := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
+		explicit := time.Date(2025, 11, 5, 0, 0, 0, 0, time.UTC)
+		now := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
+		_, err := resolveBQExitEndDate(NullableTime{Time: &explicit, Valid: true}, &stored, &start, now)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if err.Error() != "quarantine end date cannot be before start date" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
+	})
+
+	t.Run("explicit end date with nil stored start is rejected", func(t *testing.T) {
+		explicit := time.Date(2025, 11, 20, 0, 0, 0, 0, time.UTC)
+		now := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
+		_, err := resolveBQExitEndDate(NullableTime{Time: &explicit, Valid: true}, nil, nil, now)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if err.Error() != "quarantine end date cannot be set without a quarantine start date" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
+	})
+
+	t.Run("no explicit end date, stored end date already passed, returns the stored date", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+		stored := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+		now := time.Date(2025, 11, 16, 9, 0, 0, 0, time.UTC) // 3 days after the stored end date — closing out late
+		result, err := resolveBQExitEndDate(NullableTime{}, &stored, &start, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(stored) {
+			t.Errorf("expected %v, got %v", stored, result)
+		}
+	})
+
+	t.Run("no explicit end date, stored end date still in the future, returns now", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+		stored := time.Date(2025, 11, 13, 0, 0, 0, 0, time.UTC)
+		now := time.Date(2025, 11, 6, 9, 0, 0, 0, time.UTC) // exiting 7 days early
+		result, err := resolveBQExitEndDate(NullableTime{}, &stored, &start, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(now) {
+			t.Errorf("expected %v, got %v", now, result)
+		}
+	})
+
+	t.Run("no explicit end date, no stored end date, returns now", func(t *testing.T) {
+		start := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+		now := time.Date(2025, 11, 6, 9, 0, 0, 0, time.UTC)
+		result, err := resolveBQExitEndDate(NullableTime{}, nil, &start, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil || !result.Equal(now) {
+			t.Errorf("expected %v, got %v", now, result)
+		}
+	})
+}

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -2569,3 +2569,64 @@ func TestUpdateAnimal_LeaveQuarantine_ClearsEndDate(t *testing.T) {
 		t.Errorf("Expected QuarantineEndDate to be cleared, got %v", got.QuarantineEndDate)
 	}
 }
+
+// TestUpdateAnimal_LeaveQuarantine_EarlyExit_CapsEndDateAtNow verifies that when an
+// animal leaves bite_quarantine before its stored end date has arrived (no explicit
+// end date provided), the closed incident is stamped with now, not the future stored
+// date.
+func TestUpdateAnimal_LeaveQuarantine_EarlyExit_CapsEndDateAtNow(t *testing.T) {
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+	animal := createTestAnimal(t, db, group.ID, "Rex", "Dog")
+
+	startDate := time.Now().Add(-2 * 24 * time.Hour)
+	futureEndDate := time.Now().Add(7 * 24 * time.Hour) // stored end date still a week out
+	if err := db.Model(animal).Updates(map[string]interface{}{
+		"status":                "bite_quarantine",
+		"quarantine_start_date": startDate,
+		"quarantine_end_date":   futureEndDate,
+	}).Error; err != nil {
+		t.Fatalf("Failed to seed animal into quarantine: %v", err)
+	}
+	if err := db.Create(&models.AnimalBQIncident{
+		AnimalID:  animal.ID,
+		StartDate: startDate,
+	}).Error; err != nil {
+		t.Fatalf("seed incident row: %v", err)
+	}
+
+	beforeRequest := time.Now()
+	updateReq := AnimalRequest{
+		Name:    "Rex",
+		Species: "Dog",
+		Status:  "available",
+	}
+	jsonData, _ := json.Marshal(updateReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "animalId", Value: fmt.Sprintf("%d", animal.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateAnimal(db, nil)
+	handler(c)
+	afterRequest := time.Now()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var incident models.AnimalBQIncident
+	if err := db.Where("animal_id = ?", animal.ID).First(&incident).Error; err != nil {
+		t.Fatalf("reload incident row: %v", err)
+	}
+	if incident.EndDate == nil {
+		t.Fatal("Expected EndDate to be stamped, got nil")
+	}
+	if incident.EndDate.Before(beforeRequest) || incident.EndDate.After(afterRequest) {
+		t.Errorf("Expected EndDate to be capped at now (between %v and %v), got %v (stored future end date was %v)", beforeRequest, afterRequest, *incident.EndDate, futureEndDate)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a confirmation modal to `AnimalForm.tsx`, symmetric to the existing entry-into-quarantine modal, that pops up when an animal's status changes away from `bite_quarantine`. Staff confirm/edit the true end date before saving, defaulting to `min(stored end date, today)` so both late closures and early exits default correctly.
- Extends `UpdateAnimal`/`UpdateAnimalAdmin` to accept that confirmed date (reusing the existing `quarantine_end_date` request field) and use it to close the historical `AnimalBQIncident` row, via a new shared `resolveBQExitEndDate` helper.
- Fixes a bug where an animal exiting quarantine *early* (before its computed end date arrived) got a future-dated incident close date; the fallback for callers that don't go through the modal (e.g. scripts) now correctly caps at `now`.
- `BulkUpdateAnimals` is explicitly left untouched (out of scope — not used today, already has no BQ incident bookkeeping).

## Test plan
- [x] `go build ./internal/... && go test ./internal/handlers/...` — passes except the pre-existing, unrelated `TestCreateGroup/accepts_valid_GroupMe_bot_id` (present on `main` too)
- [x] `cd frontend && npx vitest run` — 344/344 passing, including 21/21 in `AnimalForm.test.tsx`
- [x] `cd frontend && npm run build` — clean TypeScript build
- [x] Implemented via 4 reviewed tasks (helper, `UpdateAnimal`, `UpdateAnimalAdmin`, frontend modal) plus a final whole-branch review — all approved, no Critical/Important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)