### PR TITLE
Keyword + semantic hybrid search over animals, comments, and updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,19 +76,23 @@ SMTP_FROM_NAME=MyHAWS
 FRONTEND_URL=http://localhost:5173
 
 # Semantic Search Configuration (embeddings via Voyage AI)
-# Get your API key from https://dashboard.voyageai.com
-VOYAGE_API_KEY=pa-your_api_key_here
+# Get your API key from https://dashboard.voyageai.com. Left empty (rather
+# than a placeholder) on purpose: unlike RESEND_API_KEY above, Voyage is a
+# paid, usage-billed API — a non-empty placeholder here plus
+# SEMANTIC_SEARCH_ENABLED's own "enabled unless false/0" default would mean
+# copying this file to .env without editing starts making real (failing)
+# outbound API calls immediately.
+VOYAGE_API_KEY=
 
 # Optional: override the embedding model (default: voyage-4)
 # VOYAGE_MODEL=voyage-4
 
-# Set SEMANTIC_SEARCH_ENABLED=false to disable semantic search and fall back
-# to keyword-only search — useful as a cost kill switch. Default: enabled
-# (omit or set to anything but "false" or "0"). Disabling stops all Voyage
-# API calls (write-path embedding, the reconciliation sweep, and query-time
-# search embedding); existing embeddings/index are left in place, so
-# re-enabling requires no manual backfill step.
-# SEMANTIC_SEARCH_ENABLED=true
+# Semantic search is a ranking enhancement on top of keyword search, never
+# a hard dependency — disabling it (or leaving VOYAGE_API_KEY empty above)
+# falls back to keyword-only search rather than failing requests. Set to
+# true once VOYAGE_API_KEY is a real key and semantic ranking is wanted;
+# left explicitly false here as a safer local/dev default.
+SEMANTIC_SEARCH_ENABLED=false
 
 # Storage Configuration
 # STORAGE_PROVIDER: "postgres" (default, backward compatible) or "azure" (recommended for production)

--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,21 @@ SMTP_FROM_NAME=MyHAWS
 # Frontend URL (for password reset links)
 FRONTEND_URL=http://localhost:5173
 
+# Semantic Search Configuration (embeddings via Voyage AI)
+# Get your API key from https://dashboard.voyageai.com
+VOYAGE_API_KEY=pa-your_api_key_here
+
+# Optional: override the embedding model (default: voyage-4)
+# VOYAGE_MODEL=voyage-4
+
+# Set SEMANTIC_SEARCH_ENABLED=false to disable semantic search and fall back
+# to keyword-only search — useful as a cost kill switch. Default: enabled
+# (omit or set to anything but "false" or "0"). Disabling stops all Voyage
+# API calls (write-path embedding, the reconciliation sweep, and query-time
+# search embedding); existing embeddings/index are left in place, so
+# re-enabling requires no manual backfill step.
+# SEMANTIC_SEARCH_ENABLED=true
+
 # Storage Configuration
 # STORAGE_PROVIDER: "postgres" (default, backward compatible) or "azure" (recommended for production)
 # Feature flag to enable Azure Blob Storage for images and documents

--- a/.env.example
+++ b/.env.example
@@ -78,10 +78,7 @@ FRONTEND_URL=http://localhost:5173
 # Semantic Search Configuration (embeddings via Voyage AI)
 # Get your API key from https://dashboard.voyageai.com. Left empty (rather
 # than a placeholder) on purpose: unlike RESEND_API_KEY above, Voyage is a
-# paid, usage-billed API — a non-empty placeholder here plus
-# SEMANTIC_SEARCH_ENABLED's own "enabled unless false/0" default would mean
-# copying this file to .env without editing starts making real (failing)
-# outbound API calls immediately.
+# paid, usage-billed API, so this shouldn't have a value that looks real.
 VOYAGE_API_KEY=
 
 # Optional: override the embedding model (default: voyage-4)
@@ -89,10 +86,12 @@ VOYAGE_API_KEY=
 
 # Semantic search is a ranking enhancement on top of keyword search, never
 # a hard dependency — disabling it (or leaving VOYAGE_API_KEY empty above)
-# falls back to keyword-only search rather than failing requests. Set to
-# true once VOYAGE_API_KEY is a real key and semantic ranking is wanted;
-# left explicitly false here as a safer local/dev default.
-SEMANTIC_SEARCH_ENABLED=false
+# falls back to keyword-only search rather than failing requests.
+# Deliberately opt-in (unlike EMAIL_ENABLED above, which defaults to
+# enabled): Voyage is a paid, usage-billed API, so this must be set to
+# exactly "true" — not just VOYAGE_API_KEY being present — before any real
+# outbound calls happen.
+# SEMANTIC_SEARCH_ENABLED=true
 
 # Storage Configuration
 # STORAGE_PROVIDER: "postgres" (default, backward compatible) or "azure" (recommended for production)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
     
     services:
       postgres:
-        image: postgres:15
+        image: pgvector/pgvector:pg15
         env:
           POSTGRES_DB: volunteer_media_test
           POSTGRES_USER: postgres

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,7 +98,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -298,6 +298,7 @@ Consider using managed PostgreSQL services:
 - **Google Cloud SQL**: High availability, automatic updates
 - **Digital Ocean Managed Databases**: Simple setup
 - **Heroku Postgres**: Easy integration
+- **pgvector support**: if using a managed provider, confirm the `vector` extension is allow-listed (AWS RDS for PostgreSQL 15+ and Azure Database for PostgreSQL Flexible Server both support it as of this writing) before relying on semantic search in production — if the extension can't be created, semantic search silently stays keyword-only (see Error Handling in the design spec) rather than breaking the deploy.
 
 ## Reverse Proxy Setup
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -370,7 +370,10 @@ func main() {
 			group.GET("/animals/:animalId", handlers.GetAnimal(db))
 			group.GET("/animals/check-duplicates", handlers.CheckDuplicateNames(db))
 
-			// Keyword/phrase search over animals and comments (Postgres full-text search)
+			// Hybrid search over animals, comments, and updates: Postgres
+			// full-text keyword ranking, fused via RRF with semantic
+			// (embedding) ranking when SEMANTIC_SEARCH_ENABLED and Voyage
+			// are both configured — see handlers.Search's doc comment.
 			group.GET("/search", handlers.Search(db, embedder))
 
 			// Animal images - all group members can view, upload, and set profile pictures

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -345,6 +345,9 @@ func main() {
 			group.GET("/animals/:animalId", handlers.GetAnimal(db))
 			group.GET("/animals/check-duplicates", handlers.CheckDuplicateNames(db))
 
+			// Keyword/phrase search over animals and comments (Postgres full-text search)
+			group.GET("/search", handlers.Search(db))
+
 			// Animal images - all group members can view, upload, and set profile pictures
 			group.GET("/animals/:animalId/images", handlers.GetAnimalImages(db))
 			group.POST("/animals/:animalId/images", handlers.UploadAnimalImageToGallery(db, storageProvider))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -331,10 +331,10 @@ func main() {
 			// Bulk animal management (admin only)
 			admin.GET("/animals", handlers.GetAllAnimals(db))
 			admin.POST("/animals/bulk-update", handlers.BulkUpdateAnimals(db))
-			admin.POST("/animals/import-csv", handlers.ImportAnimalsCSV(db))
+			admin.POST("/animals/import-csv", handlers.ImportAnimalsCSV(db, embedder))
 			admin.POST("/animals/export-csv", handlers.ExportAnimalsCSV(db))
 			admin.GET("/animals/export-comments-csv", handlers.ExportAnimalCommentsCSV(db))
-			admin.PUT("/animals/:animalId", handlers.UpdateAnimalAdmin(db, emailService))
+			admin.PUT("/animals/:animalId", handlers.UpdateAnimalAdmin(db, emailService, embedder))
 
 			// Animal image management (admin only)
 			admin.PUT("/animals/:animalId/images/:imageId/set-profile", handlers.SetAnimalProfilePicture(db))
@@ -565,6 +565,14 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		logger.Fatal("Server forced to shutdown", err)
 	}
+
+	// srv.Shutdown only waits for in-flight HTTP handlers, not the detached
+	// write-path embed goroutines those handlers spawn (see embedAsync in
+	// internal/handlers/search_embed.go). Drain them here, before the
+	// deferred sqlDB.Close() above runs, so a goroutine started by a request
+	// that returned just before shutdown can't race PersistEmbedding against
+	// an already-closed *sql.DB.
+	handlers.WaitForPendingEmbeds()
 
 	logger.Info("Server exited gracefully")
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -556,15 +556,20 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	logger.Info("Shutting down server...")
-	stopEmbeddingSweep()
 
-	// Graceful shutdown with 5 second timeout
+	// Stop accepting new connections first. stopEmbeddingSweep() below can
+	// block for up to sweepStopTimeout (10s) draining an in-flight sweep
+	// tick — running it before srv.Shutdown would leave the server still
+	// accepting new requests for that entire window after SIGTERM/SIGINT,
+	// delaying the graceful shutdown clients are waiting on.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
 		logger.Fatal("Server forced to shutdown", err)
 	}
+
+	stopEmbeddingSweep()
 
 	// srv.Shutdown only waits for in-flight HTTP handlers, not the detached
 	// write-path embed goroutines those handlers spawn (see embedAsync in

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -144,10 +144,19 @@ func main() {
 		logger.Info("Email service not configured - password reset and email notifications will be disabled")
 	}
 
-	// Initialize embedding provider for semantic search
-	embedder := embedding.NewVoyageEmbedder()
+	// Initialize embedding provider for semantic search. Declared as the
+	// interface type (not *embedding.VoyageEmbedder) so it can be reset to a
+	// true nil interface below — embedding.Usable(nil) then correctly
+	// disables every one of its five call sites (the three write-path embed
+	// helpers, the reconciliation sweep, and the search handler) instead of
+	// each one independently discovering a broken schema at query time.
+	var embedder embedding.Embedder = embedding.NewVoyageEmbedder()
 	if embedder.IsConfigured() {
 		logger.Info("Voyage embedding provider configured and ready")
+		if !database.VectorSchemaReady(db) {
+			logger.Error("Vector schema not ready (pgvector extension or embedding columns missing) - disabling semantic search; falling back to keyword-only search", nil)
+			embedder = nil
+		}
 	} else {
 		logger.Info("Voyage embedding provider not configured - search will be keyword-only")
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -393,7 +393,7 @@ func main() {
 
 			// Updates routes
 			group.GET("/updates", handlers.GetUpdates(db))
-			group.POST("/updates", handlers.CreateUpdate(db, emailService, groupMeService))
+			group.POST("/updates", handlers.CreateUpdate(db, emailService, groupMeService, embedder))
 			group.DELETE("/updates/:updateId", handlers.DeleteUpdate(db))
 
 			// Protocol/Script routes - all group members can view

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/convert"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/database"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/groupme"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/handlers"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/lifecycle"
@@ -142,6 +143,21 @@ func main() {
 	} else {
 		logger.Info("Email service not configured - password reset and email notifications will be disabled")
 	}
+
+	// Initialize embedding provider for semantic search
+	embedder := embedding.NewVoyageEmbedder()
+	if embedder.IsConfigured() {
+		logger.Info("Voyage embedding provider configured and ready")
+	} else {
+		logger.Info("Voyage embedding provider not configured - search will be keyword-only")
+	}
+
+	// Reconciliation sweep: backfills missing embeddings and retries failed
+	// write-path embed attempts. A no-op while SEMANTIC_SEARCH_ENABLED is
+	// false or the embedder isn't configured (sweepAnimals/sweepComments
+	// find nothing new to do, and StartReconciliationSweep itself checks the
+	// flag every tick before doing any work).
+	stopEmbeddingSweep := embedding.StartReconciliationSweep(db, embedder, 60*time.Second)
 
 	// Initialize GroupMe service
 	groupMeService := groupme.NewService()
@@ -346,7 +362,7 @@ func main() {
 			group.GET("/animals/check-duplicates", handlers.CheckDuplicateNames(db))
 
 			// Keyword/phrase search over animals and comments (Postgres full-text search)
-			group.GET("/search", handlers.Search(db))
+			group.GET("/search", handlers.Search(db, embedder))
 
 			// Animal images - all group members can view, upload, and set profile pictures
 			group.GET("/animals/:animalId/images", handlers.GetAnimalImages(db))
@@ -364,8 +380,8 @@ func main() {
 
 			// Animal comments - all group members can view, add, and edit own comments
 			group.GET("/animals/:animalId/comments", handlers.GetAnimalComments(db))
-			group.POST("/animals/:animalId/comments", handlers.CreateAnimalComment(db))
-			group.PUT("/animals/:animalId/comments/:commentId", handlers.UpdateAnimalComment(db))
+			group.POST("/animals/:animalId/comments", handlers.CreateAnimalComment(db, embedder))
+			group.PUT("/animals/:animalId/comments/:commentId", handlers.UpdateAnimalComment(db, embedder))
 			group.DELETE("/animals/:animalId/comments/:commentId", handlers.DeleteAnimalComment(db))
 			group.GET("/animals/:animalId/comments/:commentId/history", handlers.GetCommentHistory(db))
 
@@ -428,8 +444,8 @@ func main() {
 		// These routes check for site admin OR group admin access within the handlers
 		groupAdminAnimals := protected.Group("/groups/:id/animals")
 		{
-			groupAdminAnimals.POST("", handlers.CreateAnimal(db, emailService))
-			groupAdminAnimals.PUT("/:animalId", handlers.UpdateAnimal(db, emailService))
+			groupAdminAnimals.POST("", handlers.CreateAnimal(db, emailService, embedder))
+			groupAdminAnimals.PUT("/:animalId", handlers.UpdateAnimal(db, emailService, embedder))
 			groupAdminAnimals.DELETE("/:animalId", handlers.DeleteAnimal(db))
 			// Tag assignment for animals
 			groupAdminAnimals.POST("/:animalId/tags", handlers.AssignTagsToAnimal(db))
@@ -531,6 +547,7 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	logger.Info("Shutting down server...")
+	stopEmbeddingSweep()
 
 	// Graceful shutdown with 5 second timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Development Database
   # Use environment variables or .env file for credentials
   postgres_dev:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     container_name: volunteer_media_db_dev
     environment:
       POSTGRES_USER: ${DB_USER:-postgres}
@@ -22,7 +22,7 @@ services:
 
   # Production Database (for testing production setup)
   postgres_prod:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     container_name: volunteer_media_db_prod
     environment:
       POSTGRES_USER: postgres

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -936,8 +936,8 @@ export const groupDocumentsApi = {
   },
 };
 
-// Keyword/phrase search over a group's animals and comments (Postgres
-// full-text search on the backend — see GET /groups/:id/search).
+// Keyword/phrase search over a group's animals, comments, and updates
+// (Postgres full-text search on the backend — see GET /groups/:id/search).
 export interface SearchAnimalResult extends Animal {
   rank: number;
 }
@@ -947,19 +947,25 @@ export interface SearchCommentResult extends AnimalComment {
   rank: number;
 }
 
+export interface SearchUpdateResult extends Update {
+  rank: number;
+}
+
 export interface SearchResponse {
   // Omitted entirely (not just empty) by the backend when `type` narrows
-  // the search to the other resource — always read via `?? []` / `?? 0`.
+  // the search to a different resource — always read via `?? []` / `?? 0`.
   animals?: SearchAnimalResult[];
   total_animals?: number;
   comments?: SearchCommentResult[];
   total_comments?: number;
+  updates?: SearchUpdateResult[];
+  total_updates?: number;
 }
 
 export const searchApi = {
   search: (
     groupId: number,
-    params: { q: string; type?: 'all' | 'animals' | 'comments'; limit?: number; offset?: number },
+    params: { q: string; type?: 'all' | 'animals' | 'comments' | 'updates'; limit?: number; offset?: number },
     options?: { signal?: AbortSignal }
   ) => api.get<SearchResponse>(`/groups/${groupId}/search`, { params, signal: options?.signal }),
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -936,4 +936,31 @@ export const groupDocumentsApi = {
   },
 };
 
+// Keyword/phrase search over a group's animals and comments (Postgres
+// full-text search on the backend — see GET /groups/:id/search).
+export interface SearchAnimalResult extends Animal {
+  rank: number;
+}
+
+export interface SearchCommentResult extends AnimalComment {
+  animal_name: string;
+  rank: number;
+}
+
+export interface SearchResponse {
+  // Omitted entirely (not just empty) by the backend when `type` narrows
+  // the search to the other resource — always read via `?? []` / `?? 0`.
+  animals?: SearchAnimalResult[];
+  total_animals?: number;
+  comments?: SearchCommentResult[];
+  total_comments?: number;
+}
+
+export const searchApi = {
+  search: (
+    groupId: number,
+    params: { q: string; type?: 'all' | 'animals' | 'comments'; limit?: number; offset?: number }
+  ) => api.get<SearchResponse>(`/groups/${groupId}/search`, { params }),
+};
+
 export default api;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -959,8 +959,9 @@ export interface SearchResponse {
 export const searchApi = {
   search: (
     groupId: number,
-    params: { q: string; type?: 'all' | 'animals' | 'comments'; limit?: number; offset?: number }
-  ) => api.get<SearchResponse>(`/groups/${groupId}/search`, { params }),
+    params: { q: string; type?: 'all' | 'animals' | 'comments'; limit?: number; offset?: number },
+    options?: { signal?: AbortSignal }
+  ) => api.get<SearchResponse>(`/groups/${groupId}/search`, { params, signal: options?.signal }),
 };
 
 export default api;

--- a/frontend/src/components/GroupSearch.css
+++ b/frontend/src/components/GroupSearch.css
@@ -1,0 +1,141 @@
+.group-search {
+  margin-bottom: 1.5rem;
+}
+
+.group-search__controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.group-search__input-wrap {
+  position: relative;
+  flex: 1 1 280px;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+}
+
+.group-search__input-wrap svg {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--text-tertiary, var(--neutral-400));
+  pointer-events: none;
+}
+
+.group-search__input {
+  width: 100%;
+  padding: 0.625rem 0.75rem 0.625rem 2.25rem;
+  border: 1px solid var(--neutral-300);
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  background: var(--surface);
+  color: var(--text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.group-search__input:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 163, 173, 0.1);
+}
+
+.group-search__type {
+  padding: 0.625rem;
+  border: 1px solid var(--neutral-300);
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.group-search__type:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 163, 173, 0.1);
+}
+
+.group-search__results {
+  margin-top: 1rem;
+}
+
+.group-search__section + .group-search__section {
+  margin-top: 1.25rem;
+}
+
+.group-search__section-title {
+  font-size: var(--text-base, 1rem);
+  font-weight: var(--font-semibold, 600);
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+}
+
+.group-search__count {
+  font-weight: 400;
+  color: var(--text-tertiary, var(--neutral-500));
+}
+
+.group-search__animal-list,
+.group-search__comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.group-search__animal-result,
+.group-search__comment-result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--neutral-200);
+  border-radius: 10px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.group-search__animal-result:hover,
+.group-search__comment-result:hover,
+.group-search__animal-result:focus-visible,
+.group-search__comment-result:focus-visible {
+  border-color: var(--brand);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  outline: none;
+}
+
+.group-search__animal-name {
+  font-weight: var(--font-semibold, 600);
+  color: var(--text-primary);
+}
+
+.group-search__animal-meta {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--text-secondary);
+}
+
+.group-search__comment-animal {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: var(--font-semibold, 600);
+  color: var(--brand);
+}
+
+.group-search__snippet {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.group-search__load-more {
+  margin-top: 1rem;
+}
+
+[data-theme='dark'] .group-search__animal-result,
+[data-theme='dark'] .group-search__comment-result {
+  border-color: var(--neutral-700, #374151);
+}

--- a/frontend/src/components/GroupSearch.test.tsx
+++ b/frontend/src/components/GroupSearch.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import GroupSearch from './GroupSearch';
 import { searchApi } from '../api/client';
@@ -12,6 +12,9 @@ vi.mock('../api/client', () => ({
   },
 }));
 
+// Must match GroupSearch.tsx's DEBOUNCE_MS.
+const DEBOUNCE_MS = 400;
+
 const renderSearch = (groupId = 1) =>
   render(
     <BrowserRouter>
@@ -21,6 +24,24 @@ const renderSearch = (groupId = 1) =>
 
 const mockSearchResponse = (data: SearchResponse) => {
   vi.mocked(searchApi.search).mockResolvedValue({ data } as AxiosResponse<SearchResponse>);
+};
+
+// Flushes pending microtasks (mocked-promise resolution and the resulting
+// state updates/effects) without relying on real wall-clock time — the
+// fake-timers replacement for RTL's real-timer-based findBy/waitFor.
+const flush = async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+};
+
+// Types into the search box and advances fake time past the debounce delay,
+// flushing the resulting search request/state updates along the way.
+const typeQuery = async (input: HTMLElement, value: string) => {
+  fireEvent.change(input, { target: { value } });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
 };
 
 const rex: SearchAnimalResult = {
@@ -52,7 +73,12 @@ const rexComment: SearchCommentResult = {
 
 describe('GroupSearch', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.mocked(searchApi.search).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('shows no results panel before a query is typed', () => {
@@ -65,20 +91,18 @@ describe('GroupSearch', () => {
     mockSearchResponse({ animals: [rex], total_animals: 1, comments: [rexComment], total_comments: 1 });
     renderSearch(7);
 
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), {
-      target: { value: 'resource guarding' },
-    });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'resource guarding');
 
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.getByText('Rex')).toBeInTheDocument();
     expect(screen.getByText('on Rex')).toBeInTheDocument();
     expect(screen.getByText(/Rex had a great playgroup session today\./)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
 
-    expect(searchApi.search).toHaveBeenCalledWith(7, {
-      q: 'resource guarding',
-      type: 'all',
-      limit: 10,
-      offset: 0,
-    });
+    expect(searchApi.search).toHaveBeenCalledWith(
+      7,
+      { q: 'resource guarding', type: 'all', limit: 10, offset: 0 },
+      { signal: expect.any(AbortSignal) }
+    );
   });
 
   it('shows a loading state while the request is in flight', async () => {
@@ -91,47 +115,91 @@ describe('GroupSearch', () => {
     renderSearch();
 
     fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
 
-    expect(await screen.findAllByRole('status')).not.toHaveLength(0);
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
 
-    resolveRequest({ data: { animals: [rex], total_animals: 1 } } as AxiosResponse<SearchResponse>);
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    await act(async () => {
+      resolveRequest({ data: { animals: [rex], total_animals: 1 } } as AxiosResponse<SearchResponse>);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText('Rex')).toBeInTheDocument();
   });
 
   it('shows an empty state when a query matches nothing', async () => {
     mockSearchResponse({ animals: [], total_animals: 0, comments: [], total_comments: 0 });
     renderSearch();
 
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'nonexistentterm' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'nonexistentterm');
 
-    expect(await screen.findByText('No matches found')).toBeInTheDocument();
+    expect(screen.getByText('No matches found')).toBeInTheDocument();
     expect(screen.getByText(/nonexistentterm/)).toBeInTheDocument();
   });
 
-  it('shows an error state with a working retry on failure', async () => {
-    vi.mocked(searchApi.search).mockRejectedValueOnce(new Error('network error'));
+  it('shows an error state, logs the failure, and retries successfully', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const networkError = new Error('network error');
+    vi.mocked(searchApi.search).mockRejectedValueOnce(networkError);
     renderSearch();
 
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
 
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to search:', networkError);
 
     mockSearchResponse({ animals: [rex], total_animals: 1 });
     fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    await flush();
 
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.getByText('Rex')).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
   });
 
-  it('omits the comments section entirely when type=animals, and vice versa', async () => {
+  it('does not surface an error for a cancelled/superseded request', async () => {
+    // Simulate what an aborted request looks like: axios rejects with a
+    // cancellation error, which axios.isCancel() must recognize so it's
+    // swallowed instead of shown as "Failed to search".
+    const { CanceledError } = await import('axios');
+    vi.mocked(searchApi.search).mockRejectedValueOnce(new CanceledError());
+    renderSearch();
+
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('hides the comments section entirely when type=animals', async () => {
     mockSearchResponse({ animals: [rex], total_animals: 1 });
     renderSearch();
 
     fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'animals' } });
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
 
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.getByText('Rex')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^Comments/ })).not.toBeInTheDocument();
-    expect(searchApi.search).toHaveBeenCalledWith(1, { q: 'guarding', type: 'animals', limit: 10, offset: 0 });
+    expect(searchApi.search).toHaveBeenCalledWith(
+      1,
+      { q: 'guarding', type: 'animals', limit: 10, offset: 0 },
+      { signal: expect.any(AbortSignal) }
+    );
+  });
+
+  it('hides the animals section entirely when type=comments', async () => {
+    mockSearchResponse({ comments: [rexComment], total_comments: 1 });
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'comments' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+
+    expect(screen.getByText('on Rex')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Animals/ })).not.toBeInTheDocument();
+    expect(searchApi.search).toHaveBeenCalledWith(
+      1,
+      { q: 'guarding', type: 'comments', limit: 10, offset: 0 },
+      { signal: expect.any(AbortSignal) }
+    );
   });
 
   it('loads more results on click, appending to the existing list and advancing the offset', async () => {
@@ -143,17 +211,22 @@ describe('GroupSearch', () => {
       .mockResolvedValueOnce({ data: { animals: [page2], total_animals: 2 } } as AxiosResponse<SearchResponse>);
 
     renderSearch();
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'dog' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'dog');
 
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.getByText('Rex')).toBeInTheDocument();
     const loadMore = screen.getByRole('button', { name: /load more results/i });
 
     fireEvent.click(loadMore);
+    await flush();
 
-    expect(await screen.findByText('Fido')).toBeInTheDocument();
+    expect(screen.getByText('Fido')).toBeInTheDocument();
     expect(screen.getByText('Rex')).toBeInTheDocument();
 
-    expect(searchApi.search).toHaveBeenLastCalledWith(1, { q: 'dog', type: 'all', limit: 10, offset: 10 });
+    expect(searchApi.search).toHaveBeenLastCalledWith(
+      1,
+      { q: 'dog', type: 'all', limit: 10, offset: 10 },
+      { signal: expect.any(AbortSignal) }
+    );
   });
 
   it('clears results when the query is cleared back to empty', async () => {
@@ -161,10 +234,53 @@ describe('GroupSearch', () => {
     renderSearch();
 
     const input = screen.getByLabelText('Search animals and comments');
-    fireEvent.change(input, { target: { value: 'guarding' } });
-    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    await typeQuery(input, 'guarding');
+    expect(screen.getByText('Rex')).toBeInTheDocument();
 
     fireEvent.change(input, { target: { value: '' } });
-    await waitFor(() => expect(screen.queryByText('Rex')).not.toBeInTheDocument());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    expect(screen.queryByText('Rex')).not.toBeInTheDocument();
+  });
+
+  it('clears stale results immediately when groupId changes, and searches the new group', async () => {
+    const groupAAnimal: SearchAnimalResult = { ...rex, id: 1, name: 'Rex' };
+    const groupBAnimal: SearchAnimalResult = { ...rex, id: 99, name: 'Buddy' };
+
+    vi.mocked(searchApi.search)
+      .mockResolvedValueOnce({ data: { animals: [groupAAnimal], total_animals: 1 } } as AxiosResponse<SearchResponse>)
+      .mockResolvedValueOnce({ data: { animals: [groupBAnimal], total_animals: 1 } } as AxiosResponse<SearchResponse>);
+
+    const { rerender } = renderSearch(1);
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'dog');
+    expect(screen.getByText('Rex')).toBeInTheDocument();
+
+    const rexLink = screen.getByText('Rex').closest('a');
+    expect(rexLink).toHaveAttribute('href', '/groups/1/animals/1/view');
+
+    await act(async () => {
+      rerender(
+        <BrowserRouter>
+          <GroupSearch groupId={2} />
+        </BrowserRouter>
+      );
+    });
+
+    // Group A's result must be gone immediately, before group B's search
+    // resolves — otherwise it would briefly render under a /groups/2/... link.
+    expect(screen.queryByText('Rex')).not.toBeInTheDocument();
+
+    await flush();
+
+    expect(screen.getByText('Buddy')).toBeInTheDocument();
+    const buddyLink = screen.getByText('Buddy').closest('a');
+    expect(buddyLink).toHaveAttribute('href', '/groups/2/animals/99/view');
+
+    expect(searchApi.search).toHaveBeenLastCalledWith(
+      2,
+      { q: 'dog', type: 'all', limit: 10, offset: 0 },
+      { signal: expect.any(AbortSignal) }
+    );
   });
 });

--- a/frontend/src/components/GroupSearch.test.tsx
+++ b/frontend/src/components/GroupSearch.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import GroupSearch from './GroupSearch';
+import { searchApi } from '../api/client';
+import type { SearchAnimalResult, SearchCommentResult, SearchResponse } from '../api/client';
+import type { AxiosResponse } from 'axios';
+
+vi.mock('../api/client', () => ({
+  searchApi: {
+    search: vi.fn(),
+  },
+}));
+
+const renderSearch = (groupId = 1) =>
+  render(
+    <BrowserRouter>
+      <GroupSearch groupId={groupId} />
+    </BrowserRouter>
+  );
+
+const mockSearchResponse = (data: SearchResponse) => {
+  vi.mocked(searchApi.search).mockResolvedValue({ data } as AxiosResponse<SearchResponse>);
+};
+
+const rex: SearchAnimalResult = {
+  id: 1,
+  group_id: 1,
+  name: 'Rex',
+  species: 'Dog',
+  breed: 'Shepherd',
+  age: 3,
+  description: 'Shows resource guarding around food bowls.',
+  image_url: '',
+  status: 'available',
+  is_returned: false,
+  rank: 0.5,
+};
+
+const rexComment: SearchCommentResult = {
+  id: 10,
+  animal_id: 1,
+  user_id: 1,
+  content: 'Rex had a great playgroup session today.',
+  image_url: '',
+  is_edited: false,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  animal_name: 'Rex',
+  rank: 0.3,
+};
+
+describe('GroupSearch', () => {
+  beforeEach(() => {
+    vi.mocked(searchApi.search).mockReset();
+  });
+
+  it('shows no results panel before a query is typed', () => {
+    renderSearch();
+    expect(searchApi.search).not.toHaveBeenCalled();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('searches with q/type/limit/offset and displays animal and comment matches', async () => {
+    mockSearchResponse({ animals: [rex], total_animals: 1, comments: [rexComment], total_comments: 1 });
+    renderSearch(7);
+
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), {
+      target: { value: 'resource guarding' },
+    });
+
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.getByText('on Rex')).toBeInTheDocument();
+    expect(screen.getByText(/Rex had a great playgroup session today\./)).toBeInTheDocument();
+
+    expect(searchApi.search).toHaveBeenCalledWith(7, {
+      q: 'resource guarding',
+      type: 'all',
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  it('shows a loading state while the request is in flight', async () => {
+    let resolveRequest: (value: AxiosResponse<SearchResponse>) => void = () => {};
+    vi.mocked(searchApi.search).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+
+    expect(await screen.findAllByRole('status')).not.toHaveLength(0);
+
+    resolveRequest({ data: { animals: [rex], total_animals: 1 } } as AxiosResponse<SearchResponse>);
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when a query matches nothing', async () => {
+    mockSearchResponse({ animals: [], total_animals: 0, comments: [], total_comments: 0 });
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'nonexistentterm' } });
+
+    expect(await screen.findByText('No matches found')).toBeInTheDocument();
+    expect(screen.getByText(/nonexistentterm/)).toBeInTheDocument();
+  });
+
+  it('shows an error state with a working retry on failure', async () => {
+    vi.mocked(searchApi.search).mockRejectedValueOnce(new Error('network error'));
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    mockSearchResponse({ animals: [rex], total_animals: 1 });
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+  });
+
+  it('omits the comments section entirely when type=animals, and vice versa', async () => {
+    mockSearchResponse({ animals: [rex], total_animals: 1 });
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'animals' } });
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Comments/ })).not.toBeInTheDocument();
+    expect(searchApi.search).toHaveBeenCalledWith(1, { q: 'guarding', type: 'animals', limit: 10, offset: 0 });
+  });
+
+  it('loads more results on click, appending to the existing list and advancing the offset', async () => {
+    const page1: SearchAnimalResult = { ...rex, id: 1, name: 'Rex' };
+    const page2: SearchAnimalResult = { ...rex, id: 2, name: 'Fido' };
+
+    vi.mocked(searchApi.search)
+      .mockResolvedValueOnce({ data: { animals: [page1], total_animals: 2 } } as AxiosResponse<SearchResponse>)
+      .mockResolvedValueOnce({ data: { animals: [page2], total_animals: 2 } } as AxiosResponse<SearchResponse>);
+
+    renderSearch();
+    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'dog' } });
+
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+    const loadMore = screen.getByRole('button', { name: /load more results/i });
+
+    fireEvent.click(loadMore);
+
+    expect(await screen.findByText('Fido')).toBeInTheDocument();
+    expect(screen.getByText('Rex')).toBeInTheDocument();
+
+    expect(searchApi.search).toHaveBeenLastCalledWith(1, { q: 'dog', type: 'all', limit: 10, offset: 10 });
+  });
+
+  it('clears results when the query is cleared back to empty', async () => {
+    mockSearchResponse({ animals: [rex], total_animals: 1 });
+    renderSearch();
+
+    const input = screen.getByLabelText('Search animals and comments');
+    fireEvent.change(input, { target: { value: 'guarding' } });
+    expect(await screen.findByText('Rex')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => expect(screen.queryByText('Rex')).not.toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/GroupSearch.test.tsx
+++ b/frontend/src/components/GroupSearch.test.tsx
@@ -103,7 +103,7 @@ describe('GroupSearch', () => {
     mockSearchResponse({ animals: [rex], total_animals: 1, comments: [rexComment], total_comments: 1 });
     renderSearch(7);
 
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'resource guarding');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'resource guarding');
 
     expect(screen.getByText('Rex')).toBeInTheDocument();
     expect(screen.getByText('on Rex')).toBeInTheDocument();
@@ -126,7 +126,7 @@ describe('GroupSearch', () => {
     );
     renderSearch();
 
-    fireEvent.change(screen.getByLabelText('Search animals and comments'), { target: { value: 'guarding' } });
+    fireEvent.change(screen.getByLabelText('Search animals, comments, and updates'), { target: { value: 'guarding' } });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     });
@@ -144,7 +144,7 @@ describe('GroupSearch', () => {
     mockSearchResponse({ animals: [], total_animals: 0, comments: [], total_comments: 0 });
     renderSearch();
 
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'nonexistentterm');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'nonexistentterm');
 
     expect(screen.getByText('No matches found')).toBeInTheDocument();
     expect(screen.getByText(/nonexistentterm/)).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe('GroupSearch', () => {
     vi.mocked(searchApi.search).mockRejectedValueOnce(networkError);
     renderSearch();
 
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'guarding');
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to search:', networkError);
@@ -177,7 +177,7 @@ describe('GroupSearch', () => {
     vi.mocked(searchApi.search).mockRejectedValueOnce(new CanceledError());
     renderSearch();
 
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'guarding');
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
@@ -187,7 +187,7 @@ describe('GroupSearch', () => {
     renderSearch();
 
     fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'animals' } });
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'guarding');
 
     expect(screen.getByText('Rex')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^Comments/ })).not.toBeInTheDocument();
@@ -202,12 +202,12 @@ describe('GroupSearch', () => {
     mockSearchResponse({ animals: [rex], total_animals: 1, updates: [playgroupUpdate], total_updates: 1 });
     renderSearch();
 
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'pairings');
 
     expect(screen.getByText('Playgroup Saturday')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'comments' } });
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'pairings');
     expect(screen.queryByText('Playgroup Saturday')).not.toBeInTheDocument();
   });
 
@@ -216,7 +216,7 @@ describe('GroupSearch', () => {
     renderSearch();
 
     fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'comments' } });
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'guarding');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'guarding');
 
     expect(screen.getByText('on Rex')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^Animals/ })).not.toBeInTheDocument();
@@ -232,7 +232,7 @@ describe('GroupSearch', () => {
     renderSearch();
 
     fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'updates' } });
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'pairings');
 
     expect(screen.getByText('Playgroup Saturday')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^Animals/ })).not.toBeInTheDocument();
@@ -253,7 +253,7 @@ describe('GroupSearch', () => {
       .mockResolvedValueOnce({ data: { animals: [page2], total_animals: 2 } } as AxiosResponse<SearchResponse>);
 
     renderSearch();
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'dog');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'dog');
 
     expect(screen.getByText('Rex')).toBeInTheDocument();
     const loadMore = screen.getByRole('button', { name: /load more results/i });
@@ -275,7 +275,7 @@ describe('GroupSearch', () => {
     mockSearchResponse({ animals: [rex], total_animals: 1 });
     renderSearch();
 
-    const input = screen.getByLabelText('Search animals and comments');
+    const input = screen.getByLabelText('Search animals, comments, and updates');
     await typeQuery(input, 'guarding');
     expect(screen.getByText('Rex')).toBeInTheDocument();
 
@@ -295,7 +295,7 @@ describe('GroupSearch', () => {
       .mockResolvedValueOnce({ data: { animals: [groupBAnimal], total_animals: 1 } } as AxiosResponse<SearchResponse>);
 
     const { rerender } = renderSearch(1);
-    await typeQuery(screen.getByLabelText('Search animals and comments'), 'dog');
+    await typeQuery(screen.getByLabelText('Search animals, comments, and updates'), 'dog');
     expect(screen.getByText('Rex')).toBeInTheDocument();
 
     const rexLink = screen.getByText('Rex').closest('a');

--- a/frontend/src/components/GroupSearch.test.tsx
+++ b/frontend/src/components/GroupSearch.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import GroupSearch from './GroupSearch';
 import { searchApi } from '../api/client';
-import type { SearchAnimalResult, SearchCommentResult, SearchResponse } from '../api/client';
+import type { SearchAnimalResult, SearchCommentResult, SearchUpdateResult, SearchResponse } from '../api/client';
 import type { AxiosResponse } from 'axios';
 
 vi.mock('../api/client', () => ({
@@ -69,6 +69,18 @@ const rexComment: SearchCommentResult = {
   updated_at: '2026-07-01T00:00:00Z',
   animal_name: 'Rex',
   rank: 0.3,
+};
+
+const playgroupUpdate: SearchUpdateResult = {
+  id: 20,
+  group_id: 1,
+  user_id: 1,
+  title: 'Playgroup Saturday',
+  content: 'Pairings: Rex+Fido, Bella+Max. 10am at the field.',
+  image_url: '',
+  send_groupme: false,
+  created_at: '2026-07-01T00:00:00Z',
+  rank: 0.4,
 };
 
 describe('GroupSearch', () => {
@@ -186,6 +198,19 @@ describe('GroupSearch', () => {
     );
   });
 
+  it('shows update matches and hides them when type=comments', async () => {
+    mockSearchResponse({ animals: [rex], total_animals: 1, updates: [playgroupUpdate], total_updates: 1 });
+    renderSearch();
+
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+
+    expect(screen.getByText('Playgroup Saturday')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'comments' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+    expect(screen.queryByText('Playgroup Saturday')).not.toBeInTheDocument();
+  });
+
   it('hides the animals section entirely when type=comments', async () => {
     mockSearchResponse({ comments: [rexComment], total_comments: 1 });
     renderSearch();
@@ -198,6 +223,23 @@ describe('GroupSearch', () => {
     expect(searchApi.search).toHaveBeenCalledWith(
       1,
       { q: 'guarding', type: 'comments', limit: 10, offset: 0 },
+      { signal: expect.any(AbortSignal) }
+    );
+  });
+
+  it('hides the animals and comments sections entirely when type=updates', async () => {
+    mockSearchResponse({ updates: [playgroupUpdate], total_updates: 1 });
+    renderSearch();
+
+    fireEvent.change(screen.getByLabelText('Limit search to'), { target: { value: 'updates' } });
+    await typeQuery(screen.getByLabelText('Search animals and comments'), 'pairings');
+
+    expect(screen.getByText('Playgroup Saturday')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Animals/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Comments/ })).not.toBeInTheDocument();
+    expect(searchApi.search).toHaveBeenCalledWith(
+      1,
+      { q: 'pairings', type: 'updates', limit: 10, offset: 0 },
       { signal: expect.any(AbortSignal) }
     );
   });

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { searchApi } from '../api/client';
+import type { SearchAnimalResult, SearchCommentResult } from '../api/client';
+import { useDebounce } from '../hooks/useDebounce';
+import EmptyState from './EmptyState';
+import ErrorState from './ErrorState';
+import SkeletonLoader from './SkeletonLoader';
+import './GroupSearch.css';
+
+const PAGE_SIZE = 10;
+const DEBOUNCE_MS = 400;
+const SNIPPET_LENGTH = 160;
+
+type SearchType = 'all' | 'animals' | 'comments';
+
+interface GroupSearchProps {
+  groupId: number;
+}
+
+function snippet(text: string, length = SNIPPET_LENGTH): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= length) return trimmed;
+  return trimmed.slice(0, length).trimEnd() + '…';
+}
+
+const searchIcon = (
+  <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query.trim(), DEBOUNCE_MS);
+  const [type, setType] = useState<SearchType>('all');
+
+  const [animals, setAnimals] = useState<SearchAnimalResult[]>([]);
+  const [comments, setComments] = useState<SearchCommentResult[]>([]);
+  const [totalAnimals, setTotalAnimals] = useState(0);
+  const [totalComments, setTotalComments] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runSearch = useCallback(
+    async (q: string, searchType: SearchType, requestOffset: number, append: boolean) => {
+      if (!q) {
+        setAnimals([]);
+        setComments([]);
+        setTotalAnimals(0);
+        setTotalComments(0);
+        setError(null);
+        return;
+      }
+
+      if (append) setLoadingMore(true);
+      else setLoading(true);
+      setError(null);
+
+      try {
+        const response = await searchApi.search(groupId, {
+          q,
+          type: searchType,
+          limit: PAGE_SIZE,
+          offset: requestOffset,
+        });
+        const data = response.data;
+        setAnimals((prev) => (append ? [...prev, ...(data.animals ?? [])] : data.animals ?? []));
+        setComments((prev) => (append ? [...prev, ...(data.comments ?? [])] : data.comments ?? []));
+        setTotalAnimals(data.total_animals ?? 0);
+        setTotalComments(data.total_comments ?? 0);
+      } catch {
+        setError('Failed to search. Please try again.');
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [groupId]
+  );
+
+  // New query or type: reset pagination and replace results.
+  useEffect(() => {
+    setOffset(0);
+    runSearch(debouncedQuery, type, 0, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQuery, type, groupId]);
+
+  const handleLoadMore = () => {
+    const nextOffset = offset + PAGE_SIZE;
+    setOffset(nextOffset);
+    runSearch(debouncedQuery, type, nextOffset, true);
+  };
+
+  const showAnimals = type === 'all' || type === 'animals';
+  const showComments = type === 'all' || type === 'comments';
+  const hasResults = animals.length > 0 || comments.length > 0;
+  const canLoadMore =
+    (showAnimals && animals.length < totalAnimals) || (showComments && comments.length < totalComments);
+
+  return (
+    <div className="group-search">
+      <div className="group-search__controls">
+        <div className="group-search__input-wrap">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search animals and comments (e.g. &quot;resource guarding&quot;, &quot;playgroup&quot;)..."
+            aria-label="Search animals and comments"
+            className="group-search__input"
+          />
+        </div>
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as SearchType)}
+          aria-label="Limit search to"
+          className="group-search__type"
+        >
+          <option value="all">Animals &amp; Comments</option>
+          <option value="animals">Animals Only</option>
+          <option value="comments">Comments Only</option>
+        </select>
+      </div>
+
+      {!debouncedQuery ? null : loading ? (
+        <div className="group-search__results">
+          <SkeletonLoader variant="card" count={2} />
+        </div>
+      ) : error ? (
+        <div className="group-search__results">
+          <ErrorState message={error} onRetry={() => runSearch(debouncedQuery, type, 0, false)} />
+        </div>
+      ) : !hasResults ? (
+        <div className="group-search__results">
+          <EmptyState
+            icon={searchIcon}
+            title="No matches found"
+            description={`Nothing matched "${debouncedQuery}". Try a different word or phrase.`}
+          />
+        </div>
+      ) : (
+        <div className="group-search__results">
+          {showAnimals && animals.length > 0 && (
+            <div className="group-search__section">
+              <h3 className="group-search__section-title">
+                Animals <span className="group-search__count">({totalAnimals})</span>
+              </h3>
+              <ul className="group-search__animal-list">
+                {animals.map((animal) => (
+                  <li key={animal.id}>
+                    <Link
+                      to={`/groups/${groupId}/animals/${animal.id}/view`}
+                      className="group-search__animal-result"
+                    >
+                      <span className="group-search__animal-name">{animal.name}</span>
+                      <span className="group-search__animal-meta">
+                        {[animal.species, animal.breed].filter(Boolean).join(' · ')}
+                      </span>
+                      {animal.description && (
+                        <span className="group-search__snippet">{snippet(animal.description)}</span>
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {showComments && comments.length > 0 && (
+            <div className="group-search__section">
+              <h3 className="group-search__section-title">
+                Comments <span className="group-search__count">({totalComments})</span>
+              </h3>
+              <ul className="group-search__comment-list">
+                {comments.map((comment) => (
+                  <li key={comment.id}>
+                    <Link
+                      to={`/groups/${groupId}/animals/${comment.animal_id}/view`}
+                      className="group-search__comment-result"
+                    >
+                      <span className="group-search__comment-animal">on {comment.animal_name}</span>
+                      <span className="group-search__snippet">{snippet(comment.content)}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {canLoadMore && (
+            <button
+              type="button"
+              className="btn-secondary group-search__load-more"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+            >
+              {loadingMore ? 'Loading…' : 'Load more results'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GroupSearch;

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -85,6 +85,13 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
       if (!q) {
         setResults(emptyResults);
         setError(null);
+        // Also clear both loading flags: this call just replaced
+        // abortControllerRef.current, so if a previous request (e.g. a
+        // "load more") was still in flight, its own `finally` block will no
+        // longer match the current controller and won't clear loadingMore
+        // itself — leaving the "Load more" button stuck disabled.
+        setLoading(false);
+        setLoadingMore(false);
         return;
       }
 
@@ -144,8 +151,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
   useEffect(() => {
     setOffset(0);
     runSearch(debouncedQuery, type, 0, false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedQuery, type, groupId]);
+  }, [debouncedQuery, type, groupId, runSearch]);
 
   // Cancel any in-flight request on unmount so it can't set state on an
   // unmounted component.
@@ -184,8 +190,8 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search animals and comments (e.g. &quot;resource guarding&quot;, &quot;playgroup&quot;)..."
-            aria-label="Search animals and comments"
+            placeholder="Search animals, comments, and updates (e.g. &quot;resource guarding&quot;, &quot;playgroup&quot;)..."
+            aria-label="Search animals, comments, and updates"
             className="group-search__input"
           />
         </div>

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -176,7 +176,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
           aria-label="Limit search to"
           className="group-search__type"
         >
-          <option value="all">Animals &amp; Comments</option>
+          <option value="all">All</option>
           <option value="animals">Animals Only</option>
           <option value="comments">Comments Only</option>
           <option value="updates">Updates Only</option>

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { searchApi } from '../api/client';
-import type { SearchAnimalResult, SearchCommentResult } from '../api/client';
+import type { SearchAnimalResult, SearchCommentResult, SearchUpdateResult } from '../api/client';
 import { useDebounce } from '../hooks/useDebounce';
 import EmptyState from './EmptyState';
 import ErrorState from './ErrorState';
@@ -13,7 +13,7 @@ const PAGE_SIZE = 10;
 const DEBOUNCE_MS = 400;
 const SNIPPET_LENGTH = 160;
 
-type SearchType = 'all' | 'animals' | 'comments';
+type SearchType = 'all' | 'animals' | 'comments' | 'updates';
 
 interface GroupSearchProps {
   groupId: number;
@@ -39,8 +39,10 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
 
   const [animals, setAnimals] = useState<SearchAnimalResult[]>([]);
   const [comments, setComments] = useState<SearchCommentResult[]>([]);
+  const [updates, setUpdates] = useState<SearchUpdateResult[]>([]);
   const [totalAnimals, setTotalAnimals] = useState(0);
   const [totalComments, setTotalComments] = useState(0);
+  const [totalUpdates, setTotalUpdates] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -60,8 +62,10 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
       if (!q) {
         setAnimals([]);
         setComments([]);
+        setUpdates([]);
         setTotalAnimals(0);
         setTotalComments(0);
+        setTotalUpdates(0);
         setError(null);
         return;
       }
@@ -79,8 +83,10 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
         const data = response.data;
         setAnimals((prev) => (append ? [...prev, ...(data.animals ?? [])] : data.animals ?? []));
         setComments((prev) => (append ? [...prev, ...(data.comments ?? [])] : data.comments ?? []));
+        setUpdates((prev) => (append ? [...prev, ...(data.updates ?? [])] : data.updates ?? []));
         setTotalAnimals(data.total_animals ?? 0);
         setTotalComments(data.total_comments ?? 0);
+        setTotalUpdates(data.total_updates ?? 0);
       } catch (err) {
         // A superseded/cancelled request rejects here too — ignore it
         // silently rather than surfacing an error for a search the user
@@ -109,8 +115,10 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
   useEffect(() => {
     setAnimals([]);
     setComments([]);
+    setUpdates([]);
     setTotalAnimals(0);
     setTotalComments(0);
+    setTotalUpdates(0);
     setError(null);
   }, [groupId]);
 
@@ -138,9 +146,12 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
 
   const showAnimals = type === 'all' || type === 'animals';
   const showComments = type === 'all' || type === 'comments';
-  const hasResults = animals.length > 0 || comments.length > 0;
+  const showUpdates = type === 'all' || type === 'updates';
+  const hasResults = animals.length > 0 || comments.length > 0 || updates.length > 0;
   const canLoadMore =
-    (showAnimals && animals.length < totalAnimals) || (showComments && comments.length < totalComments);
+    (showAnimals && animals.length < totalAnimals) ||
+    (showComments && comments.length < totalComments) ||
+    (showUpdates && updates.length < totalUpdates);
 
   return (
     <div className="group-search">
@@ -168,6 +179,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
           <option value="all">Animals &amp; Comments</option>
           <option value="animals">Animals Only</option>
           <option value="comments">Comments Only</option>
+          <option value="updates">Updates Only</option>
         </select>
       </div>
 
@@ -229,6 +241,27 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
                     >
                       <span className="group-search__comment-animal">on {comment.animal_name}</span>
                       <span className="group-search__snippet">{snippet(comment.content)}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {showUpdates && updates.length > 0 && (
+            <div className="group-search__section">
+              <h3 className="group-search__section-title">
+                Updates <span className="group-search__count">({totalUpdates})</span>
+              </h3>
+              <ul className="group-search__comment-list">
+                {updates.map((update) => (
+                  <li key={update.id}>
+                    <Link
+                      to={`/groups/${groupId}?view=activity`}
+                      className="group-search__comment-result"
+                    >
+                      <span className="group-search__comment-animal">{update.title}</span>
+                      <span className="group-search__snippet">{snippet(update.content)}</span>
                     </Link>
                   </li>
                 ))}

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -22,7 +22,12 @@ interface GroupSearchProps {
 function snippet(text: string, length = SNIPPET_LENGTH): string {
   const trimmed = text.trim();
   if (trimmed.length <= length) return trimmed;
-  return trimmed.slice(0, length).trimEnd() + '…';
+  // Array.from splits on Unicode code points rather than UTF-16 code units,
+  // so a truncation boundary can't land in the middle of a surrogate pair
+  // (e.g. an emoji) the way String.slice's code-unit indexing can.
+  const codePoints = Array.from(trimmed);
+  if (codePoints.length <= length) return trimmed;
+  return codePoints.slice(0, length).join('').trimEnd() + '…';
 }
 
 const searchIcon = (
@@ -32,17 +37,35 @@ const searchIcon = (
   </svg>
 );
 
+// Animals/comments/updates results are kept in one state object (rather than
+// six separate useState calls) so resetting them — on an empty query or a
+// group switch — is always a single setResults(emptyResults) instead of
+// several setX(...) calls that could drift out of sync with each other if a
+// future resource type were added.
+interface SearchResults {
+  animals: SearchAnimalResult[];
+  comments: SearchCommentResult[];
+  updates: SearchUpdateResult[];
+  totalAnimals: number;
+  totalComments: number;
+  totalUpdates: number;
+}
+
+const emptyResults: SearchResults = {
+  animals: [],
+  comments: [],
+  updates: [],
+  totalAnimals: 0,
+  totalComments: 0,
+  totalUpdates: 0,
+};
+
 const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query.trim(), DEBOUNCE_MS);
   const [type, setType] = useState<SearchType>('all');
 
-  const [animals, setAnimals] = useState<SearchAnimalResult[]>([]);
-  const [comments, setComments] = useState<SearchCommentResult[]>([]);
-  const [updates, setUpdates] = useState<SearchUpdateResult[]>([]);
-  const [totalAnimals, setTotalAnimals] = useState(0);
-  const [totalComments, setTotalComments] = useState(0);
-  const [totalUpdates, setTotalUpdates] = useState(0);
+  const [results, setResults] = useState<SearchResults>(emptyResults);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -60,12 +83,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
       abortControllerRef.current = controller;
 
       if (!q) {
-        setAnimals([]);
-        setComments([]);
-        setUpdates([]);
-        setTotalAnimals(0);
-        setTotalComments(0);
-        setTotalUpdates(0);
+        setResults(emptyResults);
         setError(null);
         return;
       }
@@ -81,19 +99,23 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
           { signal: controller.signal }
         );
         const data = response.data;
-        setAnimals((prev) => (append ? [...prev, ...(data.animals ?? [])] : data.animals ?? []));
-        setComments((prev) => (append ? [...prev, ...(data.comments ?? [])] : data.comments ?? []));
-        setUpdates((prev) => (append ? [...prev, ...(data.updates ?? [])] : data.updates ?? []));
-        setTotalAnimals(data.total_animals ?? 0);
-        setTotalComments(data.total_comments ?? 0);
-        setTotalUpdates(data.total_updates ?? 0);
+        setResults((prev) => ({
+          animals: append ? [...prev.animals, ...(data.animals ?? [])] : data.animals ?? [],
+          comments: append ? [...prev.comments, ...(data.comments ?? [])] : data.comments ?? [],
+          updates: append ? [...prev.updates, ...(data.updates ?? [])] : data.updates ?? [],
+          totalAnimals: data.total_animals ?? 0,
+          totalComments: data.total_comments ?? 0,
+          totalUpdates: data.total_updates ?? 0,
+        }));
       } catch (err) {
         // A superseded/cancelled request rejects here too — ignore it
         // silently rather than surfacing an error for a search the user
         // has already moved on from.
         if (axios.isCancel(err)) return;
         console.error('Failed to search:', err);
-        setError('Failed to search. Please try again.');
+        const message =
+          (axios.isAxiosError(err) && err.response?.data?.error) || 'Failed to search. Please try again.';
+        setError(message);
       } finally {
         // Only the request that's still current should clear the loading
         // flags — an aborted, superseded request's `finally` must not flip
@@ -113,12 +135,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
   // still render — but under Links built from the *new* groupId, pointing
   // at the *old* group's animal IDs.
   useEffect(() => {
-    setAnimals([]);
-    setComments([]);
-    setUpdates([]);
-    setTotalAnimals(0);
-    setTotalComments(0);
-    setTotalUpdates(0);
+    setResults(emptyResults);
     setError(null);
   }, [groupId]);
 
@@ -143,6 +160,8 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
     setOffset(nextOffset);
     runSearch(debouncedQuery, type, nextOffset, true);
   };
+
+  const { animals, comments, updates, totalAnimals, totalComments, totalUpdates } = results;
 
   const showAnimals = type === 'all' || type === 'animals';
   const showComments = type === 'all' || type === 'comments';

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
+import axios from 'axios';
 import { searchApi } from '../api/client';
 import type { SearchAnimalResult, SearchCommentResult } from '../api/client';
 import { useDebounce } from '../hooks/useDebounce';
@@ -45,8 +46,17 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Tracks the in-flight request so a newer call can cancel an older one —
+  // without this, a slower earlier response could resolve after a faster
+  // later one and overwrite fresher results with stale data.
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   const runSearch = useCallback(
     async (q: string, searchType: SearchType, requestOffset: number, append: boolean) => {
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
       if (!q) {
         setAnimals([]);
         setComments([]);
@@ -61,33 +71,64 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
       setError(null);
 
       try {
-        const response = await searchApi.search(groupId, {
-          q,
-          type: searchType,
-          limit: PAGE_SIZE,
-          offset: requestOffset,
-        });
+        const response = await searchApi.search(
+          groupId,
+          { q, type: searchType, limit: PAGE_SIZE, offset: requestOffset },
+          { signal: controller.signal }
+        );
         const data = response.data;
         setAnimals((prev) => (append ? [...prev, ...(data.animals ?? [])] : data.animals ?? []));
         setComments((prev) => (append ? [...prev, ...(data.comments ?? [])] : data.comments ?? []));
         setTotalAnimals(data.total_animals ?? 0);
         setTotalComments(data.total_comments ?? 0);
-      } catch {
+      } catch (err) {
+        // A superseded/cancelled request rejects here too — ignore it
+        // silently rather than surfacing an error for a search the user
+        // has already moved on from.
+        if (axios.isCancel(err)) return;
+        console.error('Failed to search:', err);
         setError('Failed to search. Please try again.');
       } finally {
-        setLoading(false);
-        setLoadingMore(false);
+        // Only the request that's still current should clear the loading
+        // flags — an aborted, superseded request's `finally` must not flip
+        // them back off after a newer request has already set them.
+        if (abortControllerRef.current === controller) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
     },
     [groupId]
   );
 
-  // New query or type: reset pagination and replace results.
+  // Group switch: clear results immediately, before the new search below
+  // even resolves. Without this, for the brief window until the new
+  // request completes, the previous group's animal/comment data would
+  // still render — but under Links built from the *new* groupId, pointing
+  // at the *old* group's animal IDs.
+  useEffect(() => {
+    setAnimals([]);
+    setComments([]);
+    setTotalAnimals(0);
+    setTotalComments(0);
+    setError(null);
+  }, [groupId]);
+
+  // New query, type, or group: reset pagination and (re)search from the
+  // first page.
   useEffect(() => {
     setOffset(0);
     runSearch(debouncedQuery, type, 0, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedQuery, type, groupId]);
+
+  // Cancel any in-flight request on unmount so it can't set state on an
+  // unmounted component.
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   const handleLoadMore = () => {
     const nextOffset = offset + PAGE_SIZE;
@@ -147,7 +188,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
           />
         </div>
       ) : (
-        <div className="group-search__results">
+        <div className="group-search__results" role="status" aria-live="polite">
           {showAnimals && animals.length > 0 && (
             <div className="group-search__section">
               <h3 className="group-search__section-title">

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -10,6 +10,7 @@ import AnnouncementForm from '../components/AnnouncementForm';
 import EmptyState from '../components/EmptyState';
 import SkeletonLoader from '../components/SkeletonLoader';
 import ErrorState from '../components/ErrorState';
+import GroupSearch from '../components/GroupSearch';
 import Modal from '../components/Modal';
 import ScriptsList from '../components/ScriptsList';
 import { calculateAge, formatAge, formatQuarantineEndDate } from '../utils/dateUtils';
@@ -642,6 +643,8 @@ const GroupPage: React.FC = () => {
           aria-labelledby="activity-tab"
           className="group-content"
         >
+          {id && <GroupSearch groupId={Number(id)} />}
+
           {/* Enhanced Activity Filter Bar */}
           <div className="activity-filter-bar">
             <div className="filter-row">
@@ -919,6 +922,8 @@ const GroupPage: React.FC = () => {
             <div className="section-header">
               <h2>Animals</h2>
             </div>
+
+            {id && <GroupSearch groupId={Number(id)} />}
 
             {/* Filters */}
             <div className="filters-section">

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+	github.com/pgvector/pgvector-go v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/pgvector/pgvector-go v0.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/uptrace/opentelemetry-go-extra/otelgorm v0.3.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.69.0
@@ -62,7 +63,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
-	github.com/pgvector/pgvector-go v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pgvector/pgvector-go v0.4.0 h1:879hQCnuix1bkfa5TQISnnK9ik4Fo+cHj2vuZSgW5v4=
+github.com/pgvector/pgvector-go v0.4.0/go.mod h1:4fSXyjl1TYAIdByAql6JazKWRr2s7J0g4hcRY5cBFCk=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -472,6 +472,17 @@ func createCustomIndexes(db *gorm.DB) error {
 	// Generated tsvector column for full-text keyword/phrase search over animals.
 	// STORED + GENERATED ALWAYS means Postgres keeps it in sync on every
 	// insert/update automatically — no application-level reindexing needed.
+	//
+	// CAUTION: unlike a plain ADD COLUMN, adding a STORED generated column is
+	// NOT a metadata-only change — Postgres must compute and materialize the
+	// value for every existing row, which rewrites the whole table under an
+	// ACCESS EXCLUSIVE lock (blocking all reads and writes to it, including
+	// from other already-running instances on a rolling deploy) for as long
+	// as the rewrite takes. On a fresh/empty database this is instant; on any
+	// deployment with a non-trivial amount of existing animal/comment data,
+	// run this migration during a maintenance window rather than assuming it
+	// applies silently in the background. The same caution applies to the
+	// animal_comments.search_vector column below.
 	animalSearchVectorQuery := `
 		ALTER TABLE animals ADD COLUMN IF NOT EXISTS search_vector tsvector
 		GENERATED ALWAYS AS (
@@ -510,7 +521,9 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created trigram index idx_animals_name_trgm")
 	}
 
-	// Generated tsvector column for full-text keyword/phrase search over comments.
+	// Generated tsvector column for full-text keyword/phrase search over
+	// comments. Same table-rewrite/ACCESS EXCLUSIVE lock caution as
+	// animals.search_vector above applies here too.
 	commentSearchVectorQuery := `
 		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS search_vector tsvector
 		GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -601,6 +601,50 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created HNSW index idx_animal_comments_embedding")
 	}
 
+	// updates never got a search_vector column in the original keyword-search
+	// feature (it predates that feature), so this adds both keyword and
+	// semantic search capability together, unlike animals/animal_comments
+	// above which only needed the embedding half added.
+	updateSearchVectorQuery := `
+		ALTER TABLE updates ADD COLUMN IF NOT EXISTS search_vector tsvector
+		GENERATED ALWAYS AS (
+			to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, ''))
+		) STORED
+	`
+	if err := db.Exec(updateSearchVectorQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add search_vector column to updates")
+	} else {
+		logging.Info("Ensured updates.search_vector column exists")
+	}
+
+	updateSearchVectorIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_updates_search_vector ON updates USING GIN (search_vector)
+	`
+	if err := db.Exec(updateSearchVectorIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create GIN index on updates.search_vector")
+	} else {
+		logging.Info("Created GIN index idx_updates_search_vector")
+	}
+
+	updateEmbeddingColumnsQuery := `
+		ALTER TABLE updates ADD COLUMN IF NOT EXISTS embedding vector(1024);
+		ALTER TABLE updates ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
+	`
+	if err := db.Exec(updateEmbeddingColumnsQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to updates (is the pgvector extension available?)")
+	} else {
+		logging.Info("Ensured updates.embedding/embedding_updated_at columns exist")
+	}
+
+	updateEmbeddingIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_updates_embedding ON updates USING hnsw (embedding vector_cosine_ops)
+	`
+	if err := db.Exec(updateEmbeddingIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create HNSW index on updates.embedding")
+	} else {
+		logging.Info("Created HNSW index idx_updates_embedding")
+	}
+
 	logging.Info("Custom indexes creation completed")
 	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -675,6 +675,15 @@ func quotedTableLiteralList(tables []string) string {
 	return strings.Join(quoted, ", ")
 }
 
+// embeddedResourceColumns lists every column, alongside "embedding" itself,
+// that the write path (PersistEmbedding) and reconciliation sweep depend on.
+// embedding_updated_at holds the optimistic-concurrency/staleness timestamp
+// both of those read and write — if it's missing while embedding exists
+// (e.g. the two ALTER TABLE statements in createCustomIndexes' combined Exec
+// call ever stop being atomic), semantic search would look "ready" here but
+// fail the moment anything tries to persist or touch an embedding.
+var embeddedResourceColumns = []string{"embedding", "embedding_updated_at"}
+
 // VectorSchemaReady reports whether the pgvector extension, embedding
 // columns, and HNSW indexes createCustomIndexes attempts to create actually
 // exist. That creation is deliberately best-effort (warn-only, since some
@@ -691,25 +700,26 @@ func quotedTableLiteralList(tables []string) string {
 // inflate the counts and could make an incomplete public-schema setup look
 // ready, or vice versa.
 func VectorSchemaReady(db *gorm.DB) bool {
-	want := len(embeddedResourceTables)
+	wantColumns := len(embeddedResourceTables) * len(embeddedResourceColumns)
+	wantIndexes := len(embeddedResourceTables)
 
 	var columnCount int64
 	columnQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM information_schema.columns
 		WHERE table_schema = 'public'
 		  AND table_name IN (%s)
-		  AND column_name = 'embedding'
-	`, quotedTableLiteralList(embeddedResourceTables))
+		  AND column_name IN (%s)
+	`, quotedTableLiteralList(embeddedResourceTables), quotedTableLiteralList(embeddedResourceColumns))
 	if err := db.Raw(columnQuery).Scan(&columnCount).Error; err != nil {
 		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness (columns)")
 		return false
 	}
-	if int(columnCount) != want {
+	if int(columnCount) != wantColumns {
 		logMissingVectorSchema(db)
 		return false
 	}
 
-	indexNames := make([]string, want)
+	indexNames := make([]string, wantIndexes)
 	for i, t := range embeddedResourceTables {
 		indexNames[i] = vectorEmbeddingIndexName(t)
 	}
@@ -723,7 +733,7 @@ func VectorSchemaReady(db *gorm.DB) bool {
 		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness (indexes)")
 		return false
 	}
-	if int(indexCount) != want {
+	if int(indexCount) != wantIndexes {
 		logMissingVectorSchema(db)
 		return false
 	}
@@ -737,14 +747,16 @@ func VectorSchemaReady(db *gorm.DB) bool {
 // tell which of the three resource types' migration failed.
 func logMissingVectorSchema(db *gorm.DB) {
 	for _, table := range embeddedResourceTables {
-		var columnExists bool
-		if err := db.Raw(`
-			SELECT EXISTS (
-				SELECT 1 FROM information_schema.columns
-				WHERE table_schema = 'public' AND table_name = ? AND column_name = 'embedding'
-			)
-		`, table).Scan(&columnExists).Error; err == nil && !columnExists {
-			logging.WithField("table", table).Warn("Vector schema not ready: embedding column missing")
+		for _, column := range embeddedResourceColumns {
+			var columnExists bool
+			if err := db.Raw(`
+				SELECT EXISTS (
+					SELECT 1 FROM information_schema.columns
+					WHERE table_schema = 'public' AND table_name = ? AND column_name = ?
+				)
+			`, table, column).Scan(&columnExists).Error; err == nil && !columnExists {
+				logging.WithFields(map[string]interface{}{"table": table, "column": column}).Warn("Vector schema not ready: column missing")
+			}
 		}
 
 		indexName := vectorEmbeddingIndexName(table)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -460,6 +460,76 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created partial unique index idx_user_skill_tag_group_name_active")
 	}
 
+	// pg_trgm powers trigram similarity matching, used below for typo-tolerant
+	// animal name lookups alongside the phrase/keyword full-text search.
+	trgmExtensionQuery := `CREATE EXTENSION IF NOT EXISTS pg_trgm`
+	if err := db.Exec(trgmExtensionQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create pg_trgm extension")
+	} else {
+		logging.Info("Ensured pg_trgm extension exists")
+	}
+
+	// Generated tsvector column for full-text keyword/phrase search over animals.
+	// STORED + GENERATED ALWAYS means Postgres keeps it in sync on every
+	// insert/update automatically — no application-level reindexing needed.
+	animalSearchVectorQuery := `
+		ALTER TABLE animals ADD COLUMN IF NOT EXISTS search_vector tsvector
+		GENERATED ALWAYS AS (
+			to_tsvector('english',
+				coalesce(name, '') || ' ' ||
+				coalesce(species, '') || ' ' ||
+				coalesce(breed, '') || ' ' ||
+				coalesce(description, '') || ' ' ||
+				coalesce(trainer_notes, '')
+			)
+		) STORED
+	`
+	if err := db.Exec(animalSearchVectorQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add search_vector column to animals")
+	} else {
+		logging.Info("Ensured animals.search_vector column exists")
+	}
+
+	animalSearchVectorIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_animals_search_vector ON animals USING GIN (search_vector)
+	`
+	if err := db.Exec(animalSearchVectorIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create GIN index on animals.search_vector")
+	} else {
+		logging.Info("Created GIN index idx_animals_search_vector")
+	}
+
+	// Trigram index on animal name for typo-tolerant/partial matching,
+	// separate from the phrase-search vector above.
+	animalNameTrgmIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_animals_name_trgm ON animals USING GIN (name gin_trgm_ops)
+	`
+	if err := db.Exec(animalNameTrgmIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create trigram index on animals.name")
+	} else {
+		logging.Info("Created trigram index idx_animals_name_trgm")
+	}
+
+	// Generated tsvector column for full-text keyword/phrase search over comments.
+	commentSearchVectorQuery := `
+		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS search_vector tsvector
+		GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED
+	`
+	if err := db.Exec(commentSearchVectorQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add search_vector column to animal_comments")
+	} else {
+		logging.Info("Ensured animal_comments.search_vector column exists")
+	}
+
+	commentSearchVectorIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_animal_comments_search_vector ON animal_comments USING GIN (search_vector)
+	`
+	if err := db.Exec(commentSearchVectorIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create GIN index on animal_comments.search_vector")
+	} else {
+		logging.Info("Created GIN index idx_animal_comments_search_vector")
+	}
+
 	logging.Info("Custom indexes creation completed")
 	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -605,6 +605,7 @@ func createCustomIndexes(db *gorm.DB) error {
 	// feature (it predates that feature), so this adds both keyword and
 	// semantic search capability together, unlike animals/animal_comments
 	// above which only needed the embedding half added.
+	// Same table-rewrite/ACCESS EXCLUSIVE lock caution as animals.search_vector above applies here too.
 	updateSearchVectorQuery := `
 		ALTER TABLE updates ADD COLUMN IF NOT EXISTS search_vector tsvector
 		GENERATED ALWAYS AS (

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -650,25 +650,113 @@ func createCustomIndexes(db *gorm.DB) error {
 	return nil
 }
 
-// VectorSchemaReady reports whether the pgvector extension and embedding
-// columns createCustomIndexes attempts to create actually exist. That
-// creation is deliberately best-effort (warn-only, since some managed
-// Postgres providers reject CREATE EXTENSION), so nothing else in migration
-// signals failure — callers use this to decide whether it's safe to enable
-// semantic search, instead of discovering the gap as a query-time SQL error
-// against a column that was never created.
+// embeddedResourceTables lists every table createCustomIndexes adds an
+// embedding column and HNSW index to. VectorSchemaReady checks against this
+// same list — rather than a second hardcoded literal — so adding or
+// removing an embedded resource type only requires updating one place.
+var embeddedResourceTables = []string{"animals", "animal_comments", "updates"}
+
+// vectorEmbeddingIndexName returns the HNSW index name createCustomIndexes
+// creates for table's embedding column, following the "idx_<table>_embedding"
+// convention used throughout createCustomIndexes' embedding-index queries.
+func vectorEmbeddingIndexName(table string) string {
+	return "idx_" + table + "_embedding"
+}
+
+// quotedTableLiteralList renders tables as a comma-separated list of
+// single-quoted SQL literals for an IN (...) clause. Safe via fmt.Sprintf
+// only because every caller passes this package's own hardcoded table-name
+// constants — never user input.
+func quotedTableLiteralList(tables []string) string {
+	quoted := make([]string, len(tables))
+	for i, t := range tables {
+		quoted[i] = "'" + t + "'"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// VectorSchemaReady reports whether the pgvector extension, embedding
+// columns, and HNSW indexes createCustomIndexes attempts to create actually
+// exist. That creation is deliberately best-effort (warn-only, since some
+// managed Postgres providers reject CREATE EXTENSION or CREATE INDEX ...
+// USING hnsw), so nothing else in migration signals failure — callers use
+// this to decide whether it's safe to enable semantic search, instead of
+// discovering the gap as a query-time SQL error against a column that was
+// never created, or as a silent unindexed full-table scan on every semantic
+// query if only the index (and not the column) failed to create.
+//
+// Both checks are qualified to table_schema/schemaname = 'public': without
+// it, a same-named table or index in another schema on the search_path (a
+// shadow/template schema some migration tooling uses, for example) would
+// inflate the counts and could make an incomplete public-schema setup look
+// ready, or vice versa.
 func VectorSchemaReady(db *gorm.DB) bool {
-	var count int64
-	err := db.Raw(`
+	want := len(embeddedResourceTables)
+
+	var columnCount int64
+	columnQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM information_schema.columns
-		WHERE table_name IN ('animals', 'animal_comments', 'updates')
+		WHERE table_schema = 'public'
+		  AND table_name IN (%s)
 		  AND column_name = 'embedding'
-	`).Scan(&count).Error
-	if err != nil {
-		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness")
+	`, quotedTableLiteralList(embeddedResourceTables))
+	if err := db.Raw(columnQuery).Scan(&columnCount).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness (columns)")
 		return false
 	}
-	return count == 3
+	if int(columnCount) != want {
+		logMissingVectorSchema(db)
+		return false
+	}
+
+	indexNames := make([]string, want)
+	for i, t := range embeddedResourceTables {
+		indexNames[i] = vectorEmbeddingIndexName(t)
+	}
+	var indexCount int64
+	indexQuery := fmt.Sprintf(`
+		SELECT COUNT(*) FROM pg_indexes
+		WHERE schemaname = 'public'
+		  AND indexname IN (%s)
+	`, quotedTableLiteralList(indexNames))
+	if err := db.Raw(indexQuery).Scan(&indexCount).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness (indexes)")
+		return false
+	}
+	if int(indexCount) != want {
+		logMissingVectorSchema(db)
+		return false
+	}
+	return true
+}
+
+// logMissingVectorSchema is called only once VectorSchemaReady has already
+// determined the schema isn't fully ready. It re-checks each table/index
+// individually so the startup log names exactly what's missing, instead of
+// leaving the operator with only an aggregate count mismatch and no way to
+// tell which of the three resource types' migration failed.
+func logMissingVectorSchema(db *gorm.DB) {
+	for _, table := range embeddedResourceTables {
+		var columnExists bool
+		if err := db.Raw(`
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = 'public' AND table_name = ? AND column_name = 'embedding'
+			)
+		`, table).Scan(&columnExists).Error; err == nil && !columnExists {
+			logging.WithField("table", table).Warn("Vector schema not ready: embedding column missing")
+		}
+
+		indexName := vectorEmbeddingIndexName(table)
+		var indexExists bool
+		if err := db.Raw(`
+			SELECT EXISTS (
+				SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = ?
+			)
+		`, indexName).Scan(&indexExists).Error; err == nil && !indexExists {
+			logging.WithField("index", indexName).Warn("Vector schema not ready: HNSW index missing")
+		}
+	}
 }
 
 // createDefaultGroups creates the default groups if they don't exist

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -460,6 +460,64 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created partial unique index idx_user_skill_tag_group_name_active")
 	}
 
+	// pgvector powers the embedding columns/HNSW indexes below.
+	vectorExtensionQuery := `CREATE EXTENSION IF NOT EXISTS vector`
+	if err := db.Exec(vectorExtensionQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create vector extension")
+	} else {
+		logging.Info("Ensured vector extension exists")
+	}
+
+	// Embedding columns for semantic (hybrid) search. Unlike search_vector
+	// above, these can't be GENERATED columns — computing an embedding
+	// requires an external API call, which Postgres generated columns can't
+	// make. They're plain nullable columns populated by the application (see
+	// internal/embedding's write-path goroutine and reconciliation sweep).
+	// Deliberately not added to models.Animal/models.AnimalComment — see the
+	// comment on the search_vector columns above for why (AutoMigrate runs
+	// before this function, before the vector extension exists).
+	//
+	// Unlike the STORED generated tsvector columns above, adding a plain
+	// nullable vector column is metadata-only — no table rewrite, no
+	// ACCESS EXCLUSIVE lock, no maintenance-window concern.
+	animalEmbeddingColumnsQuery := `
+		ALTER TABLE animals ADD COLUMN IF NOT EXISTS embedding vector(1024);
+		ALTER TABLE animals ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
+	`
+	if err := db.Exec(animalEmbeddingColumnsQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to animals (is the pgvector extension available?)")
+	} else {
+		logging.Info("Ensured animals.embedding/embedding_updated_at columns exist")
+	}
+
+	animalEmbeddingIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_animals_embedding ON animals USING hnsw (embedding vector_cosine_ops)
+	`
+	if err := db.Exec(animalEmbeddingIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create HNSW index on animals.embedding")
+	} else {
+		logging.Info("Created HNSW index idx_animals_embedding")
+	}
+
+	commentEmbeddingColumnsQuery := `
+		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS embedding vector(1024);
+		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
+	`
+	if err := db.Exec(commentEmbeddingColumnsQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to animal_comments (is the pgvector extension available?)")
+	} else {
+		logging.Info("Ensured animal_comments.embedding/embedding_updated_at columns exist")
+	}
+
+	commentEmbeddingIndexQuery := `
+		CREATE INDEX IF NOT EXISTS idx_animal_comments_embedding ON animal_comments USING hnsw (embedding vector_cosine_ops)
+	`
+	if err := db.Exec(commentEmbeddingIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create HNSW index on animal_comments.embedding")
+	} else {
+		logging.Info("Created HNSW index idx_animal_comments_embedding")
+	}
+
 	logging.Info("Custom indexes creation completed")
 	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -650,6 +650,27 @@ func createCustomIndexes(db *gorm.DB) error {
 	return nil
 }
 
+// VectorSchemaReady reports whether the pgvector extension and embedding
+// columns createCustomIndexes attempts to create actually exist. That
+// creation is deliberately best-effort (warn-only, since some managed
+// Postgres providers reject CREATE EXTENSION), so nothing else in migration
+// signals failure — callers use this to decide whether it's safe to enable
+// semantic search, instead of discovering the gap as a query-time SQL error
+// against a column that was never created.
+func VectorSchemaReady(db *gorm.DB) bool {
+	var count int64
+	err := db.Raw(`
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_name IN ('animals', 'animal_comments', 'updates')
+		  AND column_name = 'embedding'
+	`).Scan(&count).Error
+	if err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to check vector schema readiness")
+		return false
+	}
+	return count == 3
+}
+
 // createDefaultGroups creates the default groups if they don't exist
 func createDefaultGroups(db *gorm.DB) error {
 	defaultGroups := []models.Group{

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -17,6 +17,17 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// vectorEmbeddingDimension is the width of the vector column
+// createCustomIndexes creates on animals/animal_comments/updates.embedding.
+// Must match embedding.Dimension (internal/embedding/embedder.go) — the two
+// can't share a single Go constant because internal/embedding's own
+// Postgres-gated test file imports internal/database, so internal/database
+// importing internal/embedding would create an import cycle. Centralized
+// here (instead of repeating the literal in three separate ALTER TABLE
+// strings) so a future embedding-model change with a different dimension
+// only needs updating in two places instead of four.
+const vectorEmbeddingDimension = 1024
+
 // Initialize creates and returns a database connection
 func Initialize() (*gorm.DB, error) {
 	dbHost := os.Getenv("DB_HOST")
@@ -460,8 +471,13 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created partial unique index idx_user_skill_tag_group_name_active")
 	}
 
-	// pg_trgm powers trigram similarity matching, used below for typo-tolerant
-	// animal name lookups alongside the phrase/keyword full-text search.
+	// pg_trgm powers trigram similarity matching. Only the extension and the
+	// GIN index below are set up so far — it currently accelerates the
+	// existing LOWER(name) LIKE '%...%' substring search in GetAnimals/
+	// GetAllAnimals (a plain B-tree index can't serve a leading-wildcard
+	// LIKE), but nothing yet queries via the actual %/similarity() fuzzy
+	// operators, so true typo-tolerant matching ("Rax" surfacing "Rex")
+	// isn't implemented yet — the infrastructure is just in place for it.
 	trgmExtensionQuery := `CREATE EXTENSION IF NOT EXISTS pg_trgm`
 	if err := db.Exec(trgmExtensionQuery).Error; err != nil {
 		logging.WithField("error", err.Error()).Warn("Failed to create pg_trgm extension")
@@ -563,10 +579,10 @@ func createCustomIndexes(db *gorm.DB) error {
 	// Unlike the STORED generated tsvector columns above, adding a plain
 	// nullable vector column is metadata-only — no table rewrite, no
 	// ACCESS EXCLUSIVE lock, no maintenance-window concern.
-	animalEmbeddingColumnsQuery := `
-		ALTER TABLE animals ADD COLUMN IF NOT EXISTS embedding vector(1024);
+	animalEmbeddingColumnsQuery := fmt.Sprintf(`
+		ALTER TABLE animals ADD COLUMN IF NOT EXISTS embedding vector(%d);
 		ALTER TABLE animals ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
-	`
+	`, vectorEmbeddingDimension)
 	if err := db.Exec(animalEmbeddingColumnsQuery).Error; err != nil {
 		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to animals (is the pgvector extension available?)")
 	} else {
@@ -582,10 +598,10 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created HNSW index idx_animals_embedding")
 	}
 
-	commentEmbeddingColumnsQuery := `
-		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS embedding vector(1024);
+	commentEmbeddingColumnsQuery := fmt.Sprintf(`
+		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS embedding vector(%d);
 		ALTER TABLE animal_comments ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
-	`
+	`, vectorEmbeddingDimension)
 	if err := db.Exec(commentEmbeddingColumnsQuery).Error; err != nil {
 		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to animal_comments (is the pgvector extension available?)")
 	} else {
@@ -627,10 +643,10 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created GIN index idx_updates_search_vector")
 	}
 
-	updateEmbeddingColumnsQuery := `
-		ALTER TABLE updates ADD COLUMN IF NOT EXISTS embedding vector(1024);
+	updateEmbeddingColumnsQuery := fmt.Sprintf(`
+		ALTER TABLE updates ADD COLUMN IF NOT EXISTS embedding vector(%d);
 		ALTER TABLE updates ADD COLUMN IF NOT EXISTS embedding_updated_at timestamptz
-	`
+	`, vectorEmbeddingDimension)
 	if err := db.Exec(updateEmbeddingColumnsQuery).Error; err != nil {
 		logging.WithField("error", err.Error()).Warn("Failed to add embedding columns to updates (is the pgvector extension available?)")
 	} else {

--- a/internal/database/database_postgres_test.go
+++ b/internal/database/database_postgres_test.go
@@ -76,6 +76,24 @@ func TestCreateCustomIndexes_CreatesEmbeddingColumnsAndIndexes(t *testing.T) {
 	`).Scan(&commentColumnExists).Error)
 	assert.True(t, commentColumnExists, "animal_comments.embedding column must exist after migration")
 
+	var animalsEmbeddingUpdatedAtExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'animals' AND column_name = 'embedding_updated_at'
+		)
+	`).Scan(&animalsEmbeddingUpdatedAtExists).Error)
+	assert.True(t, animalsEmbeddingUpdatedAtExists, "animals.embedding_updated_at column must exist after migration")
+
+	var commentEmbeddingUpdatedAtExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'animal_comments' AND column_name = 'embedding_updated_at'
+		)
+	`).Scan(&commentEmbeddingUpdatedAtExists).Error)
+	assert.True(t, commentEmbeddingUpdatedAtExists, "animal_comments.embedding_updated_at column must exist after migration")
+
 	var animalsIndexExists bool
 	assert.NoError(t, db.Raw(`
 		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_animals_embedding')

--- a/internal/database/database_postgres_test.go
+++ b/internal/database/database_postgres_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// Mirrors internal/handlers/search_postgres_test.go's gating pattern: skip
+// entirely if no Postgres is reachable, so `go test ./...` stays green
+// without a database.
+func openDatabaseTestPostgres(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	host := envOrDefault("DB_HOST", "localhost")
+	port := envOrDefault("DB_PORT", "5432")
+
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 2*time.Second)
+	if err != nil {
+		t.Skipf("skipping: no Postgres reachable at %s:%s", host, port)
+	}
+	_ = conn.Close()
+
+	user := envOrDefault("DB_USER", "postgres")
+	password := envOrDefault("DB_PASSWORD", "postgres")
+	dbname := envOrDefault("DB_NAME", "volunteer_media_test")
+	sslmode := envOrDefault("DB_SSLMODE", "disable")
+
+	dsn := "host=" + host + " port=" + port + " user=" + user + " password=" + password +
+		" dbname=" + dbname + " sslmode=" + sslmode + " connect_timeout=5"
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Skipf("skipping: could not connect to postgres database %q (%v)", dbname, err)
+	}
+	return db
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func TestCreateCustomIndexes_CreatesEmbeddingColumnsAndIndexes(t *testing.T) {
+	db := openDatabaseTestPostgres(t)
+
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations failed: %v", err)
+	}
+
+	var columnExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'animals' AND column_name = 'embedding'
+		)
+	`).Scan(&columnExists).Error)
+	assert.True(t, columnExists, "animals.embedding column must exist after migration")
+
+	var commentColumnExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'animal_comments' AND column_name = 'embedding'
+		)
+	`).Scan(&commentColumnExists).Error)
+	assert.True(t, commentColumnExists, "animal_comments.embedding column must exist after migration")
+
+	var animalsIndexExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_animals_embedding')
+	`).Scan(&animalsIndexExists).Error)
+	assert.True(t, animalsIndexExists, "idx_animals_embedding HNSW index must exist")
+
+	var commentsIndexExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_animal_comments_embedding')
+	`).Scan(&commentsIndexExists).Error)
+	assert.True(t, commentsIndexExists, "idx_animal_comments_embedding HNSW index must exist")
+}

--- a/internal/database/database_postgres_test.go
+++ b/internal/database/database_postgres_test.go
@@ -105,4 +105,28 @@ func TestCreateCustomIndexes_CreatesEmbeddingColumnsAndIndexes(t *testing.T) {
 		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_animal_comments_embedding')
 	`).Scan(&commentsIndexExists).Error)
 	assert.True(t, commentsIndexExists, "idx_animal_comments_embedding HNSW index must exist")
+
+	var updatesSearchVectorExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'updates' AND column_name = 'search_vector'
+		)
+	`).Scan(&updatesSearchVectorExists).Error)
+	assert.True(t, updatesSearchVectorExists, "updates.search_vector column must exist after migration")
+
+	var updatesEmbeddingExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'updates' AND column_name = 'embedding'
+		)
+	`).Scan(&updatesEmbeddingExists).Error)
+	assert.True(t, updatesEmbeddingExists, "updates.embedding column must exist after migration")
+
+	var updatesEmbeddingIndexExists bool
+	assert.NoError(t, db.Raw(`
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_updates_embedding')
+	`).Scan(&updatesEmbeddingIndexExists).Error)
+	assert.True(t, updatesEmbeddingIndexExists, "idx_updates_embedding HNSW index must exist")
 }

--- a/internal/embedding/embedder.go
+++ b/internal/embedding/embedder.go
@@ -41,24 +41,29 @@ type Embedder interface {
 // SemanticSearchEnabled is the single source of truth for the
 // SEMANTIC_SEARCH_ENABLED flag's parsing, so its three call sites (the
 // write-path embed goroutine, the reconciliation sweep, and the search
-// handler) can't disagree on what "enabled" means. Matches the existing
-// EMAIL_ENABLED convention in internal/email/provider.go: unset or any value
-// other than "false"/"0" means enabled.
+// handler) can't disagree on what "enabled" means.
+//
+// Deliberately opt-in — unset or any value other than "true"/"1" means
+// disabled — unlike EMAIL_ENABLED's opt-out convention in
+// internal/email/provider.go. Email is a low-cost, well-understood default;
+// Voyage is a paid, usage-billed API, so an operator who sets
+// VOYAGE_API_KEY but never separately considers this flag should not
+// silently start incurring real outbound API calls.
 func SemanticSearchEnabled() bool {
 	v := os.Getenv("SEMANTIC_SEARCH_ENABLED")
-	return v != "false" && v != "0"
+	return v == "true" || v == "1"
 }
 
 // Usable combines the SEMANTIC_SEARCH_ENABLED flag with the embedder's own
 // IsConfigured check into the single question every call site actually
-// cares about: should this attempt semantic work at all? Checking
-// SemanticSearchEnabled() alone lets an unconfigured-but-enabled embedder
-// (the default: the flag is enabled unless explicitly turned off, so a
-// deployment that simply forgets to set an API key is "enabled" by default)
-// retry and fail indefinitely on every write and every sweep tick — this is
-// the single source of truth all five call sites (three write-path embed
-// helpers, the sweep, and the search handler's query-time embed) must use
-// so none of them can drift out of sync with the others.
+// cares about: should this attempt semantic work at all? Neither check
+// alone is sufficient — an enabled-but-unconfigured embedder (flag on, no
+// API key) or a configured-but-disabled one (API key set, flag left at its
+// opt-in default) would each retry and fail indefinitely on every write and
+// every sweep tick if only one side were checked. This is the single source
+// of truth all five call sites (three write-path embed helpers, the sweep,
+// and the search handler's query-time embed) must use so none of them can
+// drift out of sync with the others.
 func Usable(embedder Embedder) bool {
 	return SemanticSearchEnabled() && embedder != nil && embedder.IsConfigured()
 }

--- a/internal/embedding/embedder.go
+++ b/internal/embedding/embedder.go
@@ -30,6 +30,12 @@ type Embedder interface {
 	EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error)
 	// EmbedQuery embeds a user's search string at query time.
 	EmbedQuery(ctx context.Context, text string) ([]float32, error)
+	// IsConfigured reports whether this Embedder can actually serve
+	// requests (e.g. an API key is present). Combined with
+	// SemanticSearchEnabled via Usable — an operator-enabled-but-unconfigured
+	// embedder must not be treated as usable, or every write-path embed
+	// attempt and every sweep tick would retry and fail forever.
+	IsConfigured() bool
 }
 
 // SemanticSearchEnabled is the single source of truth for the
@@ -41,4 +47,18 @@ type Embedder interface {
 func SemanticSearchEnabled() bool {
 	v := os.Getenv("SEMANTIC_SEARCH_ENABLED")
 	return v != "false" && v != "0"
+}
+
+// Usable combines the SEMANTIC_SEARCH_ENABLED flag with the embedder's own
+// IsConfigured check into the single question every call site actually
+// cares about: should this attempt semantic work at all? Checking
+// SemanticSearchEnabled() alone lets an unconfigured-but-enabled embedder
+// (the default: the flag is enabled unless explicitly turned off, so a
+// deployment that simply forgets to set an API key is "enabled" by default)
+// retry and fail indefinitely on every write and every sweep tick — this is
+// the single source of truth all five call sites (three write-path embed
+// helpers, the sweep, and the search handler's query-time embed) must use
+// so none of them can drift out of sync with the others.
+func Usable(embedder Embedder) bool {
+	return SemanticSearchEnabled() && embedder != nil && embedder.IsConfigured()
 }

--- a/internal/embedding/embedder.go
+++ b/internal/embedding/embedder.go
@@ -1,0 +1,44 @@
+// Package embedding provides semantic-search embedding generation, behind a
+// provider-agnostic Embedder interface, and the SEMANTIC_SEARCH_ENABLED
+// feature flag that gates every Voyage API call in the system (write-path
+// embedding, the reconciliation sweep, and query-time search embedding).
+package embedding
+
+import (
+	"context"
+	"os"
+)
+
+// Dimension is the embedding vector size used everywhere: the Voyage model
+// configuration, the animals/animal_comments.embedding pgvector columns, and
+// the HNSW indexes on them. All four must agree — changing this requires a
+// schema migration and a full re-embed of the corpus, not just a config edit.
+const Dimension = 1024
+
+// Embedder generates embedding vectors for search indexing and querying.
+// Document and query embedding are separate methods (not the same call)
+// because Voyage's retrieval-tuned models produce better results when told
+// which side of a search a piece of text is on ("document" being indexed vs.
+// "query" being searched for) — see VoyageEmbedder's input_type usage.
+type Embedder interface {
+	// EmbedDocument embeds text being indexed (an animal's searchable
+	// fields, or a comment's content) for storage.
+	EmbedDocument(ctx context.Context, text string) ([]float32, error)
+	// EmbedDocuments batches EmbedDocument for multiple texts in one API
+	// call — used by the reconciliation sweep to embed a batch of stale
+	// rows at once instead of one request per row.
+	EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error)
+	// EmbedQuery embeds a user's search string at query time.
+	EmbedQuery(ctx context.Context, text string) ([]float32, error)
+}
+
+// SemanticSearchEnabled is the single source of truth for the
+// SEMANTIC_SEARCH_ENABLED flag's parsing, so its three call sites (the
+// write-path embed goroutine, the reconciliation sweep, and the search
+// handler) can't disagree on what "enabled" means. Matches the existing
+// EMAIL_ENABLED convention in internal/email/provider.go: unset or any value
+// other than "false"/"0" means enabled.
+func SemanticSearchEnabled() bool {
+	v := os.Getenv("SEMANTIC_SEARCH_ENABLED")
+	return v != "false" && v != "0"
+}

--- a/internal/embedding/embedder_test.go
+++ b/internal/embedding/embedder_test.go
@@ -1,0 +1,33 @@
+package embedding
+
+import (
+	"testing"
+)
+
+func TestSemanticSearchEnabled_DefaultsTrue(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "")
+	if !SemanticSearchEnabled() {
+		t.Fatal("expected SemanticSearchEnabled to default to true when unset")
+	}
+}
+
+func TestSemanticSearchEnabled_FalseDisables(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "false")
+	if SemanticSearchEnabled() {
+		t.Fatal("expected SemanticSearchEnabled to be false when set to \"false\"")
+	}
+}
+
+func TestSemanticSearchEnabled_ZeroDisables(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "0")
+	if SemanticSearchEnabled() {
+		t.Fatal("expected SemanticSearchEnabled to be false when set to \"0\"")
+	}
+}
+
+func TestSemanticSearchEnabled_OtherValuesEnable(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+	if !SemanticSearchEnabled() {
+		t.Fatal("expected SemanticSearchEnabled to be true when set to \"true\"")
+	}
+}

--- a/internal/embedding/embedder_test.go
+++ b/internal/embedding/embedder_test.go
@@ -4,42 +4,44 @@ import (
 	"testing"
 )
 
-func TestSemanticSearchEnabled_DefaultsTrue(t *testing.T) {
+func TestSemanticSearchEnabled_DefaultsFalse(t *testing.T) {
 	t.Setenv("SEMANTIC_SEARCH_ENABLED", "")
-	if !SemanticSearchEnabled() {
-		t.Fatal("expected SemanticSearchEnabled to default to true when unset")
-	}
-}
-
-func TestSemanticSearchEnabled_FalseDisables(t *testing.T) {
-	t.Setenv("SEMANTIC_SEARCH_ENABLED", "false")
 	if SemanticSearchEnabled() {
-		t.Fatal("expected SemanticSearchEnabled to be false when set to \"false\"")
+		t.Fatal("expected SemanticSearchEnabled to default to false when unset (opt-in, unlike EMAIL_ENABLED)")
 	}
 }
 
-func TestSemanticSearchEnabled_ZeroDisables(t *testing.T) {
-	t.Setenv("SEMANTIC_SEARCH_ENABLED", "0")
-	if SemanticSearchEnabled() {
-		t.Fatal("expected SemanticSearchEnabled to be false when set to \"0\"")
-	}
-}
-
-func TestSemanticSearchEnabled_OtherValuesEnable(t *testing.T) {
+func TestSemanticSearchEnabled_TrueEnables(t *testing.T) {
 	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
 	if !SemanticSearchEnabled() {
 		t.Fatal("expected SemanticSearchEnabled to be true when set to \"true\"")
 	}
 }
 
+func TestSemanticSearchEnabled_OneEnables(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "1")
+	if !SemanticSearchEnabled() {
+		t.Fatal("expected SemanticSearchEnabled to be true when set to \"1\"")
+	}
+}
+
+func TestSemanticSearchEnabled_OtherValuesDisable(t *testing.T) {
+	for _, v := range []string{"false", "0", "yes", "TRUE", "enabled"} {
+		t.Setenv("SEMANTIC_SEARCH_ENABLED", v)
+		if SemanticSearchEnabled() {
+			t.Fatalf("expected SemanticSearchEnabled to be false when set to %q — only exactly \"true\" or \"1\" enable", v)
+		}
+	}
+}
+
 func TestUsable_RequiresBothFlagAndConfigured(t *testing.T) {
-	t.Setenv("SEMANTIC_SEARCH_ENABLED", "")
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
 
 	if !Usable(&StubEmbedder{}) {
 		t.Fatal("expected Usable to be true when the flag is enabled and the embedder is configured")
 	}
 	if Usable(&StubEmbedder{Unconfigured: true}) {
-		t.Fatal("expected Usable to be false when the embedder is not configured, even though the flag defaults to enabled — this is the exact gap that let an unconfigured-but-enabled Voyage embedder retry and fail indefinitely on every write and every sweep tick")
+		t.Fatal("expected Usable to be false when the embedder is not configured, even though the flag is enabled — this is the exact gap that let an unconfigured-but-enabled Voyage embedder retry and fail indefinitely on every write and every sweep tick")
 	}
 
 	t.Setenv("SEMANTIC_SEARCH_ENABLED", "false")

--- a/internal/embedding/embedder_test.go
+++ b/internal/embedding/embedder_test.go
@@ -31,3 +31,23 @@ func TestSemanticSearchEnabled_OtherValuesEnable(t *testing.T) {
 		t.Fatal("expected SemanticSearchEnabled to be true when set to \"true\"")
 	}
 }
+
+func TestUsable_RequiresBothFlagAndConfigured(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "")
+
+	if !Usable(&StubEmbedder{}) {
+		t.Fatal("expected Usable to be true when the flag is enabled and the embedder is configured")
+	}
+	if Usable(&StubEmbedder{Unconfigured: true}) {
+		t.Fatal("expected Usable to be false when the embedder is not configured, even though the flag defaults to enabled — this is the exact gap that let an unconfigured-but-enabled Voyage embedder retry and fail indefinitely on every write and every sweep tick")
+	}
+
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "false")
+	if Usable(&StubEmbedder{}) {
+		t.Fatal("expected Usable to be false when the flag is disabled, even though the embedder is configured")
+	}
+
+	if Usable(nil) {
+		t.Fatal("expected Usable to be false for a nil embedder")
+	}
+}

--- a/internal/embedding/persist.go
+++ b/internal/embedding/persist.go
@@ -31,3 +31,21 @@ func PersistEmbedding(db *gorm.DB, table string, id uint, updatedAt time.Time, v
 	updateSQL := fmt.Sprintf("UPDATE %s SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?", table)
 	return db.Exec(updateSQL, pgvector.NewVector(vec), id, updatedAt).Error
 }
+
+// TouchEmbeddingTimestamp marks a row's embedding as fresh as of updatedAt
+// without re-embedding it, for callers that determined the embeddable text
+// hasn't actually changed since the last real embed (e.g. a status-only
+// animal edit). Without this, the row's embedding_updated_at stays behind
+// its now-bumped updated_at, and the reconciliation sweep's staleness check
+// ("embedding_updated_at < updated_at") re-embeds the identical text on its
+// very next tick — spending exactly the Voyage API call the caller skipped.
+//
+// Deliberately scoped to "AND embedding IS NOT NULL": a row that was never
+// embedded still needs a real embed, not just a timestamp bump, so it's left
+// alone here and stays visible to the sweep even if its current text
+// happens to match some pre-embedding state. The "AND updated_at = ?" guard
+// is the same optimistic-concurrency check PersistEmbedding uses.
+func TouchEmbeddingTimestamp(db *gorm.DB, table string, id uint, updatedAt time.Time) error {
+	updateSQL := fmt.Sprintf("UPDATE %s SET embedding_updated_at = now() WHERE id = ? AND updated_at = ? AND embedding IS NOT NULL", table)
+	return db.Exec(updateSQL, id, updatedAt).Error
+}

--- a/internal/embedding/persist.go
+++ b/internal/embedding/persist.go
@@ -1,0 +1,33 @@
+package embedding
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pgvector/pgvector-go"
+	"gorm.io/gorm"
+)
+
+// PersistEmbedding writes a single row's embedding vector, used by both the
+// write-path embed helpers (internal/handlers/search_embed.go) and the
+// reconciliation sweep (sweep.go) — the single source of truth for how an
+// embedding gets persisted, so a fix to that logic only needs to be made
+// once instead of being kept in sync by hand across both call sites.
+//
+// table is always one of this package's callers' hardcoded constants
+// ("animals", "animal_comments", "updates") — never user input — so
+// building it into the UPDATE statement via fmt.Sprintf is safe.
+//
+// The "AND updated_at = ?" clause is an optimistic-concurrency guard against
+// the row version this vector's text was captured from: if the row was
+// edited again since (by the user, or by another embed attempt that won a
+// race), the captured updatedAt no longer matches, the UPDATE matches zero
+// rows, and this write is silently discarded rather than overwriting newer
+// content with an outdated vector. The row remains (or becomes) stale under
+// the normal "embedding_updated_at < updated_at" check, so whatever next
+// re-embeds it — the write path's next attempt, or the sweep — retries
+// against the row's current state.
+func PersistEmbedding(db *gorm.DB, table string, id uint, updatedAt time.Time, vec []float32) error {
+	updateSQL := fmt.Sprintf("UPDATE %s SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?", table)
+	return db.Exec(updateSQL, pgvector.NewVector(vec), id, updatedAt).Error
+}

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -21,9 +21,12 @@ type StubEmbedder struct {
 // IsConfigured always reports true unless Unconfigured is explicitly set —
 // StubEmbedder never needs real credentials, so it's "configured" by
 // default in every test that doesn't specifically exercise the
-// not-configured path.
+// not-configured path. Nil-receiver-safe for the same reason as
+// VoyageEmbedder.IsConfigured: a typed-nil *StubEmbedder held in the
+// Embedder interface is not == nil, so Usable() relies on this method
+// itself to catch that case.
 func (s *StubEmbedder) IsConfigured() bool {
-	return !s.Unconfigured
+	return s != nil && !s.Unconfigured
 }
 
 func (s *StubEmbedder) dimension() int {

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -7,11 +7,23 @@ import "context"
 // (useful for asserting exact nearest-neighbor behavior in tests without a
 // real embedding model), and different text produces a different vector.
 // Set Err to make every call fail, for exercising fallback/error-handling
-// paths (query-embedding failure degrading to keyword-only, etc.).
+// paths (query-embedding failure degrading to keyword-only, etc.). Set
+// Unconfigured to make IsConfigured() report false, for exercising the
+// Usable()-gated degrade path without needing Err (which fails every call
+// outright rather than modeling "not configured").
 type StubEmbedder struct {
 	// Dim overrides the vector length; defaults to Dimension (1024) when zero.
-	Dim int
-	Err error
+	Dim          int
+	Err          error
+	Unconfigured bool
+}
+
+// IsConfigured always reports true unless Unconfigured is explicitly set —
+// StubEmbedder never needs real credentials, so it's "configured" by
+// default in every test that doesn't specifically exercise the
+// not-configured path.
+func (s *StubEmbedder) IsConfigured() bool {
+	return !s.Unconfigured
 }
 
 func (s *StubEmbedder) dimension() int {

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -1,0 +1,55 @@
+package embedding
+
+import "context"
+
+// StubEmbedder is a deterministic, in-memory Embedder for tests — no
+// network calls. Identical input text always produces an identical vector
+// (useful for asserting exact nearest-neighbor behavior in tests without a
+// real embedding model), and different text produces a different vector.
+// Set Err to make every call fail, for exercising fallback/error-handling
+// paths (query-embedding failure degrading to keyword-only, etc.).
+type StubEmbedder struct {
+	// Dim overrides the vector length; defaults to Dimension (1024) when zero.
+	Dim int
+	Err error
+}
+
+func (s *StubEmbedder) dimension() int {
+	if s.Dim == 0 {
+		return Dimension
+	}
+	return s.Dim
+}
+
+func (s *StubEmbedder) vectorFor(text string) []float32 {
+	vec := make([]float32, s.dimension())
+	if len(text) == 0 {
+		return vec
+	}
+	for i := range vec {
+		vec[i] = float32(text[i%len(text)]) / 255.0
+	}
+	return vec
+}
+
+func (s *StubEmbedder) EmbedDocument(_ context.Context, text string) ([]float32, error) {
+	if s.Err != nil {
+		return nil, s.Err
+	}
+	return s.vectorFor(text), nil
+}
+
+func (s *StubEmbedder) EmbedDocuments(_ context.Context, texts []string) ([][]float32, error) {
+	if s.Err != nil {
+		return nil, s.Err
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = s.vectorFor(t)
+	}
+	return out, nil
+}
+
+func (s *StubEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	return s.EmbedDocument(ctx, text)
+}

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -1,0 +1,97 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStubEmbedder_DeterministicPerText(t *testing.T) {
+	s := &StubEmbedder{}
+	ctx := context.Background()
+
+	v1, err := s.EmbedDocument(ctx, "resource guarding around food")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v2, err := s.EmbedDocument(ctx, "resource guarding around food")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(v1) != Dimension {
+		t.Fatalf("expected vector of length %d, got %d", Dimension, len(v1))
+	}
+	for i := range v1 {
+		if v1[i] != v2[i] {
+			t.Fatalf("expected identical text to produce identical vectors at index %d: %v != %v", i, v1[i], v2[i])
+		}
+	}
+}
+
+func TestStubEmbedder_DifferentTextDiffersVector(t *testing.T) {
+	s := &StubEmbedder{}
+	ctx := context.Background()
+
+	v1, _ := s.EmbedDocument(ctx, "resource guarding around food")
+	v2, _ := s.EmbedDocument(ctx, "loves belly rubs")
+
+	same := true
+	for i := range v1 {
+		if v1[i] != v2[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Fatal("expected different input text to produce different vectors")
+	}
+}
+
+func TestStubEmbedder_EmptyTextDoesNotPanic(t *testing.T) {
+	s := &StubEmbedder{}
+	vec, err := s.EmbedDocument(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vec) != Dimension {
+		t.Fatalf("expected vector of length %d for empty input, got %d", Dimension, len(vec))
+	}
+}
+
+func TestStubEmbedder_ErrPropagates(t *testing.T) {
+	wantErr := errors.New("boom")
+	s := &StubEmbedder{Err: wantErr}
+	ctx := context.Background()
+
+	if _, err := s.EmbedDocument(ctx, "text"); err != wantErr {
+		t.Fatalf("EmbedDocument: expected %v, got %v", wantErr, err)
+	}
+	if _, err := s.EmbedQuery(ctx, "text"); err != wantErr {
+		t.Fatalf("EmbedQuery: expected %v, got %v", wantErr, err)
+	}
+	if _, err := s.EmbedDocuments(ctx, []string{"text"}); err != wantErr {
+		t.Fatalf("EmbedDocuments: expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestStubEmbedder_EmbedDocumentsBatchesInOrder(t *testing.T) {
+	s := &StubEmbedder{}
+	ctx := context.Background()
+
+	texts := []string{"alpha", "bravo", "charlie"}
+	batch, err := s.EmbedDocuments(ctx, texts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(batch) != len(texts) {
+		t.Fatalf("expected %d vectors, got %d", len(texts), len(batch))
+	}
+	for i, text := range texts {
+		single, _ := s.EmbedDocument(ctx, text)
+		for j := range single {
+			if batch[i][j] != single[j] {
+				t.Fatalf("batch[%d] does not match single EmbedDocument(%q) at index %d", i, text, j)
+			}
+		}
+	}
+}

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -106,6 +106,12 @@ func embedAndPersist(ctx context.Context, span trace.Span, db *gorm.DB, embedder
 		texts[i] = r.Text
 	}
 
+	// A deadline here, rather than the bare context callers pass in, bounds
+	// the batch call regardless of what the concrete Embedder does
+	// internally — see the same reasoning on embedNow in
+	// internal/handlers/search_embed.go.
+	ctx, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
 	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to embed %s: %w", resourceName, err), "embed failed")

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -1,0 +1,139 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"github.com/pgvector/pgvector-go"
+	"gorm.io/gorm"
+)
+
+// sweepBatchSize bounds how many rows one sweep tick embeds, per resource
+// type. A large first-deploy backfill drains gradually over several ticks
+// instead of firing one unbounded request.
+const sweepBatchSize = 50
+
+// StartReconciliationSweep runs a periodic background pass that embeds any
+// animal/comment whose embedding is missing or older than the row's last
+// edit. One mechanism covers three situations: initial backfill of
+// pre-existing rows on first deploy, retrying rows whose async write-path
+// embed attempt failed, and catching up on anything created/edited while
+// SEMANTIC_SEARCH_ENABLED was false — none of these need special-casing
+// differently from one another. Returns a stop function; call it during
+// graceful shutdown to stop the ticker.
+func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Duration) (stop func()) {
+	ticker := time.NewTicker(interval)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if !SemanticSearchEnabled() {
+					continue
+				}
+				sweepAnimals(db, embedder)
+				sweepComments(db, embedder)
+			case <-done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return func() { close(done) }
+}
+
+type staleAnimal struct {
+	ID           uint
+	Name         string
+	Species      string
+	Breed        string
+	Description  string
+	TrainerNotes string
+}
+
+func sweepAnimals(db *gorm.DB, embedder Embedder) {
+	ctx, span := tracer.Start(context.Background(), "embedding.sweep.animals")
+	defer span.End()
+
+	var rows []staleAnimal
+	if err := db.Model(&models.Animal{}).
+		Select("id, name, species, breed, description, trainer_notes").
+		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to query stale animal embeddings: %w", err), "query failed")
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	texts := make([]string, len(rows))
+	for i, r := range rows {
+		texts[i] = r.Name + " " + r.Species + " " + r.Breed + " " + r.Description + " " + r.TrainerNotes
+	}
+
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to embed animals: %w", err), "embed failed")
+		return
+	}
+
+	for i, r := range rows {
+		if err := db.Exec(
+			"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+			pgvector.NewVector(vectors[i]), r.ID,
+		).Error; err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to persist animal embedding during sweep")
+		}
+	}
+}
+
+type staleComment struct {
+	ID      uint
+	Content string
+}
+
+func sweepComments(db *gorm.DB, embedder Embedder) {
+	ctx, span := tracer.Start(context.Background(), "embedding.sweep.comments")
+	defer span.End()
+
+	var rows []staleComment
+	if err := db.Model(&models.AnimalComment{}).
+		Select("id, content").
+		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to query stale comment embeddings: %w", err), "query failed")
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	texts := make([]string, len(rows))
+	for i, r := range rows {
+		texts[i] = r.Content
+	}
+
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to embed comments: %w", err), "embed failed")
+		return
+	}
+
+	for i, r := range rows {
+		if err := db.Exec(
+			"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+			pgvector.NewVector(vectors[i]), r.ID,
+		).Error; err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to persist comment embedding during sweep")
+		}
+	}
+}

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -87,6 +87,10 @@ func sweepAnimals(db *gorm.DB, embedder Embedder) {
 		telemetry.Fail(span, fmt.Errorf("failed to embed animals: %w", err), "embed failed")
 		return
 	}
+	if len(vectors) != len(rows) {
+		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d animals", len(vectors), len(rows)), "vector count mismatch")
+		return
+	}
 
 	for i, r := range rows {
 		if err := db.Exec(
@@ -128,6 +132,10 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to embed comments: %w", err), "embed failed")
+		return
+	}
+	if len(vectors) != len(rows) {
+		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d comments", len(vectors), len(rows)), "vector count mismatch")
 		return
 	}
 
@@ -172,6 +180,10 @@ func sweepUpdates(db *gorm.DB, embedder Embedder) {
 	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to embed updates: %w", err), "embed failed")
+		return
+	}
+	if len(vectors) != len(rows) {
+		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d updates", len(vectors), len(rows)), "vector count mismatch")
 		return
 	}
 

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -9,7 +9,6 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
-	"github.com/pgvector/pgvector-go"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 )
@@ -52,51 +51,57 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 	return func() { once.Do(func() { close(done) }) }
 }
 
-// embedAndPersist is the shared core of every sweep function: given the
-// stale rows' IDs, the row's updated_at at the time it was queried (see the
-// UPDATE guard below), and pre-built embedding text (which genuinely
-// differs per resource — animals concatenate five fields, comments and
-// updates fewer — so that part stays in each resource's own sweep
-// function), it embeds the batch and writes each vector back, one UPDATE
-// per row. Factored out so a fix to retry/logging/vector-count-mismatch
-// handling only needs to be made once instead of risking the three
-// resources' sweep functions drifting out of sync with each other. `table`
-// is always one of this package's own hardcoded constants ("animals",
-// "animal_comments", "updates") — never user input — so building it into
-// the UPDATE statement is safe.
-//
-// The "AND updated_at = ?" guard is an optimistic-concurrency check: if the
-// row was edited again between this sweep tick's query and this write (by
-// the user, or by a write-path embed goroutine that won the race), the
-// captured updated_at no longer matches, the UPDATE matches zero rows, and
-// this stale embed attempt is silently discarded rather than overwriting
-// newer content with an outdated vector. The row stays (or becomes) stale
-// under the normal embedding_updated_at < updated_at check, so the next
-// sweep tick retries it against whatever the row looks like by then.
-func embedAndPersist(ctx context.Context, span trace.Span, db *gorm.DB, embedder Embedder, table string, ids []uint, updatedAts []time.Time, texts []string) {
-	if len(texts) == 0 {
+// staleRow is one row awaiting embedding: its ID, its updated_at at query
+// time (used as PersistEmbedding's optimistic-concurrency guard), and the
+// text to embed — kept together in one struct, rather than three parallel
+// slices, so they can't desync by index if a future sweep function's
+// row-building loop changes shape.
+type staleRow struct {
+	ID        uint
+	UpdatedAt time.Time
+	Text      string
+}
+
+// embedAndPersist is the shared core of every sweep function: embeds a
+// batch of stale rows' text and persists each result via PersistEmbedding
+// (the same function the write-path embed helpers in
+// internal/handlers/search_embed.go use), so a fix to
+// retry/logging/vector-count-mismatch/persistence handling only needs to be
+// made in one place instead of risking the three resources' sweep functions
+// drifting out of sync with each other. table is the literal SQL table
+// name ("animals", "animal_comments", "updates"); resourceName is the
+// human-readable word used in log/telemetry messages ("animals",
+// "comments", "updates") — kept separate from table because they diverge
+// for comments, and an operator's saved log search for "comments" shouldn't
+// silently break because the underlying table is called "animal_comments".
+func embedAndPersist(ctx context.Context, span trace.Span, db *gorm.DB, embedder Embedder, table, resourceName string, rows []staleRow) {
+	if len(rows) == 0 {
 		return
+	}
+
+	texts := make([]string, len(rows))
+	for i, r := range rows {
+		texts[i] = r.Text
 	}
 
 	vectors, err := embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
-		telemetry.Fail(span, fmt.Errorf("failed to embed %s: %w", table, err), "embed failed")
+		telemetry.Fail(span, fmt.Errorf("failed to embed %s: %w", resourceName, err), "embed failed")
 		return
 	}
-	if len(vectors) != len(ids) {
-		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d %s", len(vectors), len(ids), table), "vector count mismatch")
+	if len(vectors) != len(rows) {
+		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d %s", len(vectors), len(rows), resourceName), "vector count mismatch")
 		return
 	}
 
-	updateSQL := fmt.Sprintf("UPDATE %s SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?", table)
-	for i, id := range ids {
-		if err := db.Exec(updateSQL, pgvector.NewVector(vectors[i]), id, updatedAts[i]).Error; err != nil {
-			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to persist %s embedding during sweep", table))
+	for i, r := range rows {
+		if err := PersistEmbedding(db, table, r.ID, r.UpdatedAt, vectors[i]); err != nil {
+			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to persist %s embedding during sweep", resourceName))
 		}
 	}
 }
 
-type staleAnimal struct {
+type staleAnimalRow struct {
 	ID           uint
 	UpdatedAt    time.Time
 	Name         string
@@ -110,31 +115,28 @@ func sweepAnimals(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.animals")
 	defer span.End()
 
-	var rows []staleAnimal
+	var dbRows []staleAnimalRow
 	if err := db.Model(&models.Animal{}).
 		Select("id, updated_at, name, species, breed, description, trainer_notes").
 		Where("embedding IS NULL OR embedding_updated_at < updated_at").
 		Limit(sweepBatchSize).
-		Find(&rows).Error; err != nil {
+		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale animal embeddings: %w", err), "query failed")
 		return
 	}
-	if len(rows) == 0 {
-		return
-	}
 
-	ids := make([]uint, len(rows))
-	updatedAts := make([]time.Time, len(rows))
-	texts := make([]string, len(rows))
-	for i, r := range rows {
-		ids[i] = r.ID
-		updatedAts[i] = r.UpdatedAt
-		texts[i] = r.Name + " " + r.Species + " " + r.Breed + " " + r.Description + " " + r.TrainerNotes
+	rows := make([]staleRow, len(dbRows))
+	for i, r := range dbRows {
+		rows[i] = staleRow{
+			ID:        r.ID,
+			UpdatedAt: r.UpdatedAt,
+			Text:      AnimalEmbeddingText(r.Name, r.Species, r.Breed, r.Description, r.TrainerNotes),
+		}
 	}
-	embedAndPersist(ctx, span, db, embedder, "animals", ids, updatedAts, texts)
+	embedAndPersist(ctx, span, db, embedder, "animals", "animals", rows)
 }
 
-type staleComment struct {
+type staleCommentRow struct {
 	ID        uint
 	UpdatedAt time.Time
 	Content   string
@@ -144,31 +146,32 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.comments")
 	defer span.End()
 
-	var rows []staleComment
+	// Joins animals and excludes soft-deleted ones for the same reason
+	// internal/handlers/search.go's comment search does: without this,
+	// comments belonging to a deleted animal are perpetually re-selected as
+	// "stale" (their embedding_updated_at can never catch up to anything
+	// meaningful, since they're never actually re-edited) and burn sweep
+	// batch slots and Voyage calls embedding content that can never surface
+	// in search results.
+	var dbRows []staleCommentRow
 	if err := db.Model(&models.AnimalComment{}).
-		Select("id, updated_at, content").
-		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+		Joins("JOIN animals ON animals.id = animal_comments.animal_id").
+		Select("animal_comments.id, animal_comments.updated_at, animal_comments.content").
+		Where("animals.deleted_at IS NULL AND (animal_comments.embedding IS NULL OR animal_comments.embedding_updated_at < animal_comments.updated_at)").
 		Limit(sweepBatchSize).
-		Find(&rows).Error; err != nil {
+		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale comment embeddings: %w", err), "query failed")
 		return
 	}
-	if len(rows) == 0 {
-		return
-	}
 
-	ids := make([]uint, len(rows))
-	updatedAts := make([]time.Time, len(rows))
-	texts := make([]string, len(rows))
-	for i, r := range rows {
-		ids[i] = r.ID
-		updatedAts[i] = r.UpdatedAt
-		texts[i] = r.Content
+	rows := make([]staleRow, len(dbRows))
+	for i, r := range dbRows {
+		rows[i] = staleRow{ID: r.ID, UpdatedAt: r.UpdatedAt, Text: r.Content}
 	}
-	embedAndPersist(ctx, span, db, embedder, "animal_comments", ids, updatedAts, texts)
+	embedAndPersist(ctx, span, db, embedder, "animal_comments", "comments", rows)
 }
 
-type staleUpdate struct {
+type staleUpdateRow struct {
 	ID        uint
 	UpdatedAt time.Time
 	Title     string
@@ -179,26 +182,19 @@ func sweepUpdates(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.updates")
 	defer span.End()
 
-	var rows []staleUpdate
+	var dbRows []staleUpdateRow
 	if err := db.Model(&models.Update{}).
 		Select("id, updated_at, title, content").
 		Where("embedding IS NULL OR embedding_updated_at < updated_at").
 		Limit(sweepBatchSize).
-		Find(&rows).Error; err != nil {
+		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale update embeddings: %w", err), "query failed")
 		return
 	}
-	if len(rows) == 0 {
-		return
-	}
 
-	ids := make([]uint, len(rows))
-	updatedAts := make([]time.Time, len(rows))
-	texts := make([]string, len(rows))
-	for i, r := range rows {
-		ids[i] = r.ID
-		updatedAts[i] = r.UpdatedAt
-		texts[i] = r.Title + " " + r.Content
+	rows := make([]staleRow, len(dbRows))
+	for i, r := range dbRows {
+		rows[i] = staleRow{ID: r.ID, UpdatedAt: r.UpdatedAt, Text: UpdateEmbeddingText(r.Title, r.Content)}
 	}
-	embedAndPersist(ctx, span, db, embedder, "updates", ids, updatedAts, texts)
+	embedAndPersist(ctx, span, db, embedder, "updates", "updates", rows)
 }

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -19,8 +19,8 @@ import (
 const sweepBatchSize = 50
 
 // StartReconciliationSweep runs a periodic background pass that embeds any
-// animal/comment whose embedding is missing or older than the row's last
-// edit. One mechanism covers three situations: initial backfill of
+// animal/comment/update whose embedding is missing or older than the row's
+// last edit. One mechanism covers three situations: initial backfill of
 // pre-existing rows on first deploy, retrying rows whose async write-path
 // embed attempt failed, and catching up on anything created/edited while
 // SEMANTIC_SEARCH_ENABLED was false — none of these need special-casing
@@ -39,6 +39,7 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 				}
 				sweepAnimals(db, embedder)
 				sweepComments(db, embedder)
+				sweepUpdates(db, embedder)
 			case <-done:
 				ticker.Stop()
 				return
@@ -136,6 +137,50 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 			pgvector.NewVector(vectors[i]), r.ID,
 		).Error; err != nil {
 			logging.WithField("error", err.Error()).Warn("Failed to persist comment embedding during sweep")
+		}
+	}
+}
+
+type staleUpdate struct {
+	ID      uint
+	Title   string
+	Content string
+}
+
+func sweepUpdates(db *gorm.DB, embedder Embedder) {
+	ctx, span := tracer.Start(context.Background(), "embedding.sweep.updates")
+	defer span.End()
+
+	var rows []staleUpdate
+	if err := db.Model(&models.Update{}).
+		Select("id, title, content").
+		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to query stale update embeddings: %w", err), "query failed")
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	texts := make([]string, len(rows))
+	for i, r := range rows {
+		texts[i] = r.Title + " " + r.Content
+	}
+
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to embed updates: %w", err), "embed failed")
+		return
+	}
+
+	for i, r := range rows {
+		if err := db.Exec(
+			"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+			pgvector.NewVector(vectors[i]), r.ID,
+		).Error; err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to persist update embedding during sweep")
 		}
 	}
 }

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -10,6 +10,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
 	"github.com/pgvector/pgvector-go"
+	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 )
 
@@ -34,7 +35,7 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 		for {
 			select {
 			case <-ticker.C:
-				if !SemanticSearchEnabled() {
+				if !Usable(embedder) {
 					continue
 				}
 				sweepAnimals(db, embedder)
@@ -51,8 +52,53 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 	return func() { once.Do(func() { close(done) }) }
 }
 
+// embedAndPersist is the shared core of every sweep function: given the
+// stale rows' IDs, the row's updated_at at the time it was queried (see the
+// UPDATE guard below), and pre-built embedding text (which genuinely
+// differs per resource — animals concatenate five fields, comments and
+// updates fewer — so that part stays in each resource's own sweep
+// function), it embeds the batch and writes each vector back, one UPDATE
+// per row. Factored out so a fix to retry/logging/vector-count-mismatch
+// handling only needs to be made once instead of risking the three
+// resources' sweep functions drifting out of sync with each other. `table`
+// is always one of this package's own hardcoded constants ("animals",
+// "animal_comments", "updates") — never user input — so building it into
+// the UPDATE statement is safe.
+//
+// The "AND updated_at = ?" guard is an optimistic-concurrency check: if the
+// row was edited again between this sweep tick's query and this write (by
+// the user, or by a write-path embed goroutine that won the race), the
+// captured updated_at no longer matches, the UPDATE matches zero rows, and
+// this stale embed attempt is silently discarded rather than overwriting
+// newer content with an outdated vector. The row stays (or becomes) stale
+// under the normal embedding_updated_at < updated_at check, so the next
+// sweep tick retries it against whatever the row looks like by then.
+func embedAndPersist(ctx context.Context, span trace.Span, db *gorm.DB, embedder Embedder, table string, ids []uint, updatedAts []time.Time, texts []string) {
+	if len(texts) == 0 {
+		return
+	}
+
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		telemetry.Fail(span, fmt.Errorf("failed to embed %s: %w", table, err), "embed failed")
+		return
+	}
+	if len(vectors) != len(ids) {
+		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d %s", len(vectors), len(ids), table), "vector count mismatch")
+		return
+	}
+
+	updateSQL := fmt.Sprintf("UPDATE %s SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?", table)
+	for i, id := range ids {
+		if err := db.Exec(updateSQL, pgvector.NewVector(vectors[i]), id, updatedAts[i]).Error; err != nil {
+			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to persist %s embedding during sweep", table))
+		}
+	}
+}
+
 type staleAnimal struct {
 	ID           uint
+	UpdatedAt    time.Time
 	Name         string
 	Species      string
 	Breed        string
@@ -66,7 +112,7 @@ func sweepAnimals(db *gorm.DB, embedder Embedder) {
 
 	var rows []staleAnimal
 	if err := db.Model(&models.Animal{}).
-		Select("id, name, species, breed, description, trainer_notes").
+		Select("id, updated_at, name, species, breed, description, trainer_notes").
 		Where("embedding IS NULL OR embedding_updated_at < updated_at").
 		Limit(sweepBatchSize).
 		Find(&rows).Error; err != nil {
@@ -77,34 +123,21 @@ func sweepAnimals(db *gorm.DB, embedder Embedder) {
 		return
 	}
 
+	ids := make([]uint, len(rows))
+	updatedAts := make([]time.Time, len(rows))
 	texts := make([]string, len(rows))
 	for i, r := range rows {
+		ids[i] = r.ID
+		updatedAts[i] = r.UpdatedAt
 		texts[i] = r.Name + " " + r.Species + " " + r.Breed + " " + r.Description + " " + r.TrainerNotes
 	}
-
-	vectors, err := embedder.EmbedDocuments(ctx, texts)
-	if err != nil {
-		telemetry.Fail(span, fmt.Errorf("failed to embed animals: %w", err), "embed failed")
-		return
-	}
-	if len(vectors) != len(rows) {
-		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d animals", len(vectors), len(rows)), "vector count mismatch")
-		return
-	}
-
-	for i, r := range rows {
-		if err := db.Exec(
-			"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-			pgvector.NewVector(vectors[i]), r.ID,
-		).Error; err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to persist animal embedding during sweep")
-		}
-	}
+	embedAndPersist(ctx, span, db, embedder, "animals", ids, updatedAts, texts)
 }
 
 type staleComment struct {
-	ID      uint
-	Content string
+	ID        uint
+	UpdatedAt time.Time
+	Content   string
 }
 
 func sweepComments(db *gorm.DB, embedder Embedder) {
@@ -113,7 +146,7 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 
 	var rows []staleComment
 	if err := db.Model(&models.AnimalComment{}).
-		Select("id, content").
+		Select("id, updated_at, content").
 		Where("embedding IS NULL OR embedding_updated_at < updated_at").
 		Limit(sweepBatchSize).
 		Find(&rows).Error; err != nil {
@@ -124,35 +157,22 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 		return
 	}
 
+	ids := make([]uint, len(rows))
+	updatedAts := make([]time.Time, len(rows))
 	texts := make([]string, len(rows))
 	for i, r := range rows {
+		ids[i] = r.ID
+		updatedAts[i] = r.UpdatedAt
 		texts[i] = r.Content
 	}
-
-	vectors, err := embedder.EmbedDocuments(ctx, texts)
-	if err != nil {
-		telemetry.Fail(span, fmt.Errorf("failed to embed comments: %w", err), "embed failed")
-		return
-	}
-	if len(vectors) != len(rows) {
-		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d comments", len(vectors), len(rows)), "vector count mismatch")
-		return
-	}
-
-	for i, r := range rows {
-		if err := db.Exec(
-			"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-			pgvector.NewVector(vectors[i]), r.ID,
-		).Error; err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to persist comment embedding during sweep")
-		}
-	}
+	embedAndPersist(ctx, span, db, embedder, "animal_comments", ids, updatedAts, texts)
 }
 
 type staleUpdate struct {
-	ID      uint
-	Title   string
-	Content string
+	ID        uint
+	UpdatedAt time.Time
+	Title     string
+	Content   string
 }
 
 func sweepUpdates(db *gorm.DB, embedder Embedder) {
@@ -161,7 +181,7 @@ func sweepUpdates(db *gorm.DB, embedder Embedder) {
 
 	var rows []staleUpdate
 	if err := db.Model(&models.Update{}).
-		Select("id, title, content").
+		Select("id, updated_at, title, content").
 		Where("embedding IS NULL OR embedding_updated_at < updated_at").
 		Limit(sweepBatchSize).
 		Find(&rows).Error; err != nil {
@@ -172,27 +192,13 @@ func sweepUpdates(db *gorm.DB, embedder Embedder) {
 		return
 	}
 
+	ids := make([]uint, len(rows))
+	updatedAts := make([]time.Time, len(rows))
 	texts := make([]string, len(rows))
 	for i, r := range rows {
+		ids[i] = r.ID
+		updatedAts[i] = r.UpdatedAt
 		texts[i] = r.Title + " " + r.Content
 	}
-
-	vectors, err := embedder.EmbedDocuments(ctx, texts)
-	if err != nil {
-		telemetry.Fail(span, fmt.Errorf("failed to embed updates: %w", err), "embed failed")
-		return
-	}
-	if len(vectors) != len(rows) {
-		telemetry.Fail(span, fmt.Errorf("embedder returned %d vectors for %d updates", len(vectors), len(rows)), "vector count mismatch")
-		return
-	}
-
-	for i, r := range rows {
-		if err := db.Exec(
-			"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-			pgvector.NewVector(vectors[i]), r.ID,
-		).Error; err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to persist update embedding during sweep")
-		}
-	}
+	embedAndPersist(ctx, span, db, embedder, "updates", ids, updatedAts, texts)
 }

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -18,6 +18,12 @@ import (
 // instead of firing one unbounded request.
 const sweepBatchSize = 50
 
+// sweepStopTimeout bounds how long stop() waits for an in-flight sweep tick
+// to finish before giving up, mirroring the bounded waits already used
+// elsewhere during shutdown (see cmd/api/main.go's shutdownTelemetry and
+// srv.Shutdown timeouts).
+const sweepStopTimeout = 10 * time.Second
+
 // StartReconciliationSweep runs a periodic background pass that embeds any
 // animal/comment/update whose embedding is missing or older than the row's
 // last edit. One mechanism covers three situations: initial backfill of
@@ -26,11 +32,20 @@ const sweepBatchSize = 50
 // SEMANTIC_SEARCH_ENABLED was false — none of these need special-casing
 // differently from one another. Returns a stop function; call it during
 // graceful shutdown to stop the ticker.
+//
+// stop() blocks (up to sweepStopTimeout) until the sweep goroutine actually
+// exits, including finishing any tick already in flight — without this, a
+// caller that immediately closes the DB connection pool after stop() returns
+// (as cmd/api/main.go does) could race an in-flight sweepAnimals/
+// sweepComments/sweepUpdates call's PersistEmbedding write against a closed
+// *sql.DB.
 func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Duration) (stop func()) {
 	ticker := time.NewTicker(interval)
 	done := make(chan struct{})
+	finished := make(chan struct{})
 
 	go func() {
+		defer close(finished)
 		for {
 			select {
 			case <-ticker.C:
@@ -48,7 +63,14 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 	}()
 
 	var once sync.Once
-	return func() { once.Do(func() { close(done) }) }
+	return func() {
+		once.Do(func() { close(done) })
+		select {
+		case <-finished:
+		case <-time.After(sweepStopTimeout):
+			logging.Warn(fmt.Sprintf("Reconciliation sweep did not stop within %s of shutdown signal; proceeding with shutdown anyway", sweepStopTimeout))
+		}
+	}
 }
 
 // staleRow is one row awaiting embedding: its ID, its updated_at at query
@@ -115,10 +137,16 @@ func sweepAnimals(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.animals")
 	defer span.End()
 
+	// models.NonDeletedGroupAnimalsQuery excludes animals belonging to a
+	// soft-deleted group — DeleteGroup doesn't cascade to its animals, so
+	// without this join an animal under a deleted group is never itself
+	// soft-deleted and would otherwise be re-selected as "stale" forever,
+	// burning sweep batch slots and Voyage calls embedding content for a
+	// group that's supposed to be gone.
 	var dbRows []staleAnimalRow
-	if err := db.Model(&models.Animal{}).
-		Select("id, updated_at, name, species, breed, description, trainer_notes").
-		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+	if err := models.NonDeletedGroupAnimalsQuery(db).
+		Select("animals.id, animals.updated_at, animals.name, animals.species, animals.breed, animals.description, animals.trainer_notes").
+		Where("animals.embedding IS NULL OR animals.embedding_updated_at < animals.updated_at").
 		Limit(sweepBatchSize).
 		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale animal embeddings: %w", err), "query failed")
@@ -146,18 +174,18 @@ func sweepComments(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.comments")
 	defer span.End()
 
-	// Joins animals and excludes soft-deleted ones for the same reason
-	// internal/handlers/search.go's comment search does: without this,
-	// comments belonging to a deleted animal are perpetually re-selected as
-	// "stale" (their embedding_updated_at can never catch up to anything
-	// meaningful, since they're never actually re-edited) and burn sweep
-	// batch slots and Voyage calls embedding content that can never surface
-	// in search results.
+	// models.NonDeletedAnimalCommentsQuery excludes soft-deleted animals'
+	// comments for the same reason internal/handlers/search.go's comment
+	// search does (shared helper so the two call sites can't drift out of
+	// sync): without this, comments belonging to a deleted animal are
+	// perpetually re-selected as "stale" (their embedding_updated_at can
+	// never catch up to anything meaningful, since they're never actually
+	// re-edited) and burn sweep batch slots and Voyage calls embedding
+	// content that can never surface in search results.
 	var dbRows []staleCommentRow
-	if err := db.Model(&models.AnimalComment{}).
-		Joins("JOIN animals ON animals.id = animal_comments.animal_id").
+	if err := models.NonDeletedAnimalCommentsQuery(db).
 		Select("animal_comments.id, animal_comments.updated_at, animal_comments.content").
-		Where("animals.deleted_at IS NULL AND (animal_comments.embedding IS NULL OR animal_comments.embedding_updated_at < animal_comments.updated_at)").
+		Where("animal_comments.embedding IS NULL OR animal_comments.embedding_updated_at < animal_comments.updated_at").
 		Limit(sweepBatchSize).
 		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale comment embeddings: %w", err), "query failed")
@@ -182,10 +210,13 @@ func sweepUpdates(db *gorm.DB, embedder Embedder) {
 	ctx, span := tracer.Start(context.Background(), "embedding.sweep.updates")
 	defer span.End()
 
+	// models.NonDeletedGroupUpdatesQuery excludes updates belonging to a
+	// soft-deleted group, for the same reason sweepAnimals excludes animals
+	// under a soft-deleted group above.
 	var dbRows []staleUpdateRow
-	if err := db.Model(&models.Update{}).
-		Select("id, updated_at, title, content").
-		Where("embedding IS NULL OR embedding_updated_at < updated_at").
+	if err := models.NonDeletedGroupUpdatesQuery(db).
+		Select("updates.id, updates.updated_at, updates.title, updates.content").
+		Where("updates.embedding IS NULL OR updates.embedding_updated_at < updates.updated_at").
 		Limit(sweepBatchSize).
 		Find(&dbRows).Error; err != nil {
 		telemetry.Fail(span, fmt.Errorf("failed to query stale update embeddings: %w", err), "query failed")

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -3,6 +3,7 @@ package embedding
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
@@ -45,7 +46,8 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 		}
 	}()
 
-	return func() { close(done) }
+	var once sync.Once
+	return func() { once.Do(func() { close(done) }) }
 }
 
 type staleAnimal struct {

--- a/internal/embedding/sweep_postgres_test.go
+++ b/internal/embedding/sweep_postgres_test.go
@@ -1,0 +1,160 @@
+package embedding
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/database"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/pgvector/pgvector-go"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func openSweepTestPostgres(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	host := envOrDefault("DB_HOST", "localhost")
+	port := envOrDefault("DB_PORT", "5432")
+
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 2*time.Second)
+	if err != nil {
+		t.Skipf("skipping: no Postgres reachable at %s:%s", host, port)
+	}
+	_ = conn.Close()
+
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s connect_timeout=5",
+		host, port,
+		envOrDefault("DB_USER", "postgres"),
+		envOrDefault("DB_PASSWORD", "postgres"),
+		envOrDefault("DB_NAME", "volunteer_media_test"),
+		envOrDefault("DB_SSLMODE", "disable"),
+	)
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: gormlogger.Default.LogMode(gormlogger.Silent)})
+	if err != nil {
+		t.Skipf("skipping: could not connect to postgres (%v)", err)
+	}
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("failed to run migrations: %v", err)
+	}
+	return db
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func TestSweepAnimals_EmbedsRowsWithNullEmbedding(t *testing.T) {
+	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available", Description: "Loves belly rubs."}
+	if err := tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	sweepAnimals(tx, &StubEmbedder{})
+
+	var embeddingIsNull bool
+	assert.NoError(t, tx.Raw("SELECT embedding IS NULL FROM animals WHERE id = ?", animal.ID).Scan(&embeddingIsNull).Error)
+	assert.False(t, embeddingIsNull, "expected sweepAnimals to populate the embedding column")
+}
+
+func TestSweepAnimals_ReEmbedsStaleRows(t *testing.T) {
+	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	// Simulate an embedding computed before the row's last edit: set
+	// embedding_updated_at to a time before updated_at.
+	if err := tx.Exec(
+		"UPDATE animals SET embedding = ?, embedding_updated_at = ?, updated_at = ? WHERE id = ?",
+		pgvector.NewVector(make([]float32, Dimension)), time.Now().Add(-time.Hour), time.Now(), animal.ID,
+	).Error; err != nil {
+		t.Fatalf("failed to simulate stale embedding: %v", err)
+	}
+
+	var embeddedAtBefore time.Time
+	assert.NoError(t, tx.Raw("SELECT embedding_updated_at FROM animals WHERE id = ?", animal.ID).Scan(&embeddedAtBefore).Error)
+
+	sweepAnimals(tx, &StubEmbedder{})
+
+	var embeddedAtAfter time.Time
+	assert.NoError(t, tx.Raw("SELECT embedding_updated_at FROM animals WHERE id = ?", animal.ID).Scan(&embeddedAtAfter).Error)
+	assert.True(t, embeddedAtAfter.After(embeddedAtBefore), "expected the stale embedding to be refreshed")
+}
+
+func TestSweepAnimals_RespectsBatchSizeCap(t *testing.T) {
+	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	for i := 0; i < sweepBatchSize+10; i++ {
+		a := models.Animal{GroupID: group.ID, Name: fmt.Sprintf("Animal%d", i), Species: "Dog", Status: "available"}
+		if err := tx.Create(&a).Error; err != nil {
+			t.Fatalf("create animal %d: %v", i, err)
+		}
+	}
+
+	sweepAnimals(tx, &StubEmbedder{})
+
+	var embeddedCount int64
+	assert.NoError(t, tx.Model(&models.Animal{}).Where("group_id = ? AND embedding IS NOT NULL", group.ID).Count(&embeddedCount).Error)
+	assert.Equal(t, int64(sweepBatchSize), embeddedCount, "expected exactly one batch's worth of animals to be embedded per sweep call")
+}
+
+// TestStartReconciliationSweep_StopDoesNotLeakGoroutine guards against a
+// regression where the sweep's background goroutine keeps running (and its
+// ticker keeps firing) after stop() is called — e.g. if the select loop's
+// done case were dropped, or if ticker.Stop() were omitted.
+func TestStartReconciliationSweep_StopDoesNotLeakGoroutine(t *testing.T) {
+	db := openSweepTestPostgres(t)
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	stop := StartReconciliationSweep(db, &StubEmbedder{}, 5*time.Millisecond)
+	time.Sleep(20 * time.Millisecond) // let the ticker fire at least once
+	stop()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		runtime.GC()
+		after := runtime.NumGoroutine()
+		if after <= before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine count did not return to baseline after stop(): before=%d after=%d", before, after)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/embedding/sweep_postgres_test.go
+++ b/internal/embedding/sweep_postgres_test.go
@@ -133,6 +133,31 @@ func TestSweepAnimals_RespectsBatchSizeCap(t *testing.T) {
 	assert.Equal(t, int64(sweepBatchSize), embeddedCount, "expected exactly one batch's worth of animals to be embedded per sweep call")
 }
 
+func TestSweepUpdates_EmbedsRowsWithNullEmbedding(t *testing.T) {
+	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	user := models.User{Username: "sweeptest", Email: "sweeptest@example.com", Password: "x"}
+	if err := tx.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	update := models.Update{GroupID: group.ID, UserID: user.ID, Title: "Playgroup Saturday", Content: "10am at the field."}
+	if err := tx.Create(&update).Error; err != nil {
+		t.Fatalf("create update: %v", err)
+	}
+
+	sweepUpdates(tx, &StubEmbedder{})
+
+	var embeddingIsNull bool
+	assert.NoError(t, tx.Raw("SELECT embedding IS NULL FROM updates WHERE id = ?", update.ID).Scan(&embeddingIsNull).Error)
+	assert.False(t, embeddingIsNull, "expected sweepUpdates to populate the embedding column")
+}
+
 // countingEmbedder wraps another Embedder and atomically counts calls to
 // EmbedDocuments, so tests can observe how many sweep ticks actually did
 // embedding work.

--- a/internal/embedding/sweep_postgres_test.go
+++ b/internal/embedding/sweep_postgres_test.go
@@ -1,10 +1,12 @@
 package embedding
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -131,19 +133,96 @@ func TestSweepAnimals_RespectsBatchSizeCap(t *testing.T) {
 	assert.Equal(t, int64(sweepBatchSize), embeddedCount, "expected exactly one batch's worth of animals to be embedded per sweep call")
 }
 
+// countingEmbedder wraps another Embedder and atomically counts calls to
+// EmbedDocuments, so tests can observe how many sweep ticks actually did
+// embedding work.
+type countingEmbedder struct {
+	Embedder
+	calls int64
+}
+
+func (c *countingEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return c.Embedder.EmbedDocuments(ctx, texts)
+}
+
+func (c *countingEmbedder) Calls() int64 {
+	return atomic.LoadInt64(&c.calls)
+}
+
 // TestStartReconciliationSweep_StopDoesNotLeakGoroutine guards against a
 // regression where the sweep's background goroutine keeps running (and its
 // ticker keeps firing) after stop() is called — e.g. if the select loop's
 // done case were dropped, or if ticker.Stop() were omitted.
+//
+// It runs against a rolled-back transaction (not the raw db) so the sweep's
+// real UPDATEs against animals/animal_comments never escape the test — a
+// prior version of this test passed the raw db and permanently overwrote
+// live dev-database rows with StubEmbedder junk vectors once the sweep
+// goroutine fired for real.
+//
+// To prove the ticker itself stops (not just that the goroutine exits,
+// which NumGoroutine alone can't distinguish from "ticker leaked but the
+// goroutine happened to return anyway"), the test seeds a row that stays
+// perpetually stale — its updated_at is pinned far in the future, so every
+// sweep tick's "embedding_updated_at = now()" write is still older than
+// updated_at and the row is re-embedded on every single tick. A counting
+// embedder records how many times embedding actually ran. After stop(),
+// the count must not increase even after waiting several more tick
+// intervals — if it did, the ticker would still be firing.
 func TestStartReconciliationSweep_StopDoesNotLeakGoroutine(t *testing.T) {
 	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepLeakTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	// Pin updated_at far in the future so the row is always considered
+	// stale (embedding_updated_at, set to now() on every sweep tick, is
+	// always earlier than this), guaranteeing the embedder is invoked on
+	// every tick until the sweep is actually stopped.
+	if err := tx.Exec(
+		"UPDATE animals SET updated_at = ? WHERE id = ?",
+		time.Now().Add(24*time.Hour), animal.ID,
+	).Error; err != nil {
+		t.Fatalf("failed to pin updated_at: %v", err)
+	}
 
 	runtime.GC()
 	before := runtime.NumGoroutine()
 
-	stop := StartReconciliationSweep(db, &StubEmbedder{}, 5*time.Millisecond)
-	time.Sleep(20 * time.Millisecond) // let the ticker fire at least once
+	embedder := &countingEmbedder{Embedder: &StubEmbedder{}}
+	interval := 5 * time.Millisecond
+	stop := StartReconciliationSweep(tx, embedder, interval)
+
+	// Wait for at least one real tick to have run the embedder, so we know
+	// the sweep is actually ticking before we try to stop it.
+	tickDeadline := time.Now().Add(500 * time.Millisecond)
+	for embedder.Calls() == 0 {
+		if time.Now().After(tickDeadline) {
+			t.Fatalf("sweep never invoked the embedder before stop() — test setup didn't produce a stale row")
+		}
+		time.Sleep(interval)
+	}
+
 	stop()
+
+	// Let any tick that was already in flight when stop() was called
+	// finish, then snapshot the call count.
+	time.Sleep(interval * 2)
+	countAtStop := embedder.Calls()
+
+	// Wait past several more tick intervals. If the ticker were still
+	// firing (e.g. ticker.Stop() were omitted or the done case dropped),
+	// the always-stale row would keep incrementing the counter.
+	time.Sleep(interval * 10)
+	assert.Equal(t, countAtStop, embedder.Calls(), "embedder was invoked again after stop() — the ticker did not actually stop")
 
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for {

--- a/internal/embedding/sweep_postgres_test.go
+++ b/internal/embedding/sweep_postgres_test.go
@@ -244,6 +244,11 @@ func (c *countingEmbedder) Calls() int64 {
 // the count must not increase even after waiting several more tick
 // intervals — if it did, the ticker would still be firing.
 func TestStartReconciliationSweep_StopDoesNotLeakGoroutine(t *testing.T) {
+	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — this test
+	// needs the sweep to actually invoke the embedder every tick (see the
+	// comment below), so it must be explicitly enabled here.
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
 	db := openSweepTestPostgres(t)
 	tx := db.Begin()
 	defer tx.Rollback()

--- a/internal/embedding/sweep_postgres_test.go
+++ b/internal/embedding/sweep_postgres_test.go
@@ -133,6 +133,54 @@ func TestSweepAnimals_RespectsBatchSizeCap(t *testing.T) {
 	assert.Equal(t, int64(sweepBatchSize), embeddedCount, "expected exactly one batch's worth of animals to be embedded per sweep call")
 }
 
+func TestSweepComments_ExcludesCommentsOnDeletedAnimal(t *testing.T) {
+	db := openSweepTestPostgres(t)
+	tx := db.Begin()
+	defer tx.Rollback()
+
+	group := models.Group{Name: fmt.Sprintf("SweepTest-%d", time.Now().UnixNano())}
+	if err := tx.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	user := models.User{Username: fmt.Sprintf("sweeptest-%d", time.Now().UnixNano()), Email: fmt.Sprintf("sweeptest-%d@example.com", time.Now().UnixNano()), Password: "x"}
+	if err := tx.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	keptAnimal := models.Animal{GroupID: group.ID, Name: "Buddy", Species: "Dog", Status: "available"}
+	if err := tx.Create(&keptAnimal).Error; err != nil {
+		t.Fatalf("create kept animal: %v", err)
+	}
+	deletedAnimal := models.Animal{GroupID: group.ID, Name: "Ghost", Species: "Dog", Status: "available"}
+	if err := tx.Create(&deletedAnimal).Error; err != nil {
+		t.Fatalf("create animal to be deleted: %v", err)
+	}
+
+	keptComment := models.AnimalComment{AnimalID: keptAnimal.ID, UserID: user.ID, Content: "Great playgroup session today."}
+	if err := tx.Create(&keptComment).Error; err != nil {
+		t.Fatalf("create comment on kept animal: %v", err)
+	}
+	orphanedComment := models.AnimalComment{AnimalID: deletedAnimal.ID, UserID: user.ID, Content: "Great playgroup session today too."}
+	if err := tx.Create(&orphanedComment).Error; err != nil {
+		t.Fatalf("create comment on animal to be deleted: %v", err)
+	}
+
+	// Soft-delete, exactly as DeleteAnimal does.
+	if err := tx.Delete(&deletedAnimal).Error; err != nil {
+		t.Fatalf("soft-delete animal: %v", err)
+	}
+
+	sweepComments(tx, &StubEmbedder{})
+
+	var keptEmbeddingIsNull bool
+	assert.NoError(t, tx.Raw("SELECT embedding IS NULL FROM animal_comments WHERE id = ?", keptComment.ID).Scan(&keptEmbeddingIsNull).Error)
+	assert.False(t, keptEmbeddingIsNull, "expected the comment on the kept animal to be embedded")
+
+	var orphanedEmbeddingIsNull bool
+	assert.NoError(t, tx.Raw("SELECT embedding IS NULL FROM animal_comments WHERE id = ?", orphanedComment.ID).Scan(&orphanedEmbeddingIsNull).Error)
+	assert.True(t, orphanedEmbeddingIsNull, "expected the comment on the deleted animal to be excluded from the sweep, not embedded")
+}
+
 func TestSweepUpdates_EmbedsRowsWithNullEmbedding(t *testing.T) {
 	db := openSweepTestPostgres(t)
 	tx := db.Begin()

--- a/internal/embedding/text.go
+++ b/internal/embedding/text.go
@@ -1,0 +1,20 @@
+package embedding
+
+// AnimalEmbeddingText builds the canonical searchable text for an animal
+// from its name/species/breed/description/trainer_notes fields — matching
+// the same field set the search_vector generated column indexes. This is
+// the single source of truth for the formula, used by both the write-path
+// embed helpers (internal/handlers/search_embed.go) and the reconciliation
+// sweep, so keyword search and semantic search always index the same
+// content for the same row.
+func AnimalEmbeddingText(name, species, breed, description, trainerNotes string) string {
+	return name + " " + species + " " + breed + " " + description + " " + trainerNotes
+}
+
+// UpdateEmbeddingText builds the canonical searchable text for a group
+// update from its title/content fields, matching the search_vector
+// generated column. See AnimalEmbeddingText's comment for why this lives
+// here rather than being duplicated per call site.
+func UpdateEmbeddingText(title, content string) string {
+	return title + " " + content
+}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -43,9 +43,12 @@ func NewVoyageEmbedder() *VoyageEmbedder {
 	}
 }
 
-// IsConfigured reports whether an API key is present.
+// IsConfigured reports whether an API key is present. Nil-receiver-safe so
+// Usable(embedder) can call it even when embedder is a typed-nil
+// *VoyageEmbedder held in the Embedder interface (interface != nil in that
+// case, so Usable's own nil check can't catch it).
 func (v *VoyageEmbedder) IsConfigured() bool {
-	return v.apiKey != ""
+	return v != nil && v.apiKey != ""
 }
 
 type voyageRequest struct {

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -1,0 +1,160 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+)
+
+const (
+	defaultVoyageAPIURL = "https://api.voyageai.com/v1/embeddings"
+	defaultVoyageModel  = "voyage-4"
+)
+
+var tracer = telemetry.Tracer("internal/embedding")
+
+// VoyageEmbedder implements Embedder using Voyage AI's embeddings API.
+type VoyageEmbedder struct {
+	apiKey string
+	model  string
+	apiURL string // configurable for testing
+	client *http.Client
+}
+
+// NewVoyageEmbedder creates a VoyageEmbedder from environment variables
+// (VOYAGE_API_KEY required; VOYAGE_MODEL optional, defaults to "voyage-4").
+func NewVoyageEmbedder() *VoyageEmbedder {
+	model := os.Getenv("VOYAGE_MODEL")
+	if model == "" {
+		model = defaultVoyageModel
+	}
+	return &VoyageEmbedder{
+		apiKey: os.Getenv("VOYAGE_API_KEY"),
+		model:  model,
+		apiURL: defaultVoyageAPIURL,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// IsConfigured reports whether an API key is present.
+func (v *VoyageEmbedder) IsConfigured() bool {
+	return v.apiKey != ""
+}
+
+type voyageRequest struct {
+	Input           interface{} `json:"input"`
+	Model           string      `json:"model"`
+	InputType       string      `json:"input_type"`
+	OutputDimension int         `json:"output_dimension"`
+}
+
+type voyageResponseItem struct {
+	Embedding []float32 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type voyageResponse struct {
+	Data []voyageResponseItem `json:"data"`
+}
+
+func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input interface{}, inputType string) ([]voyageResponseItem, error) {
+	if !v.IsConfigured() {
+		return nil, fmt.Errorf("Voyage embedder is not configured (VOYAGE_API_KEY not set)")
+	}
+
+	ctx, span := tracer.Start(ctx, spanName)
+	defer span.End()
+
+	reqBody := voyageRequest{
+		Input:           input,
+		Model:           v.model,
+		InputType:       inputType,
+		OutputDimension: Dimension,
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, telemetry.Fail(span, fmt.Errorf("failed to marshal Voyage request: %w", err), "marshal failed")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, telemetry.Fail(span, fmt.Errorf("failed to create Voyage request: %w", err), "request creation failed")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+v.apiKey)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, telemetry.Fail(span, fmt.Errorf("failed to send Voyage request: %w", err), "request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, telemetry.Fail(span, fmt.Errorf("failed to read Voyage response: %w", err), "read failed")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, telemetry.Fail(span, fmt.Errorf("Voyage API error: status %d, body: %s", resp.StatusCode, string(body)), "non-200 response")
+	}
+
+	var voyageResp voyageResponse
+	if err := json.Unmarshal(body, &voyageResp); err != nil {
+		return nil, telemetry.Fail(span, fmt.Errorf("failed to unmarshal Voyage response: %w", err), "unmarshal failed")
+	}
+
+	return voyageResp.Data, nil
+}
+
+// EmbedDocument embeds a single piece of indexed text (input_type "document").
+func (v *VoyageEmbedder) EmbedDocument(ctx context.Context, text string) ([]float32, error) {
+	items, err := v.embed(ctx, "embedding.voyage.embed_document", text, "document")
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("Voyage API returned no embeddings")
+	}
+	return items[0].Embedding, nil
+}
+
+// EmbedQuery embeds a user's search string (input_type "query") — Voyage's
+// retrieval-tuned models perform better when query text is distinguished
+// from document text at embed time.
+func (v *VoyageEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	items, err := v.embed(ctx, "embedding.voyage.embed_query", text, "query")
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("Voyage API returned no embeddings")
+	}
+	return items[0].Embedding, nil
+}
+
+// EmbedDocuments batches multiple documents into a single Voyage API call.
+func (v *VoyageEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error) {
+	inputs := make([]interface{}, len(texts))
+	for i, t := range texts {
+		inputs[i] = t
+	}
+	items, err := v.embed(ctx, "embedding.voyage.embed_documents", inputs, "document")
+	if err != nil {
+		return nil, err
+	}
+	out := make([][]float32, len(items))
+	for _, item := range items {
+		if item.Index < 0 || item.Index >= len(out) {
+			return nil, fmt.Errorf("Voyage API returned out-of-range index %d for %d inputs", item.Index, len(out))
+		}
+		out[item.Index] = item.Embedding
+	}
+	return out, nil
+}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -116,16 +116,28 @@ func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input inter
 	return voyageResp.Data, nil
 }
 
+// firstEmbedding extracts and validates the single embedding from a
+// single-item Voyage response, applying the same index-integrity check
+// EmbedDocuments applies to its batch responses — a single-item request
+// should only ever get back index 0, so anything else means the API
+// response doesn't correspond to the request we sent.
+func firstEmbedding(items []voyageResponseItem) ([]float32, error) {
+	if len(items) == 0 {
+		return nil, fmt.Errorf("Voyage API returned no embeddings")
+	}
+	if items[0].Index != 0 {
+		return nil, fmt.Errorf("Voyage API returned unexpected index %d for a single-item request", items[0].Index)
+	}
+	return items[0].Embedding, nil
+}
+
 // EmbedDocument embeds a single piece of indexed text (input_type "document").
 func (v *VoyageEmbedder) EmbedDocument(ctx context.Context, text string) ([]float32, error) {
 	items, err := v.embed(ctx, "embedding.voyage.embed_document", text, "document")
 	if err != nil {
 		return nil, err
 	}
-	if len(items) == 0 {
-		return nil, fmt.Errorf("Voyage API returned no embeddings")
-	}
-	return items[0].Embedding, nil
+	return firstEmbedding(items)
 }
 
 // EmbedQuery embeds a user's search string (input_type "query") — Voyage's
@@ -136,10 +148,7 @@ func (v *VoyageEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32
 	if err != nil {
 		return nil, err
 	}
-	if len(items) == 0 {
-		return nil, fmt.Errorf("Voyage API returned no embeddings")
-	}
-	return items[0].Embedding, nil
+	return firstEmbedding(items)
 }
 
 // EmbedDocuments batches multiple documents into a single Voyage API call.

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -167,5 +167,15 @@ func (v *VoyageEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([]
 		}
 		out[item.Index] = item.Embedding
 	}
+	// A response with a duplicate index (e.g. two items both claiming index
+	// 3) passes the length and range checks above while leaving another
+	// index's slot never written — catch that here instead of letting a nil
+	// embedding reach PersistEmbedding indistinguishably from a normal
+	// transient DB error.
+	for i, vec := range out {
+		if vec == nil {
+			return nil, fmt.Errorf("Voyage API response never populated index %d for %d inputs (duplicate index in response)", i, len(out))
+		}
+	}
 	return out, nil
 }

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -18,7 +18,30 @@ const (
 	defaultVoyageModel  = "voyage-4"
 )
 
+// RequestTimeout bounds a single embedding HTTP call — used both as
+// VoyageEmbedder's own http.Client.Timeout below and by
+// internal/handlers/search_embed.go to derive its own bounds (the
+// write-path embed call's context deadline and the shutdown drain
+// timeout), so those callers can't drift out of sync with how long an
+// embed call is actually allowed to take.
+const RequestTimeout = 30 * time.Second
+
 var tracer = telemetry.Tracer("internal/embedding")
+
+// maxErrorBodyLen bounds how much of an upstream error response body gets
+// embedded in this package's own error messages (and, from there, into
+// logs) — an API error page can be arbitrarily large or, in the worst case,
+// echo back request content this process shouldn't be re-logging wholesale.
+const maxErrorBodyLen = 500
+
+// truncateForError renders body as a string capped at maxErrorBodyLen,
+// marking whether it was cut short.
+func truncateForError(body []byte) string {
+	if len(body) <= maxErrorBodyLen {
+		return string(body)
+	}
+	return string(body[:maxErrorBodyLen]) + "... (truncated)"
+}
 
 // VoyageEmbedder implements Embedder using Voyage AI's embeddings API.
 type VoyageEmbedder struct {
@@ -39,7 +62,7 @@ func NewVoyageEmbedder() *VoyageEmbedder {
 		apiKey: os.Getenv("VOYAGE_API_KEY"),
 		model:  model,
 		apiURL: defaultVoyageAPIURL,
-		client: &http.Client{Timeout: 30 * time.Second},
+		client: &http.Client{Timeout: RequestTimeout},
 	}
 }
 
@@ -105,7 +128,11 @@ func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input inter
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, telemetry.Fail(span, fmt.Errorf("Voyage API error: status %d, body: %s", resp.StatusCode, string(body)), "non-200 response")
+		// Truncated rather than included in full: an error response body is
+		// operator-facing diagnostic text, not something this app's own
+		// logs should let grow unbounded or risk echoing back arbitrarily
+		// large/sensitive upstream content.
+		return nil, telemetry.Fail(span, fmt.Errorf("Voyage API error: status %d, body: %s", resp.StatusCode, truncateForError(body)), "non-200 response")
 	}
 
 	var voyageResp voyageResponse

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -34,6 +34,16 @@ var tracer = telemetry.Tracer("internal/embedding")
 // echo back request content this process shouldn't be re-logging wholesale.
 const maxErrorBodyLen = 500
 
+// maxResponseBodyBytes bounds how much of the Voyage HTTP response this
+// process reads into memory at all, via io.LimitReader below — separate
+// from (and enforced before) maxErrorBodyLen's log-message truncation. A
+// legitimate embeddings response is comfortably under this even at a full
+// batch (sweepBatchSize texts at Dimension floats each is on the order of
+// ~1 MB JSON-encoded), so this exists to guard against a misbehaving
+// upstream/proxy returning something disproportionately large (e.g. a
+// multi-GB error page) rather than to constrain normal operation.
+const maxResponseBodyBytes = 10 * 1024 * 1024 // 10 MB
+
 // truncateForError renders body as a string capped at maxErrorBodyLen,
 // marking whether it was cut short.
 func truncateForError(body []byte) string {
@@ -122,9 +132,16 @@ func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input inter
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	// Read one byte past the cap so an oversized body is detected (rather
+	// than silently truncated and then fed to json.Unmarshal, which would
+	// just fail with a confusing parse error instead of the clear one
+	// below).
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes+1))
 	if err != nil {
 		return nil, telemetry.Fail(span, fmt.Errorf("failed to read Voyage response: %w", err), "read failed")
+	}
+	if len(body) > maxResponseBodyBytes {
+		return nil, telemetry.Fail(span, fmt.Errorf("Voyage response exceeded %d bytes, aborting read", maxResponseBodyBytes), "response too large")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -128,6 +128,15 @@ func firstEmbedding(items []voyageResponseItem) ([]float32, error) {
 	if items[0].Index != 0 {
 		return nil, fmt.Errorf("Voyage API returned unexpected index %d for a single-item request", items[0].Index)
 	}
+	// Fail fast here instead of letting a wrong-dimension vector reach
+	// PersistEmbedding, where it would fail at the Postgres level against
+	// the fixed-width vector(Dimension) column — and since PersistEmbedding
+	// failing never marks the row as embedded, the reconciliation sweep
+	// would just keep re-attempting (and re-failing) the same embed forever
+	// instead of surfacing a clear error once.
+	if len(items[0].Embedding) != Dimension {
+		return nil, fmt.Errorf("Voyage API returned a %d-dimensional embedding, expected %d", len(items[0].Embedding), Dimension)
+	}
 	return items[0].Embedding, nil
 }
 
@@ -173,6 +182,11 @@ func (v *VoyageEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([]
 	for _, item := range items {
 		if item.Index < 0 || item.Index >= len(out) {
 			return nil, fmt.Errorf("Voyage API returned out-of-range index %d for %d inputs", item.Index, len(out))
+		}
+		// See firstEmbedding's comment on why this needs to fail fast rather
+		// than let a wrong-dimension vector reach PersistEmbedding.
+		if len(item.Embedding) != Dimension {
+			return nil, fmt.Errorf("Voyage API returned a %d-dimensional embedding at index %d, expected %d", len(item.Embedding), item.Index, Dimension)
 		}
 		out[item.Index] = item.Embedding
 	}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -149,7 +149,15 @@ func (v *VoyageEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([]
 	if err != nil {
 		return nil, err
 	}
-	out := make([][]float32, len(items))
+	// Size and validate against the request length (len(texts)), not the
+	// response length (len(items)) — a short response (fewer items than
+	// requested) must fail loudly here rather than silently returning an
+	// undersized slice that a caller indexing by request position could
+	// misinterpret as a shorter-but-complete result.
+	if len(items) != len(texts) {
+		return nil, fmt.Errorf("Voyage API returned %d embeddings for %d inputs", len(items), len(texts))
+	}
+	out := make([][]float32, len(texts))
 	for _, item := range items {
 		if item.Index < 0 || item.Index >= len(out) {
 			return nil, fmt.Errorf("Voyage API returned out-of-range index %d for %d inputs", item.Index, len(out))

--- a/internal/embedding/voyage_integration_test.go
+++ b/internal/embedding/voyage_integration_test.go
@@ -1,0 +1,26 @@
+package embedding
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// A thin real-Voyage integration test, gated behind a real VOYAGE_API_KEY
+// (skipped otherwise — same spirit as the Postgres-gated tests elsewhere in
+// this codebase) to catch adapter-level breakage (request shape, response
+// parsing) without needing a live key in every CI run.
+func TestVoyageEmbedder_Integration_EmbedDocument(t *testing.T) {
+	if os.Getenv("VOYAGE_API_KEY") == "" {
+		t.Skip("skipping: VOYAGE_API_KEY not set")
+	}
+
+	v := NewVoyageEmbedder()
+	vec, err := v.EmbedDocument(context.Background(), "Loves belly rubs and playing fetch.")
+	if err != nil {
+		t.Fatalf("EmbedDocument failed: %v", err)
+	}
+	if len(vec) != Dimension {
+		t.Fatalf("expected vector of length %d, got %d", Dimension, len(vec))
+	}
+}

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -140,6 +140,49 @@ func TestVoyageEmbedder_EmbedDocuments_ShortResponseReturnsError(t *testing.T) {
 	}
 }
 
+func TestVoyageEmbedder_EmbedDocument_WrongDimensionReturnsError(t *testing.T) {
+	// Simulates Voyage returning a vector shorter than the configured
+	// Dimension (e.g. a model/config mismatch) — must fail fast here
+	// rather than let a wrong-width vector reach PersistEmbedding, where it
+	// would fail against the fixed-width vector(Dimension) column and leave
+	// the reconciliation sweep retrying (and re-failing) forever.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := voyageTestResponse{Data: []voyageTestResponseItem{{Embedding: make([]float32, Dimension/2), Index: 0}}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocument(context.Background(), "resource guarding"); err == nil {
+		t.Fatal("expected an error when Voyage returns a wrong-dimension embedding")
+	}
+}
+
+func TestVoyageEmbedder_EmbedDocuments_WrongDimensionReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		items := []voyageTestResponseItem{
+			{Embedding: make([]float32, Dimension), Index: 0},
+			{Embedding: make([]float32, Dimension/2), Index: 1}, // wrong dimension
+		}
+		resp := voyageTestResponse{Data: items}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocuments(context.Background(), []string{"a", "b"}); err == nil {
+		t.Fatal("expected an error when Voyage returns a wrong-dimension embedding in a batch")
+	}
+}
+
 func TestVoyageEmbedder_NonOKResponse_ReturnsError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -227,6 +227,27 @@ func TestVoyageEmbedder_NonOKResponse_TruncatesLargeBody(t *testing.T) {
 	}
 }
 
+func TestVoyageEmbedder_RejectsResponseBodyOverSizeCap(t *testing.T) {
+	// A misbehaving upstream/proxy returning a disproportionately large
+	// body (e.g. a multi-GB error page) must be rejected via a bounded
+	// read, not read into memory in full first — a memory-DoS guard, not
+	// just a log-truncation one (see TruncatesLargeBody above).
+	oversized := make([]byte, maxResponseBodyBytes+100)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(oversized)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocument(context.Background(), "text"); err == nil {
+		t.Fatal("expected an error for a response body over the size cap, got nil")
+	}
+}
+
 func TestVoyageEmbedder_IsConfigured(t *testing.T) {
 	v := NewVoyageEmbedder()
 	v.apiKey = ""

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -1,0 +1,144 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type voyageTestRequest struct {
+	Input           interface{} `json:"input"`
+	Model           string      `json:"model"`
+	InputType       string      `json:"input_type"`
+	OutputDimension int         `json:"output_dimension"`
+}
+
+type voyageTestResponseItem struct {
+	Embedding []float32 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type voyageTestResponse struct {
+	Data []voyageTestResponseItem `json:"data"`
+}
+
+func TestVoyageEmbedder_EmbedDocument_SendsDocumentInputType(t *testing.T) {
+	var captured voyageTestRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("expected Authorization header \"Bearer test-key\", got %q", got)
+		}
+		resp := voyageTestResponse{Data: []voyageTestResponseItem{{Embedding: make([]float32, Dimension), Index: 0}}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	vec, err := v.EmbedDocument(context.Background(), "resource guarding around food bowls")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vec) != Dimension {
+		t.Fatalf("expected vector of length %d, got %d", Dimension, len(vec))
+	}
+	if captured.InputType != "document" {
+		t.Fatalf("expected input_type \"document\", got %q", captured.InputType)
+	}
+	if captured.OutputDimension != Dimension {
+		t.Fatalf("expected output_dimension %d, got %d", Dimension, captured.OutputDimension)
+	}
+}
+
+func TestVoyageEmbedder_EmbedQuery_SendsQueryInputType(t *testing.T) {
+	var captured voyageTestRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&captured)
+		resp := voyageTestResponse{Data: []voyageTestResponseItem{{Embedding: make([]float32, Dimension), Index: 0}}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedQuery(context.Background(), "resource guarding"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.InputType != "query" {
+		t.Fatalf("expected input_type \"query\", got %q", captured.InputType)
+	}
+}
+
+func TestVoyageEmbedder_EmbedDocuments_SendsBatchAndReturnsInOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req voyageTestRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		inputs, _ := req.Input.([]interface{})
+		items := make([]voyageTestResponseItem, len(inputs))
+		for i := range inputs {
+			vec := make([]float32, Dimension)
+			vec[0] = float32(i) // distinguishable per index
+			items[i] = voyageTestResponseItem{Embedding: vec, Index: i}
+		}
+		resp := voyageTestResponse{Data: items}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	vecs, err := v.EmbedDocuments(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("expected 3 vectors, got %d", len(vecs))
+	}
+	for i := range vecs {
+		if vecs[i][0] != float32(i) {
+			t.Fatalf("expected vecs[%d][0] == %d, got %v", i, i, vecs[i][0])
+		}
+	}
+}
+
+func TestVoyageEmbedder_NonOKResponse_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocument(context.Background(), "text"); err == nil {
+		t.Fatal("expected an error for a non-200 response, got nil")
+	}
+}
+
+func TestVoyageEmbedder_IsConfigured(t *testing.T) {
+	v := NewVoyageEmbedder()
+	v.apiKey = ""
+	if v.IsConfigured() {
+		t.Fatal("expected IsConfigured to be false with no API key")
+	}
+	v.apiKey = "test-key"
+	if !v.IsConfigured() {
+		t.Fatal("expected IsConfigured to be true with an API key set")
+	}
+}

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -115,6 +115,31 @@ func TestVoyageEmbedder_EmbedDocuments_SendsBatchAndReturnsInOrder(t *testing.T)
 	}
 }
 
+func TestVoyageEmbedder_EmbedDocuments_ShortResponseReturnsError(t *testing.T) {
+	// Simulates Voyage returning fewer embeddings than requested (e.g. a
+	// partial batch failure that still responds 200 with a shorter data
+	// array) — must fail loudly rather than silently returning an
+	// undersized slice a caller could index past the end of.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		items := []voyageTestResponseItem{
+			{Embedding: make([]float32, Dimension), Index: 0},
+			{Embedding: make([]float32, Dimension), Index: 1},
+		}
+		resp := voyageTestResponse{Data: items}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocuments(context.Background(), []string{"a", "b", "c"}); err == nil {
+		t.Fatal("expected an error when Voyage returns fewer embeddings than requested texts")
+	}
+}
+
 func TestVoyageEmbedder_NonOKResponse_ReturnsError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -196,6 +197,33 @@ func TestVoyageEmbedder_NonOKResponse_ReturnsError(t *testing.T) {
 
 	if _, err := v.EmbedDocument(context.Background(), "text"); err == nil {
 		t.Fatal("expected an error for a non-200 response, got nil")
+	}
+}
+
+func TestVoyageEmbedder_NonOKResponse_TruncatesLargeBody(t *testing.T) {
+	// An oversized error page (e.g. an HTML error page from a proxy/gateway
+	// in front of the real API) must not be echoed into this app's own logs
+	// in full.
+	largeBody := strings.Repeat("x", maxErrorBodyLen*3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(largeBody))
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	_, err := v.EmbedDocument(context.Background(), "text")
+	if err == nil {
+		t.Fatal("expected an error for a non-200 response, got nil")
+	}
+	if len(err.Error()) >= len(largeBody) {
+		t.Fatalf("expected the error message to truncate the %d-byte response body, got a %d-byte error message", len(largeBody), len(err.Error()))
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("expected the error message to indicate truncation, got: %s", err.Error())
 	}
 }
 

--- a/internal/handlers/animal_admin.go
+++ b/internal/handlers/animal_admin.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
 )
 
 // UpdateAnimalAdmin updates an existing animal by ID (admin only, no group check needed)
-func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
+func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		logger := middleware.GetLogger(c)
 		animalID := c.Param("animalId")
@@ -43,6 +44,12 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
 			return
 		}
+
+		// Captured before any field mutations below so it can be compared
+		// against the post-update text to decide whether re-embedding is
+		// actually necessary — mirrors the same pattern in
+		// animal_crud.go's UpdateAnimal.
+		oldEmbeddingText := animalEmbeddingText(animal)
 
 		// Build update map with only provided fields
 		updates := make(map[string]interface{})
@@ -194,6 +201,16 @@ func UpdateAnimalAdmin(db *gorm.DB, emailService *email.Service) gin.HandlerFunc
 		if err := dbCtx.Preload("Tags").First(&animal, animalID).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reload animal"})
 			return
+		}
+
+		// db is the unscoped *gorm.DB (see the comment on dbCtx above) so the
+		// detached embed goroutine isn't tied to this request's context.
+		if animalEmbeddingText(animal) != oldEmbeddingText {
+			embedAnimalAsync(db, embedder, animal)
+		} else if embedding.Usable(embedder) {
+			if err := embedding.TouchEmbeddingTimestamp(db, "animals", animal.ID, animal.UpdatedAt); err != nil {
+				logger.Error("Failed to touch animal embedding timestamp", err)
+			}
 		}
 
 		if enteredQuarantine {

--- a/internal/handlers/animal_admin_test.go
+++ b/internal/handlers/animal_admin_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
@@ -37,7 +38,7 @@ func TestUpdateAnimalAdmin_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -86,7 +87,7 @@ func TestUpdateAnimalAdmin_PartialUpdate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -126,7 +127,7 @@ func TestUpdateAnimalAdmin_StatusTransition(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -169,7 +170,7 @@ func TestUpdateAnimalAdmin_EnterQuarantine_StoresIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -213,7 +214,7 @@ func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -252,7 +253,7 @@ func TestUpdateAnimalAdmin_UnderVetCareTransition(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -299,7 +300,7 @@ func TestUpdateAnimalAdmin_MoveGroup(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -332,7 +333,7 @@ func TestUpdateAnimalAdmin_NotFound(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/api/v1/admin/animals/99999", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusNotFound {
@@ -360,7 +361,7 @@ func TestUpdateAnimalAdmin_NoUpdates(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	// The handler will accept this as an update (even though the value is the same)
@@ -387,7 +388,7 @@ func TestUpdateAnimalAdmin_ValidationError(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -584,7 +585,7 @@ func TestUpdateAnimalAdmin_ApprovalStatusSet(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimalAdmin(db, nil)(c)
+	UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -620,7 +621,7 @@ func TestUpdateAnimalAdmin_ApprovalClearedOnTransitionToAvailable(t *testing.T) 
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimalAdmin(db, nil)(c)
+	UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -656,7 +657,7 @@ func TestUpdateAnimalAdmin_BiteQuarantine_DefaultEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -699,7 +700,7 @@ func TestUpdateAnimalAdmin_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -738,7 +739,7 @@ func TestUpdateAnimalAdmin_EditEndDateOnly_WhileInQuarantine(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -783,7 +784,7 @@ func TestUpdateAnimalAdmin_LeaveQuarantine_ClearsEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -819,7 +820,7 @@ func TestUpdateAnimalAdmin_BQEntry_CreatesIncidentRow(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -864,7 +865,7 @@ func TestUpdateAnimalAdmin_BQExit_StampsEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -922,7 +923,7 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -978,7 +979,7 @@ func TestUpdateAnimalAdmin_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1036,7 +1037,7 @@ func TestUpdateAnimalAdmin_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving(t *
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -1094,7 +1095,7 @@ func TestUpdateAnimalAdmin_LeaveQuarantine_EarlyExit_CapsEndDateAtNow(t *testing
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 	afterRequest := time.Now()
 
@@ -1147,7 +1148,7 @@ func TestUpdateAnimalAdmin_MidBQ_UpdatesIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1202,7 +1203,7 @@ func TestUpdateAnimalAdmin_MidBQ_EditStartDate_SyncsIncidentRow(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/admin/animals/%d", animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimalAdmin(db, nil)
+	handler := UpdateAnimalAdmin(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
@@ -184,8 +185,14 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 }
 
 // CreateAnimalComment creates a new comment on an animal
-func CreateAnimalComment(db *gorm.DB) gin.HandlerFunc {
+func CreateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// rawDB is captured before the shadow below so the detached
+		// goroutine spawned by embedCommentAsync gets the unscoped db, not
+		// one bound to this request's context (which is canceled the
+		// instant this handler returns). See the same pattern in
+		// animal_crud.go's sendQuarantineNotificationEmail usage.
+		rawDB := db
 		db := middleware.GetDB(c, db)
 		groupID := c.Param("id")
 		animalID := c.Param("animalId")
@@ -245,6 +252,8 @@ func CreateAnimalComment(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		embedCommentAsync(rawDB, embedder, comment)
+
 		// Attach tags if provided
 		if len(req.TagIDs) > 0 {
 			var tags []models.CommentTag
@@ -268,8 +277,14 @@ func CreateAnimalComment(db *gorm.DB) gin.HandlerFunc {
 
 // UpdateAnimalComment updates a comment on an animal
 // Users can only edit their own comments
-func UpdateAnimalComment(db *gorm.DB) gin.HandlerFunc {
+func UpdateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// rawDB is captured before the shadow below so the detached
+		// goroutine spawned by embedCommentAsync gets the unscoped db, not
+		// one bound to this request's context (which is canceled the
+		// instant this handler returns). See the same pattern in
+		// animal_crud.go's sendQuarantineNotificationEmail usage.
+		rawDB := db
 		db := middleware.GetDB(c, db)
 		groupID := c.Param("id")
 		animalID := c.Param("animalId")
@@ -350,6 +365,8 @@ func UpdateAnimalComment(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update comment"})
 			return
 		}
+
+		embedCommentAsync(rawDB, embedder, comment)
 
 		// Update tags if provided
 		if len(req.TagIDs) > 0 {

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -355,6 +355,12 @@ func UpdateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFu
 			log.Printf("Failed to save comment history: %v", err)
 		}
 
+		// Captured before the mutation below so it can be compared against
+		// the post-save content to decide whether re-embedding is actually
+		// necessary — a metadata/image-only edit doesn't change the embedded
+		// text at all.
+		oldContent := comment.Content
+
 		// Update comment fields
 		comment.Content = req.Content
 		comment.ImageURL = req.ImageURL
@@ -366,7 +372,21 @@ func UpdateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFu
 			return
 		}
 
-		embedCommentAsync(rawDB, embedder, comment)
+		// Skip the embed call entirely when the embedded text (Content)
+		// didn't actually change — the reconciliation sweep only ever
+		// retries rows that are actually stale, so nothing is lost by not
+		// re-embedding unchanged text. When skipped, embedding_updated_at is
+		// touched forward to the new updated_at instead: db.Save above
+		// always bumps updated_at regardless of which fields changed, so
+		// without this the sweep would see the row as stale on its very next
+		// tick and re-embed the exact unchanged content anyway.
+		if comment.Content != oldContent {
+			embedCommentAsync(rawDB, embedder, comment)
+		} else if embedding.Usable(embedder) {
+			if err := embedding.TouchEmbeddingTimestamp(rawDB, "animal_comments", comment.ID, comment.UpdatedAt); err != nil {
+				log.Printf("Failed to touch comment embedding timestamp: %v", err)
+			}
+		}
 
 		// Update tags if provided
 		if len(req.TagIDs) > 0 {

--- a/internal/handlers/animal_comment_test.go
+++ b/internal/handlers/animal_comment_test.go
@@ -22,6 +22,22 @@ func setupAnimalCommentTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to open database: %v", err)
 	}
 
+	// IMPORTANT: SQLite in-memory databases are per-connection. Without
+	// capping the pool to a single connection, database/sql may open a
+	// second physical connection to service a concurrent caller (e.g. the
+	// detached goroutine embedCommentAsync spawns) — and since ":memory:"
+	// isn't shared-cache here, that second connection is a distinct, blank,
+	// unmigrated database, producing intermittent "no such table:
+	// animal_comments" errors. Forcing a single connection makes the pool
+	// serialize access instead, matching the pattern in SetupTestDB
+	// (test_helpers.go).
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get database instance: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
 	// Migrate models
 	err = db.AutoMigrate(
 		&models.User{},

--- a/internal/handlers/animal_comment_test.go
+++ b/internal/handlers/animal_comment_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
@@ -289,7 +290,7 @@ func TestCreateAnimalComment(t *testing.T) {
 			tt.setupContext(c)
 
 			// Execute
-			handler := CreateAnimalComment(db)
+			handler := CreateAnimalComment(db, &embedding.StubEmbedder{})
 			handler(c)
 
 			// Assert
@@ -329,7 +330,7 @@ func TestCreateAnimalComment_WithTags(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/groups/1/animals/1/comments", bytes.NewBuffer(bodyBytes))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimalComment(db)
+	handler := CreateAnimalComment(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	assert.Equal(t, http.StatusCreated, w.Code)

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
@@ -190,7 +191,7 @@ func GetAnimal(db *gorm.DB) gin.HandlerFunc {
 }
 
 // CreateAnimal creates a new animal in a group
-func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
+func CreateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// rawDB is captured before the shadow below so the detached
 		// goroutine spawned by sendQuarantineNotificationEmail gets the
@@ -293,6 +294,8 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 			return
 		}
 
+		embedAnimalAsync(rawDB, embedder, animal)
+
 		if animal.Status == "bite_quarantine" {
 			if err := db.Create(&models.AnimalBQIncident{
 				AnimalID:        animal.ID,
@@ -328,7 +331,7 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 }
 
 // UpdateAnimal updates an existing animal
-func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
+func UpdateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// rawDB is captured before the shadow below so the detached
 		// goroutine spawned by sendQuarantineNotificationEmail gets the
@@ -528,6 +531,8 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update animal"})
 			return
 		}
+
+		embedAnimalAsync(rawDB, embedder, animal)
 
 		if enteredQuarantine {
 			if err := db.Create(&models.AnimalBQIncident{

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -367,6 +367,12 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.E
 			return
 		}
 
+		// Captured before any field mutations below so it can be compared
+		// against the post-save text to decide whether re-embedding is
+		// actually necessary (e.g. a pure quarantine-status/approval-status
+		// edit doesn't change the embedded text at all).
+		oldEmbeddingText := animalEmbeddingText(animal)
+
 		// Track name changes
 		oldName := animal.Name
 		if req.Name != oldName {
@@ -532,7 +538,22 @@ func UpdateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.E
 			return
 		}
 
-		embedAnimalAsync(rawDB, embedder, animal)
+		// Skip the embed call entirely when none of the embedded fields
+		// actually changed (e.g. a pure quarantine/approval-status edit) —
+		// the reconciliation sweep only ever retries rows that are actually
+		// stale, so nothing is lost by not re-embedding unchanged text. When
+		// skipped, embedding_updated_at is touched forward to the new
+		// updated_at instead: db.Save above always bumps updated_at
+		// regardless of which fields changed, so without this the sweep
+		// would see the row as stale on its very next tick and re-embed the
+		// exact unchanged text anyway.
+		if animalEmbeddingText(animal) != oldEmbeddingText {
+			embedAnimalAsync(rawDB, embedder, animal)
+		} else if embedding.Usable(embedder) {
+			if err := embedding.TouchEmbeddingTimestamp(rawDB, "animals", animal.ID, animal.UpdatedAt); err != nil {
+				logging.WithField("error", err.Error()).Warn("Failed to touch animal embedding timestamp")
+			}
+		}
 
 		if enteredQuarantine {
 			if err := db.Create(&models.AnimalBQIncident{

--- a/internal/handlers/animal_crud_email_test.go
+++ b/internal/handlers/animal_crud_email_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
@@ -73,7 +74,7 @@ func TestUpdateAnimal_EnterQuarantine_StoresIncidentAndKeepsItOnEdit(t *testing.
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -105,7 +106,7 @@ func TestUpdateAnimal_EnterQuarantine_StoresIncidentAndKeepsItOnEdit(t *testing.
 	c2.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData2))
 	c2.Request.Header.Set("Content-Type", "application/json")
 
-	handler2 := UpdateAnimal(db, nil)
+	handler2 := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler2(c2)
 
 	if w2.Code != http.StatusOK {
@@ -150,7 +151,7 @@ func TestUpdateAnimal_LeaveQuarantine_ClearsIncident(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -186,7 +187,7 @@ func TestCreateAnimal_BQEntry_CreatesIncidentRow(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -225,7 +226,7 @@ func TestUpdateAnimal_BQEntry_CreatesIncidentRow(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -274,7 +275,7 @@ func TestUpdateAnimal_BQExit_StampsEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -335,7 +336,7 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_UsesProvidedValue(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -393,7 +394,7 @@ func TestUpdateAnimal_BQExit_ExplicitEndDate_NoStoredStartDate_Succeeds(t *testi
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -454,7 +455,7 @@ func TestUpdateAnimal_BQExit_InvalidExplicitEndDate_RejectsBeforeSaving(t *testi
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -516,7 +517,7 @@ func TestUpdateAnimal_MidBQ_UpdatesIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -554,7 +555,7 @@ func TestCreateAnimal_BiteQuarantine_StoresIncidentDetails(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -669,7 +670,7 @@ func TestUpdateAnimal_MidBQ_EditStartDate_SyncsIncidentRow(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {

--- a/internal/handlers/animal_import_export.go
+++ b/internal/handlers/animal_import_export.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
@@ -81,7 +82,7 @@ func ExportAnimalsCSV(db *gorm.DB) gin.HandlerFunc {
 }
 
 // ImportAnimalsCSV imports animals from CSV file
-func ImportAnimalsCSV(db *gorm.DB) gin.HandlerFunc {
+func ImportAnimalsCSV(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := middleware.GetDB(c, db)
 		logger := middleware.GetLogger(c)
@@ -250,6 +251,14 @@ func ImportAnimalsCSV(db *gorm.DB) gin.HandlerFunc {
 			logger.Error("Failed to import animals", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to import animals"})
 			return
+		}
+
+		// db.Create above populates each animal's ID, so these are safe to
+		// embed now. Uses the unscoped db (not middleware.GetDB(c, db)) since
+		// embedAnimalAsync's goroutines outlive this request — see the same
+		// pattern in animal_crud.go's CreateAnimal.
+		for _, animal := range animals {
+			embedAnimalAsync(db, embedder, animal)
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_import_export.go
+++ b/internal/handlers/animal_import_export.go
@@ -84,6 +84,12 @@ func ExportAnimalsCSV(db *gorm.DB) gin.HandlerFunc {
 // ImportAnimalsCSV imports animals from CSV file
 func ImportAnimalsCSV(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// rawDB is captured before the shadow below so the detached embed
+		// goroutines spawned below get the unscoped db, not one bound to
+		// this request's context (which is canceled the instant this
+		// handler returns). See the same pattern in animal_crud.go's
+		// CreateAnimal.
+		rawDB := db
 		db := middleware.GetDB(c, db)
 		logger := middleware.GetLogger(c)
 
@@ -254,11 +260,11 @@ func ImportAnimalsCSV(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc 
 		}
 
 		// db.Create above populates each animal's ID, so these are safe to
-		// embed now. Uses the unscoped db (not middleware.GetDB(c, db)) since
+		// embed now. Uses rawDB (not the request-scoped db) since
 		// embedAnimalAsync's goroutines outlive this request — see the same
 		// pattern in animal_crud.go's CreateAnimal.
 		for _, animal := range animals {
-			embedAnimalAsync(db, embedder, animal)
+			embedAnimalAsync(rawDB, embedder, animal)
 		}
 
 		logger.WithFields(map[string]interface{}{

--- a/internal/handlers/animal_import_export_test.go
+++ b/internal/handlers/animal_import_export_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
@@ -127,7 +128,7 @@ func TestImportAnimalsCSV_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
 	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -173,7 +174,7 @@ func TestImportAnimalsCSV_UnderVetCareStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
 	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -206,7 +207,7 @@ func TestImportAnimalsCSV_InvalidFile(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
 	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -239,7 +240,7 @@ func TestImportAnimalsCSV_MissingRequiredColumn(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
 	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -274,7 +275,7 @@ invalid,Rex,Dog
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", body)
 	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -308,7 +309,7 @@ func TestImportAnimalsCSV_NoFile(t *testing.T) {
 	c, w := setupAnimalTestContext(user.ID, true)
 	c.Request = httptest.NewRequest("POST", "/api/v1/admin/animals/import-csv", nil)
 
-	handler := ImportAnimalsCSV(db)
+	handler := ImportAnimalsCSV(db, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
@@ -420,7 +421,7 @@ func TestCreateAnimal_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -473,7 +474,7 @@ func TestCreateAnimal_ValidationError(t *testing.T) {
 			c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := CreateAnimal(db, nil)
+			handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 			handler(c)
 
 			if w.Code != http.StatusBadRequest {
@@ -501,7 +502,7 @@ func TestCreateAnimal_DefaultStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -573,7 +574,7 @@ func TestCreateAnimal_StatusSpecificDates(t *testing.T) {
 			c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := CreateAnimal(db, nil)
+			handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 			handler(c)
 
 			if w.Code != http.StatusCreated {
@@ -611,7 +612,7 @@ func TestCreateAnimal_AccessDenied(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group1.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusForbidden {
@@ -636,7 +637,7 @@ func TestCreateAnimal_InvalidGroupID(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/api/v1/groups/invalid/animals", bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	// Invalid group ID causes checkGroupAccess to fail (returns 403) or parsing fails (returns 400)
@@ -774,7 +775,7 @@ func TestUpdateAnimal_Success(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -820,7 +821,7 @@ func TestUpdateAnimal_NotFound(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/99999", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusNotFound {
@@ -917,7 +918,7 @@ func TestUpdateAnimal_StatusTransition(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db, nil)
+			handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 			handler(c)
 
 			if w.Code != http.StatusOK {
@@ -984,7 +985,7 @@ func TestUpdateAnimal_NoStatusChange(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1034,7 +1035,7 @@ func TestUpdateAnimal_ValidationError(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -1066,7 +1067,7 @@ func TestUpdateAnimal_AccessDenied(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group1.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusForbidden {
@@ -1109,7 +1110,7 @@ func TestUpdateAnimal_CustomQuarantineDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1470,7 +1471,7 @@ func TestUpdateAnimal_EmptyQuarantineDateString(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBufferString(tt.jsonBody))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db, nil)
+			handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 			handler(c)
 
 			if w.Code != tt.wantStatus {
@@ -1518,7 +1519,7 @@ func TestUpdateAnimal_NameHistory(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -1608,7 +1609,7 @@ func TestUpdateAnimal_IsReturned(t *testing.T) {
 			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(body))
 			c.Request.Header.Set("Content-Type", "application/json")
 
-			handler := UpdateAnimal(db, nil)
+			handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 			handler(c)
 
 			if w.Code != http.StatusOK {
@@ -1723,7 +1724,7 @@ func TestCreateAnimal_IsReturned(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -1796,7 +1797,7 @@ func TestCreateAnimal_WithApprovalStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	CreateAnimal(db, nil)(c)
+	CreateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
@@ -1832,7 +1833,7 @@ func TestUpdateAnimal_InvalidApprovalStatus(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected 400, got %d: %s", w.Code, w.Body.String())
@@ -1872,7 +1873,7 @@ func TestUpdateAnimal_ApprovalStatusSet(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -1922,7 +1923,7 @@ func TestUpdateAnimal_ApprovalStatusCleared(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -1973,7 +1974,7 @@ func TestUpdateAnimal_ApprovalNotClearedWhenOmitted(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2018,7 +2019,7 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToAvailable(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2066,7 +2067,7 @@ func TestUpdateAnimal_ApprovalClearedOnTransitionToFoster(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	UpdateAnimal(db, nil)(c)
+	UpdateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2101,7 +2102,7 @@ func TestCreateAnimal_DefaultApprovalStatusWhenOmitted(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	CreateAnimal(db, nil)(c)
+	CreateAnimal(db, nil, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
@@ -2140,7 +2141,7 @@ func TestCreateAnimal_BiteQuarantine_DefaultEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -2186,7 +2187,7 @@ func TestCreateAnimal_BiteQuarantine_ExplicitEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusCreated {
@@ -2231,7 +2232,7 @@ func TestCreateAnimal_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
 	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := CreateAnimal(db, nil)
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -2264,7 +2265,7 @@ func TestUpdateAnimal_BiteQuarantine_DefaultEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2314,7 +2315,7 @@ func TestUpdateAnimal_BiteQuarantine_ExplicitEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2363,7 +2364,7 @@ func TestUpdateAnimal_BiteQuarantine_EndDateBeforeStartDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -2406,7 +2407,7 @@ func TestUpdateAnimal_EditEndDateOnly_WhileInQuarantine(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2460,7 +2461,7 @@ func TestUpdateAnimal_ChangeStartDate_RecomputesEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2508,7 +2509,7 @@ func TestUpdateAnimal_EditUnrelatedField_KeepsEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2554,7 +2555,7 @@ func TestUpdateAnimal_LeaveQuarantine_ClearsEndDate(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 
 	if w.Code != http.StatusOK {
@@ -2611,7 +2612,7 @@ func TestUpdateAnimal_LeaveQuarantine_EarlyExit_CapsEndDateAtNow(t *testing.T) {
 	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/groups/%d/animals/%d", group.ID, animal.ID), bytes.NewBuffer(jsonData))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	handler := UpdateAnimal(db, nil)
+	handler := UpdateAnimal(db, nil, &embedding.StubEmbedder{})
 	handler(c)
 	afterRequest := time.Now()
 

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -31,6 +31,12 @@ type commentSearchResult struct {
 	Rank       float64 `json:"rank"`
 }
 
+// updateSearchResult is a group update match with its relevance rank.
+type updateSearchResult struct {
+	models.Update
+	Rank float64 `json:"rank"`
+}
+
 // Search performs hybrid keyword + semantic search over a group's animals
 // and comments. Keyword matching uses Postgres full-text search
 // (tsvector/websearch_to_tsquery, unchanged from the original keyword-search
@@ -61,8 +67,9 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 		}
 
 		searchType := c.DefaultQuery("type", "all")
-		if searchType != "all" && searchType != "animals" && searchType != "comments" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "type must be one of: all, animals, comments"})
+		validTypes := map[string]bool{"all": true, "animals": true, "comments": true, "updates": true}
+		if !validTypes[searchType] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "type must be one of: all, animals, comments, updates"})
 			return
 		}
 
@@ -181,6 +188,43 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			response["total_comments"] = totalComments
 		}
 
+		if searchType == "all" || searchType == "updates" {
+			var totalUpdates int64
+			if err := db.Model(&models.Update{}).
+				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+				Count(&totalUpdates).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count matching updates"})
+				return
+			}
+
+			var keywordUpdateRows []updateSearchResult
+			if err := db.Model(&models.Update{}).
+				Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+				Order("rank DESC").
+				Limit(pool).
+				Find(&keywordUpdateRows).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})
+				return
+			}
+
+			var semanticUpdateRows []updateSearchResult
+			if semanticAvailable {
+				if err := db.Model(&models.Update{}).
+					Select("updates.*, 0::float8 AS rank").
+					Where("group_id = ? AND embedding IS NOT NULL", groupID).
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}}).
+					Limit(pool).
+					Find(&semanticUpdateRows).Error; err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search updates"})
+					return
+				}
+			}
+
+			response["updates"] = fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
+			response["total_updates"] = totalUpdates
+		}
+
 		c.JSON(http.StatusOK, response)
 	}
 }
@@ -237,6 +281,34 @@ func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit i
 	page := paginateIDs(ordered, offset, limit)
 
 	result := make([]commentSearchResult, 0, len(page))
+	for _, id := range page {
+		row := rows[id]
+		row.Rank = scores[id]
+		result = append(result, row)
+	}
+	return result
+}
+
+// fuseUpdateResults mirrors fuseAnimalResults for updateSearchResult.
+func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int) []updateSearchResult {
+	rows := make(map[uint]updateSearchResult, len(keyword)+len(semantic))
+	keywordIDs := make([]uint, len(keyword))
+	for i, r := range keyword {
+		keywordIDs[i] = r.ID
+		rows[r.ID] = r
+	}
+	semanticIDs := make([]uint, len(semantic))
+	for i, r := range semantic {
+		semanticIDs[i] = r.ID
+		if _, ok := rows[r.ID]; !ok {
+			rows[r.ID] = r
+		}
+	}
+
+	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
+	page := paginateIDs(ordered, offset, limit)
+
+	result := make([]updateSearchResult, 0, len(page))
 	for _, id := range page {
 		row := rows[id]
 		row.Rank = scores[id]

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -148,7 +148,13 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				semanticQuery := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}})
+					// A tie-breaker on id is required for the same reason as
+					// the keyword query's: ties in vector distance (e.g.
+					// identical/empty embeddings) can otherwise return in a
+					// different order between requests, causing duplicate or
+					// skipped rows across pagination and shifting RRF's
+					// rank-position-based scores.
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?, animals.id ASC", Vars: []interface{}{queryVector}}})
 
 				// See cappedTotal's doc comment: totalAnimals alone (a
 				// keyword-only Count()) would undercount once semantic-only
@@ -202,7 +208,8 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				semanticQuery := models.NonDeletedAnimalCommentsQuery(db).
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
 					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL", groupID).
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}})
+					// See the animals query above for why a tie-breaker on id is required.
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?, animal_comments.id ASC", Vars: []interface{}{queryVector}}})
 
 				comments, total, err := finishSemanticSearch("comments", keywordRows, buildCommentsKeywordQuery, semanticQuery, pool, fuseCommentResults, totalComments, offset, limit)
 				if err != nil {
@@ -246,7 +253,8 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				semanticQuery := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}})
+					// See the animals query above for why a tie-breaker on id is required.
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?, updates.id ASC", Vars: []interface{}{queryVector}}})
 
 				updates, total, err := finishSemanticSearch("updates", keywordUpdateRows, buildUpdatesKeywordQuery, semanticQuery, pool, fuseUpdateResults, totalUpdates, offset, limit)
 				if err != nil {

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -119,15 +119,22 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordAnimalsQuery := applyPageOrPool(db.Model(&models.Animal{}).
-				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				// A tie-breaker on id is required, not cosmetic: ts_rank ties
-				// are common, and without a deterministic secondary sort key,
-				// Postgres can return tied rows in a different order between
-				// the plain page and any later "load more" page, producing
-				// duplicate or skipped rows across pagination.
-				Order("rank DESC, animals.id ASC"), semanticAvailable, pool, limit, offset)
+			// Built as a closure so it can be re-run for a real
+			// Limit(limit).Offset(offset) page if the semantic query fails
+			// after semanticAvailable was already determined true (see
+			// finishSemanticSearch) — not just for the initial pool fetch.
+			buildAnimalsKeywordQuery := func() *gorm.DB {
+				return db.Model(&models.Animal{}).
+					Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+					Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+					// A tie-breaker on id is required, not cosmetic: ts_rank ties
+					// are common, and without a deterministic secondary sort key,
+					// Postgres can return tied rows in a different order between
+					// the plain page and any later "load more" page, producing
+					// duplicate or skipped rows across pagination.
+					Order("rank DESC, animals.id ASC")
+			}
+			keywordAnimalsQuery := applyPageOrPool(buildAnimalsKeywordQuery(), semanticAvailable, pool, limit, offset)
 			var keywordRows []animalSearchResult
 			if err := keywordAnimalsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
@@ -147,7 +154,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				// keyword-only Count()) would undercount once semantic-only
 				// matches are in the results, and an uncapped total would let
 				// "Load more" promise results pagination can never reach.
-				animals, total := finishSemanticSearch("animals", keywordRows, semanticQuery, pool, fuseAnimalResults, totalAnimals, offset, limit)
+				animals, total, err := finishSemanticSearch("animals", keywordRows, buildAnimalsKeywordQuery, semanticQuery, pool, fuseAnimalResults, totalAnimals, offset, limit)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
+					return
+				}
 				response["animals"] = animals
 				response["total_animals"] = total
 			}
@@ -169,10 +180,15 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordCommentsQuery := applyPageOrPool(keywordBase.Session(&gorm.Session{}).
-				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				// See the animals query above for why a tie-breaker on id is required.
-				Order("rank DESC, animal_comments.id ASC"), semanticAvailable, pool, limit, offset)
+			// See buildAnimalsKeywordQuery above for why this is a closure
+			// (reused for the semantic-failure keyword-only re-page too).
+			buildCommentsKeywordQuery := func() *gorm.DB {
+				return keywordBase.Session(&gorm.Session{}).
+					Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+					// See the animals query above for why a tie-breaker on id is required.
+					Order("rank DESC, animal_comments.id ASC")
+			}
+			keywordCommentsQuery := applyPageOrPool(buildCommentsKeywordQuery(), semanticAvailable, pool, limit, offset)
 			var keywordRows []commentSearchResult
 			if err := keywordCommentsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
@@ -188,7 +204,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL", groupID).
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}})
 
-				comments, total := finishSemanticSearch("comments", keywordRows, semanticQuery, pool, fuseCommentResults, totalComments, offset, limit)
+				comments, total, err := finishSemanticSearch("comments", keywordRows, buildCommentsKeywordQuery, semanticQuery, pool, fuseCommentResults, totalComments, offset, limit)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
+					return
+				}
 				response["comments"] = comments
 				response["total_comments"] = total
 			}
@@ -203,11 +223,16 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordUpdatesQuery := applyPageOrPool(db.Model(&models.Update{}).
-				Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				// See the animals query above for why a tie-breaker on id is required.
-				Order("rank DESC, updates.id ASC"), semanticAvailable, pool, limit, offset)
+			// See buildAnimalsKeywordQuery above for why this is a closure
+			// (reused for the semantic-failure keyword-only re-page too).
+			buildUpdatesKeywordQuery := func() *gorm.DB {
+				return db.Model(&models.Update{}).
+					Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+					Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+					// See the animals query above for why a tie-breaker on id is required.
+					Order("rank DESC, updates.id ASC")
+			}
+			keywordUpdatesQuery := applyPageOrPool(buildUpdatesKeywordQuery(), semanticAvailable, pool, limit, offset)
 			var keywordUpdateRows []updateSearchResult
 			if err := keywordUpdatesQuery.Find(&keywordUpdateRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})
@@ -223,7 +248,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}})
 
-				updates, total := finishSemanticSearch("updates", keywordUpdateRows, semanticQuery, pool, fuseUpdateResults, totalUpdates, offset, limit)
+				updates, total, err := finishSemanticSearch("updates", keywordUpdateRows, buildUpdatesKeywordQuery, semanticQuery, pool, fuseUpdateResults, totalUpdates, offset, limit)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})
+					return
+				}
 				response["updates"] = updates
 				response["total_updates"] = total
 			}
@@ -303,20 +332,33 @@ func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int
 // semantic query and fuse function differ), so it's factored out here
 // rather than kept as three copies that could drift out of sync — e.g. a
 // fix to the degrade-on-error behavior only needs to be made once.
-func finishSemanticSearch[T any](resourceName string, keywordRows []T, semanticQuery *gorm.DB, pool int, fuse func(keyword, semantic []T, offset, limit int) ([]T, int), keywordCount int64, offset, limit int) ([]T, int64) {
+func finishSemanticSearch[T any](resourceName string, keywordRows []T, rebuildKeywordPage func() *gorm.DB, semanticQuery *gorm.DB, pool int, fuse func(keyword, semantic []T, offset, limit int) ([]T, int), keywordCount int64, offset, limit int) ([]T, int64, error) {
 	var semanticRows []T
 	if err := semanticQuery.Limit(pool).Find(&semanticRows).Error; err != nil {
 		// Semantic search is a ranking enhancement, never a hard dependency
 		// (see Search's doc comment): degrade to keyword-only ranking
-		// instead of discarding the keyword results already in hand. fuse
-		// with a nil semantic list preserves keywordRows' order, and
-		// cappedTotal still applies its usual pool-aware capping.
+		// instead of discarding the keyword results already in hand.
+		//
+		// keywordRows, though, was fetched via applyPageOrPool with
+		// Limit(pool) and no Offset — sized as an RRF candidate pool, not a
+		// real page. Once semantic fusion is off the table (this branch),
+		// fusing that pool-limited, offset-0 slice against the client's
+		// actual offset/limit would silently return wrong or empty results
+		// past the pool boundary (deep pagination broken). Re-run the
+		// keyword query as a real Limit(limit).Offset(offset) page instead
+		// of reusing the pool-shaped one.
 		logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to semantically search %s; degrading to keyword-only results", resourceName))
-		semanticRows = nil
+
+		var page []T
+		if err := rebuildKeywordPage().Limit(limit).Offset(offset).Find(&page).Error; err != nil {
+			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to re-query %s keyword-only after semantic failure", resourceName))
+			return nil, 0, err
+		}
+		return page, keywordCount, nil
 	}
 
 	rows, fusedTotal := fuse(keywordRows, semanticRows, offset, limit)
-	return rows, cappedTotal(keywordCount, fusedTotal)
+	return rows, cappedTotal(keywordCount, fusedTotal), nil
 }
 
 // applyPageOrPool applies either the client's exact requested page

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -118,23 +118,10 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordAnimalsQuery := db.Model(&models.Animal{}).
+			keywordAnimalsQuery := applyPageOrPool(db.Model(&models.Animal{}).
 				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC")
-			if semanticAvailable {
-				// A candidate pool (not the client's exact page) is needed so
-				// fusion has a real keyword-ranked list to merge with the
-				// semantic one before slicing to the requested page.
-				keywordAnimalsQuery = keywordAnimalsQuery.Limit(pool)
-			} else {
-				// No semantic signal for this request: fetch exactly the
-				// requested page directly from Postgres, exactly as the
-				// original keyword-only feature did — unlimited-depth
-				// pagination, no RRF fusion overhead, and the row's real
-				// ts_rank is preserved as-is below.
-				keywordAnimalsQuery = keywordAnimalsQuery.Limit(limit).Offset(offset)
-			}
+				Order("rank DESC"), semanticAvailable, pool, limit, offset)
 			var keywordRows []animalSearchResult
 			if err := keywordAnimalsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
@@ -158,23 +145,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 
 				animals, fusedAnimalTotal := fuseAnimalResults(keywordRows, semanticRows, offset, limit)
 				response["animals"] = animals
-				// totalAnimals alone undercounts once semantic search is enabled: it's a
-				// keyword-only Count(), but the returned page also includes semantic-only
-				// matches (no shared vocabulary with the query). Without this max(), a
-				// semantic-only match would appear in the results yet total_animals could
-				// read 0, and the frontend's canLoadMore (animals.length < totalAnimals)
-				// would then never fire — hiding any further semantic-only matches beyond
-				// this page. fusedAnimalTotal (bounded by the candidate pool, same as the
-				// results themselves) covers that gap; the keyword Count() still covers
-				// the rare case where keyword matches alone exceed the pool. The result is
-				// then capped at maxCandidatePool: candidatePoolSize never fetches beyond
-				// that ceiling, so reporting a total higher than it would let "Load more"
-				// promise results pagination can never actually deliver.
-				total := max(totalAnimals, int64(fusedAnimalTotal))
-				if total > int64(maxCandidatePool) {
-					total = int64(maxCandidatePool)
-				}
-				response["total_animals"] = total
+				// See cappedTotal's doc comment: totalAnimals alone (a
+				// keyword-only Count()) would undercount once semantic-only
+				// matches are in the results, and an uncapped total would let
+				// "Load more" promise results pagination can never reach.
+				response["total_animals"] = cappedTotal(totalAnimals, fusedAnimalTotal)
 			}
 		}
 
@@ -194,14 +169,9 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordCommentsQuery := keywordBase.Session(&gorm.Session{}).
+			keywordCommentsQuery := applyPageOrPool(keywordBase.Session(&gorm.Session{}).
 				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				Order("rank DESC")
-			if semanticAvailable {
-				keywordCommentsQuery = keywordCommentsQuery.Limit(pool)
-			} else {
-				keywordCommentsQuery = keywordCommentsQuery.Limit(limit).Offset(offset)
-			}
+				Order("rank DESC"), semanticAvailable, pool, limit, offset)
 			var keywordRows []commentSearchResult
 			if err := keywordCommentsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
@@ -228,14 +198,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 
 				comments, fusedCommentTotal := fuseCommentResults(keywordRows, semanticRows, offset, limit)
 				response["comments"] = comments
-				// See the matching comment on total_animals above: a keyword-only Count()
-				// undercounts once semantic-only matches are in the results, and the
-				// result is capped at maxCandidatePool for the same reachability reason.
-				total := max(totalComments, int64(fusedCommentTotal))
-				if total > int64(maxCandidatePool) {
-					total = int64(maxCandidatePool)
-				}
-				response["total_comments"] = total
+				response["total_comments"] = cappedTotal(totalComments, fusedCommentTotal)
 			}
 		}
 
@@ -248,15 +211,10 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			keywordUpdatesQuery := db.Model(&models.Update{}).
+			keywordUpdatesQuery := applyPageOrPool(db.Model(&models.Update{}).
 				Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC")
-			if semanticAvailable {
-				keywordUpdatesQuery = keywordUpdatesQuery.Limit(pool)
-			} else {
-				keywordUpdatesQuery = keywordUpdatesQuery.Limit(limit).Offset(offset)
-			}
+				Order("rank DESC"), semanticAvailable, pool, limit, offset)
 			var keywordUpdateRows []updateSearchResult
 			if err := keywordUpdatesQuery.Find(&keywordUpdateRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})
@@ -280,14 +238,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 
 				updates, fusedUpdateTotal := fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
 				response["updates"] = updates
-				// See the matching comment on total_animals above: a keyword-only Count()
-				// undercounts once semantic-only matches are in the results, and the
-				// result is capped at maxCandidatePool for the same reachability reason.
-				total := max(totalUpdates, int64(fusedUpdateTotal))
-				if total > int64(maxCandidatePool) {
-					total = int64(maxCandidatePool)
-				}
-				response["total_updates"] = total
+				response["total_updates"] = cappedTotal(totalUpdates, fusedUpdateTotal)
 			}
 		}
 
@@ -295,94 +246,91 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	}
 }
 
-// fuseAnimalResults merges keyword and semantic animal matches via
+// fuseResults is the shared core of fuseAnimalResults/fuseCommentResults/
+// fuseUpdateResults: merges keyword and semantic matches of any row type via
 // Reciprocal Rank Fusion and returns the requested page, plus the size of
-// the full fused candidate set (before pagination) — the caller uses this
-// to correct total_animals for semantic-only matches a keyword-only Count()
-// would miss. A row present in both lists is deduplicated (its full data is
-// taken from whichever list is checked first — identical either way, since
-// it's the same database row); only its combined score changes.
+// the full fused candidate set (before pagination) — callers use this to
+// correct total_* for semantic-only matches a keyword-only Count() would
+// miss. A row present in both lists is deduplicated (its full data is taken
+// from whichever list is checked first — identical either way, since it's
+// the same database row); only its combined score changes.
+func fuseResults[T any](keyword, semantic []T, getID func(T) uint, setRank func(*T, float64), offset, limit int) ([]T, int) {
+	rows := make(map[uint]T, len(keyword)+len(semantic))
+	keywordIDs := make([]uint, len(keyword))
+	for i, r := range keyword {
+		id := getID(r)
+		keywordIDs[i] = id
+		rows[id] = r
+	}
+	semanticIDs := make([]uint, len(semantic))
+	for i, r := range semantic {
+		id := getID(r)
+		semanticIDs[i] = id
+		if _, ok := rows[id]; !ok {
+			rows[id] = r
+		}
+	}
+
+	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
+	page := paginateIDs(ordered, offset, limit)
+
+	result := make([]T, 0, len(page))
+	for _, id := range page {
+		row := rows[id]
+		setRank(&row, scores[id])
+		result = append(result, row)
+	}
+	return result, len(ordered)
+}
+
 func fuseAnimalResults(keyword, semantic []animalSearchResult, offset, limit int) ([]animalSearchResult, int) {
-	rows := make(map[uint]animalSearchResult, len(keyword)+len(semantic))
-	keywordIDs := make([]uint, len(keyword))
-	for i, r := range keyword {
-		keywordIDs[i] = r.ID
-		rows[r.ID] = r
-	}
-	semanticIDs := make([]uint, len(semantic))
-	for i, r := range semantic {
-		semanticIDs[i] = r.ID
-		if _, ok := rows[r.ID]; !ok {
-			rows[r.ID] = r
-		}
-	}
-
-	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
-	page := paginateIDs(ordered, offset, limit)
-
-	result := make([]animalSearchResult, 0, len(page))
-	for _, id := range page {
-		row := rows[id]
-		row.Rank = scores[id]
-		result = append(result, row)
-	}
-	return result, len(ordered)
+	return fuseResults(keyword, semantic,
+		func(r animalSearchResult) uint { return r.ID },
+		func(r *animalSearchResult, rank float64) { r.Rank = rank },
+		offset, limit,
+	)
 }
 
-// fuseCommentResults mirrors fuseAnimalResults for commentSearchResult.
 func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit int) ([]commentSearchResult, int) {
-	rows := make(map[uint]commentSearchResult, len(keyword)+len(semantic))
-	keywordIDs := make([]uint, len(keyword))
-	for i, r := range keyword {
-		keywordIDs[i] = r.ID
-		rows[r.ID] = r
-	}
-	semanticIDs := make([]uint, len(semantic))
-	for i, r := range semantic {
-		semanticIDs[i] = r.ID
-		if _, ok := rows[r.ID]; !ok {
-			rows[r.ID] = r
-		}
-	}
-
-	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
-	page := paginateIDs(ordered, offset, limit)
-
-	result := make([]commentSearchResult, 0, len(page))
-	for _, id := range page {
-		row := rows[id]
-		row.Rank = scores[id]
-		result = append(result, row)
-	}
-	return result, len(ordered)
+	return fuseResults(keyword, semantic,
+		func(r commentSearchResult) uint { return r.ID },
+		func(r *commentSearchResult, rank float64) { r.Rank = rank },
+		offset, limit,
+	)
 }
 
-// fuseUpdateResults mirrors fuseAnimalResults for updateSearchResult.
 func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int) ([]updateSearchResult, int) {
-	rows := make(map[uint]updateSearchResult, len(keyword)+len(semantic))
-	keywordIDs := make([]uint, len(keyword))
-	for i, r := range keyword {
-		keywordIDs[i] = r.ID
-		rows[r.ID] = r
-	}
-	semanticIDs := make([]uint, len(semantic))
-	for i, r := range semantic {
-		semanticIDs[i] = r.ID
-		if _, ok := rows[r.ID]; !ok {
-			rows[r.ID] = r
-		}
-	}
+	return fuseResults(keyword, semantic,
+		func(r updateSearchResult) uint { return r.ID },
+		func(r *updateSearchResult, rank float64) { r.Rank = rank },
+		offset, limit,
+	)
+}
 
-	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
-	page := paginateIDs(ordered, offset, limit)
-
-	result := make([]updateSearchResult, 0, len(page))
-	for _, id := range page {
-		row := rows[id]
-		row.Rank = scores[id]
-		result = append(result, row)
+// applyPageOrPool applies either the client's exact requested page
+// (Limit(limit).Offset(offset)) when semantic search isn't available for
+// this request, or a wider candidate pool (Limit(pool)) when it is — RRF
+// fusion needs a real keyword-ranked candidate list to merge with the
+// semantic one before the actual page is sliced out afterward.
+func applyPageOrPool(q *gorm.DB, semanticAvailable bool, pool, limit, offset int) *gorm.DB {
+	if semanticAvailable {
+		return q.Limit(pool)
 	}
-	return result, len(ordered)
+	return q.Limit(limit).Offset(offset)
+}
+
+// cappedTotal folds a keyword-only Count() together with the fused
+// candidate set's size, so total_* reflects semantic-only matches a
+// keyword-only Count() would miss, then caps the result at
+// maxCandidatePool since candidatePoolSize never fetches beyond that
+// ceiling — reporting a higher total would let "Load more" promise results
+// pagination can never actually deliver.
+func cappedTotal(keywordCount int64, fusedTotal int) int64 {
+	total := max(keywordCount, int64(fusedTotal))
+	if total > int64(maxCandidatePool) {
+		total = int64(maxCandidatePool)
+	}
+	return total
 }
 
 // paginateIDs slices a fused ID order to the client's requested page,

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -132,37 +133,31 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				response["animals"] = keywordRows
 				response["total_animals"] = totalAnimals
 			} else {
-				var semanticRows []animalSearchResult
-				if err := db.Model(&models.Animal{}).
+				semanticQuery := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}}).
-					Limit(pool).
-					Find(&semanticRows).Error; err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search animals"})
-					return
-				}
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}})
 
-				animals, fusedAnimalTotal := fuseAnimalResults(keywordRows, semanticRows, offset, limit)
-				response["animals"] = animals
 				// See cappedTotal's doc comment: totalAnimals alone (a
 				// keyword-only Count()) would undercount once semantic-only
 				// matches are in the results, and an uncapped total would let
 				// "Load more" promise results pagination can never reach.
-				response["total_animals"] = cappedTotal(totalAnimals, fusedAnimalTotal)
+				animals, total := finishSemanticSearch("animals", keywordRows, semanticQuery, pool, fuseAnimalResults, totalAnimals, offset, limit)
+				response["animals"] = animals
+				response["total_animals"] = total
 			}
 		}
 
 		if searchType == "all" || searchType == "comments" {
 			var totalComments int64
 
-			// GORM's soft-delete scope only auto-applies to the query's primary
-			// model (animal_comments) — the joined animals table needs an
-			// explicit deleted_at check, or comments on a deleted animal leak
-			// through search.
-			keywordBase := db.Model(&models.AnimalComment{}).
-				Joins("JOIN animals ON animals.id = animal_comments.animal_id").
-				Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
+			// models.NonDeletedAnimalCommentsQuery joins animals and excludes
+			// soft-deleted ones — GORM's soft-delete scope only auto-applies to
+			// the query's primary model (animal_comments), and this condition is
+			// shared with internal/embedding/sweep.go's sweepComments so the two
+			// call sites can't drift out of sync.
+			keywordBase := models.NonDeletedAnimalCommentsQuery(db).
+				Where("animals.group_id = ? AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
 
 			if err := keywordBase.Session(&gorm.Session{}).Count(&totalComments).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count matching comments"})
@@ -182,23 +177,14 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				response["comments"] = keywordRows
 				response["total_comments"] = totalComments
 			} else {
-				semanticBase := db.Model(&models.AnimalComment{}).
-					Joins("JOIN animals ON animals.id = animal_comments.animal_id").
-					Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.embedding IS NOT NULL", groupID)
-
-				var semanticRows []commentSearchResult
-				if err := semanticBase.
+				semanticQuery := models.NonDeletedAnimalCommentsQuery(db).
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}}).
-					Limit(pool).
-					Find(&semanticRows).Error; err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search comments"})
-					return
-				}
+					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL", groupID).
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}})
 
-				comments, fusedCommentTotal := fuseCommentResults(keywordRows, semanticRows, offset, limit)
+				comments, total := finishSemanticSearch("comments", keywordRows, semanticQuery, pool, fuseCommentResults, totalComments, offset, limit)
 				response["comments"] = comments
-				response["total_comments"] = cappedTotal(totalComments, fusedCommentTotal)
+				response["total_comments"] = total
 			}
 		}
 
@@ -225,20 +211,14 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				response["updates"] = keywordUpdateRows
 				response["total_updates"] = totalUpdates
 			} else {
-				var semanticUpdateRows []updateSearchResult
-				if err := db.Model(&models.Update{}).
+				semanticQuery := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
-					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}}).
-					Limit(pool).
-					Find(&semanticUpdateRows).Error; err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search updates"})
-					return
-				}
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}})
 
-				updates, fusedUpdateTotal := fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
+				updates, total := finishSemanticSearch("updates", keywordUpdateRows, semanticQuery, pool, fuseUpdateResults, totalUpdates, offset, limit)
 				response["updates"] = updates
-				response["total_updates"] = cappedTotal(totalUpdates, fusedUpdateTotal)
+				response["total_updates"] = total
 			}
 		}
 
@@ -307,6 +287,31 @@ func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int
 	)
 }
 
+// finishSemanticSearch runs the shared tail of every resource type's
+// semantic-search branch in Search: query the vector index (bounded by
+// pool), degrade to keyword-only on failure, fuse with the already-fetched
+// keyword rows via Reciprocal Rank Fusion, and compute the corrected total.
+// This is the one piece of animals/comments/updates' otherwise-parallel
+// search blocks that was purely mechanical (identical shape, only the
+// semantic query and fuse function differ), so it's factored out here
+// rather than kept as three copies that could drift out of sync — e.g. a
+// fix to the degrade-on-error behavior only needs to be made once.
+func finishSemanticSearch[T any](resourceName string, keywordRows []T, semanticQuery *gorm.DB, pool int, fuse func(keyword, semantic []T, offset, limit int) ([]T, int), keywordCount int64, offset, limit int) ([]T, int64) {
+	var semanticRows []T
+	if err := semanticQuery.Limit(pool).Find(&semanticRows).Error; err != nil {
+		// Semantic search is a ranking enhancement, never a hard dependency
+		// (see Search's doc comment): degrade to keyword-only ranking
+		// instead of discarding the keyword results already in hand. fuse
+		// with a nil semantic list preserves keywordRows' order, and
+		// cappedTotal still applies its usual pool-aware capping.
+		logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to semantically search %s; degrading to keyword-only results", resourceName))
+		semanticRows = nil
+	}
+
+	rows, fusedTotal := fuse(keywordRows, semanticRows, offset, limit)
+	return rows, cappedTotal(keywordCount, fusedTotal)
+}
+
 // applyPageOrPool applies either the client's exact requested page
 // (Limit(limit).Offset(offset)) when semantic search isn't available for
 // this request, or a wider candidate pool (Limit(pool)) when it is — RRF
@@ -329,7 +334,12 @@ func applyPageOrPool(q *gorm.DB, semanticAvailable bool, pool, limit, offset int
 // and semantic queries can independently return up to `pool` rows, so a
 // largely non-overlapping pair of top-`pool` lists can fuse into a set
 // bigger than pool itself; capping it here would hide real, reachable
-// results behind "Load more" for no reason).
+// results behind "Load more" for no reason). This holds even when fusedTotal
+// is smaller than keywordCount but still exceeds maxCandidatePool: e.g.
+// keywordCount=1000 (many keyword matches overall) and fusedTotal=550 (the
+// actual fetchable fused set once a common query saturates both pools) must
+// report 550, not the 500 keywordCount alone would clamp to — the fused set
+// is exactly what's reachable.
 //
 // keywordCount, on the other hand, is an uncapped full-table Count() that
 // can vastly exceed what a bounded candidate pool will ever fetch — only
@@ -337,13 +347,7 @@ func applyPageOrPool(q *gorm.DB, semanticAvailable bool, pool, limit, offset int
 // a total driven by keywordCount alone would let "Load more" promise depth
 // pagination can never actually reach.
 func cappedTotal(keywordCount int64, fusedTotal int) int64 {
-	if int64(fusedTotal) >= keywordCount {
-		return int64(fusedTotal)
-	}
-	if keywordCount > int64(maxCandidatePool) {
-		return int64(maxCandidatePool)
-	}
-	return keywordCount
+	return max(int64(fusedTotal), min(keywordCount, int64(maxCandidatePool)))
 }
 
 // paginateIDs slices a fused ID order to the client's requested page,

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -37,17 +37,21 @@ type updateSearchResult struct {
 	Rank float64 `json:"rank"`
 }
 
-// Search performs hybrid keyword + semantic search over a group's animals
-// and comments. Keyword matching uses Postgres full-text search
+// Search performs hybrid keyword + semantic search over a group's animals,
+// comments, and updates. Keyword matching uses Postgres full-text search
 // (tsvector/websearch_to_tsquery, unchanged from the original keyword-search
 // feature); semantic matching uses pgvector cosine similarity against
 // embeddings populated by internal/embedding's write-path goroutine and
-// reconciliation sweep. The two ranked candidate lists are merged via
-// Reciprocal Rank Fusion (see search_rank.go) before the client's
-// limit/offset is applied. Semantic search is a ranking enhancement, never a
-// hard dependency: if SEMANTIC_SEARCH_ENABLED is off, the query-embedding
-// call fails, or a row has no embedding yet, results degrade to keyword-only
-// ranking rather than failing the request.
+// reconciliation sweep. When semantic search is available for this request,
+// the two ranked candidate lists are merged via Reciprocal Rank Fusion (see
+// search_rank.go) before the client's limit/offset is applied; when it
+// isn't, each resource is queried and paginated directly by Postgres exactly
+// as the original keyword-only feature did, preserving real ts_rank values
+// and unlimited-depth pagination. Semantic search is a ranking enhancement,
+// never a hard dependency: if SEMANTIC_SEARCH_ENABLED is off, the embedder
+// isn't configured, the query-embedding call fails, or a row has no
+// embedding yet, results degrade to keyword-only ranking rather than
+// failing the request.
 func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := middleware.GetDB(c, db)
@@ -94,7 +98,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 
 		var queryVector pgvector.Vector
 		semanticAvailable := false
-		if embedding.SemanticSearchEnabled() {
+		if embedding.Usable(embedder) {
 			if vec, err := embedder.EmbedQuery(c.Request.Context(), query); err == nil {
 				queryVector = pgvector.NewVector(vec)
 				semanticAvailable = true
@@ -114,19 +118,34 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			var keywordRows []animalSearchResult
-			if err := db.Model(&models.Animal{}).
+			keywordAnimalsQuery := db.Model(&models.Animal{}).
 				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC").
-				Limit(pool).
-				Find(&keywordRows).Error; err != nil {
+				Order("rank DESC")
+			if semanticAvailable {
+				// A candidate pool (not the client's exact page) is needed so
+				// fusion has a real keyword-ranked list to merge with the
+				// semantic one before slicing to the requested page.
+				keywordAnimalsQuery = keywordAnimalsQuery.Limit(pool)
+			} else {
+				// No semantic signal for this request: fetch exactly the
+				// requested page directly from Postgres, exactly as the
+				// original keyword-only feature did — unlimited-depth
+				// pagination, no RRF fusion overhead, and the row's real
+				// ts_rank is preserved as-is below.
+				keywordAnimalsQuery = keywordAnimalsQuery.Limit(limit).Offset(offset)
+			}
+			var keywordRows []animalSearchResult
+			if err := keywordAnimalsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
 				return
 			}
 
-			var semanticRows []animalSearchResult
-			if semanticAvailable {
+			if !semanticAvailable {
+				response["animals"] = keywordRows
+				response["total_animals"] = totalAnimals
+			} else {
+				var semanticRows []animalSearchResult
 				if err := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
@@ -136,20 +155,27 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search animals"})
 					return
 				}
-			}
 
-			animals, fusedAnimalTotal := fuseAnimalResults(keywordRows, semanticRows, offset, limit)
-			response["animals"] = animals
-			// totalAnimals alone undercounts once semantic search is enabled: it's a
-			// keyword-only Count(), but the returned page also includes semantic-only
-			// matches (no shared vocabulary with the query). Without this max(), a
-			// semantic-only match would appear in the results yet total_animals could
-			// read 0, and the frontend's canLoadMore (animals.length < totalAnimals)
-			// would then never fire — hiding any further semantic-only matches beyond
-			// this page. fusedAnimalTotal (bounded by the candidate pool, same as the
-			// results themselves) covers that gap; the keyword Count() still covers
-			// the rare case where keyword matches alone exceed the pool.
-			response["total_animals"] = max(totalAnimals, int64(fusedAnimalTotal))
+				animals, fusedAnimalTotal := fuseAnimalResults(keywordRows, semanticRows, offset, limit)
+				response["animals"] = animals
+				// totalAnimals alone undercounts once semantic search is enabled: it's a
+				// keyword-only Count(), but the returned page also includes semantic-only
+				// matches (no shared vocabulary with the query). Without this max(), a
+				// semantic-only match would appear in the results yet total_animals could
+				// read 0, and the frontend's canLoadMore (animals.length < totalAnimals)
+				// would then never fire — hiding any further semantic-only matches beyond
+				// this page. fusedAnimalTotal (bounded by the candidate pool, same as the
+				// results themselves) covers that gap; the keyword Count() still covers
+				// the rare case where keyword matches alone exceed the pool. The result is
+				// then capped at maxCandidatePool: candidatePoolSize never fetches beyond
+				// that ceiling, so reporting a total higher than it would let "Load more"
+				// promise results pagination can never actually deliver.
+				total := max(totalAnimals, int64(fusedAnimalTotal))
+				if total > int64(maxCandidatePool) {
+					total = int64(maxCandidatePool)
+				}
+				response["total_animals"] = total
+			}
 		}
 
 		if searchType == "all" || searchType == "comments" {
@@ -168,22 +194,29 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			var keywordRows []commentSearchResult
-			if err := keywordBase.Session(&gorm.Session{}).
+			keywordCommentsQuery := keywordBase.Session(&gorm.Session{}).
 				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				Order("rank DESC").
-				Limit(pool).
-				Find(&keywordRows).Error; err != nil {
+				Order("rank DESC")
+			if semanticAvailable {
+				keywordCommentsQuery = keywordCommentsQuery.Limit(pool)
+			} else {
+				keywordCommentsQuery = keywordCommentsQuery.Limit(limit).Offset(offset)
+			}
+			var keywordRows []commentSearchResult
+			if err := keywordCommentsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
 				return
 			}
 
-			var semanticRows []commentSearchResult
-			if semanticAvailable {
+			if !semanticAvailable {
+				response["comments"] = keywordRows
+				response["total_comments"] = totalComments
+			} else {
 				semanticBase := db.Model(&models.AnimalComment{}).
 					Joins("JOIN animals ON animals.id = animal_comments.animal_id").
 					Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.embedding IS NOT NULL", groupID)
 
+				var semanticRows []commentSearchResult
 				if err := semanticBase.
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}}).
@@ -192,13 +225,18 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search comments"})
 					return
 				}
-			}
 
-			comments, fusedCommentTotal := fuseCommentResults(keywordRows, semanticRows, offset, limit)
-			response["comments"] = comments
-			// See the matching comment on total_animals above: a keyword-only Count()
-			// undercounts once semantic-only matches are in the results.
-			response["total_comments"] = max(totalComments, int64(fusedCommentTotal))
+				comments, fusedCommentTotal := fuseCommentResults(keywordRows, semanticRows, offset, limit)
+				response["comments"] = comments
+				// See the matching comment on total_animals above: a keyword-only Count()
+				// undercounts once semantic-only matches are in the results, and the
+				// result is capped at maxCandidatePool for the same reachability reason.
+				total := max(totalComments, int64(fusedCommentTotal))
+				if total > int64(maxCandidatePool) {
+					total = int64(maxCandidatePool)
+				}
+				response["total_comments"] = total
+			}
 		}
 
 		if searchType == "all" || searchType == "updates" {
@@ -210,19 +248,26 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				return
 			}
 
-			var keywordUpdateRows []updateSearchResult
-			if err := db.Model(&models.Update{}).
+			keywordUpdatesQuery := db.Model(&models.Update{}).
 				Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC").
-				Limit(pool).
-				Find(&keywordUpdateRows).Error; err != nil {
+				Order("rank DESC")
+			if semanticAvailable {
+				keywordUpdatesQuery = keywordUpdatesQuery.Limit(pool)
+			} else {
+				keywordUpdatesQuery = keywordUpdatesQuery.Limit(limit).Offset(offset)
+			}
+			var keywordUpdateRows []updateSearchResult
+			if err := keywordUpdatesQuery.Find(&keywordUpdateRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})
 				return
 			}
 
-			var semanticUpdateRows []updateSearchResult
-			if semanticAvailable {
+			if !semanticAvailable {
+				response["updates"] = keywordUpdateRows
+				response["total_updates"] = totalUpdates
+			} else {
+				var semanticUpdateRows []updateSearchResult
 				if err := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
 					Where("group_id = ? AND embedding IS NOT NULL", groupID).
@@ -232,13 +277,18 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search updates"})
 					return
 				}
-			}
 
-			updates, fusedUpdateTotal := fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
-			response["updates"] = updates
-			// See the matching comment on total_animals above: a keyword-only Count()
-			// undercounts once semantic-only matches are in the results.
-			response["total_updates"] = max(totalUpdates, int64(fusedUpdateTotal))
+				updates, fusedUpdateTotal := fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
+				response["updates"] = updates
+				// See the matching comment on total_animals above: a keyword-only Count()
+				// undercounts once semantic-only matches are in the results, and the
+				// result is capped at maxCandidatePool for the same reachability reason.
+				total := max(totalUpdates, int64(fusedUpdateTotal))
+				if total > int64(maxCandidatePool) {
+					total = int64(maxCandidatePool)
+				}
+				response["total_updates"] = total
+			}
 		}
 
 		c.JSON(http.StatusOK, response)

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -321,16 +321,29 @@ func applyPageOrPool(q *gorm.DB, semanticAvailable bool, pool, limit, offset int
 
 // cappedTotal folds a keyword-only Count() together with the fused
 // candidate set's size, so total_* reflects semantic-only matches a
-// keyword-only Count() would miss, then caps the result at
-// maxCandidatePool since candidatePoolSize never fetches beyond that
-// ceiling — reporting a higher total would let "Load more" promise results
-// pagination can never actually deliver.
+// keyword-only Count() would miss.
+//
+// fusedTotal is the size of the actual fused candidate set (fuseResults'
+// `ordered`) — exactly what paginateIDs can serve for this request, so it's
+// reported as-is even when it exceeds maxCandidatePool (each of the keyword
+// and semantic queries can independently return up to `pool` rows, so a
+// largely non-overlapping pair of top-`pool` lists can fuse into a set
+// bigger than pool itself; capping it here would hide real, reachable
+// results behind "Load more" for no reason).
+//
+// keywordCount, on the other hand, is an uncapped full-table Count() that
+// can vastly exceed what a bounded candidate pool will ever fetch — only
+// that side of the max() gets clamped to maxCandidatePool, since promising
+// a total driven by keywordCount alone would let "Load more" promise depth
+// pagination can never actually reach.
 func cappedTotal(keywordCount int64, fusedTotal int) int64 {
-	total := max(keywordCount, int64(fusedTotal))
-	if total > int64(maxCandidatePool) {
-		total = int64(maxCandidatePool)
+	if int64(fusedTotal) >= keywordCount {
+		return int64(fusedTotal)
 	}
-	return total
+	if keywordCount > int64(maxCandidatePool) {
+		return int64(maxCandidatePool)
+	}
+	return keywordCount
 }
 
 // paginateIDs slices a fused ID order to the client's requested page,

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -122,7 +122,12 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			keywordAnimalsQuery := applyPageOrPool(db.Model(&models.Animal{}).
 				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC"), semanticAvailable, pool, limit, offset)
+				// A tie-breaker on id is required, not cosmetic: ts_rank ties
+				// are common, and without a deterministic secondary sort key,
+				// Postgres can return tied rows in a different order between
+				// the plain page and any later "load more" page, producing
+				// duplicate or skipped rows across pagination.
+				Order("rank DESC, animals.id ASC"), semanticAvailable, pool, limit, offset)
 			var keywordRows []animalSearchResult
 			if err := keywordAnimalsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
@@ -166,7 +171,8 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 
 			keywordCommentsQuery := applyPageOrPool(keywordBase.Session(&gorm.Session{}).
 				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
-				Order("rank DESC"), semanticAvailable, pool, limit, offset)
+				// See the animals query above for why a tie-breaker on id is required.
+				Order("rank DESC, animal_comments.id ASC"), semanticAvailable, pool, limit, offset)
 			var keywordRows []commentSearchResult
 			if err := keywordCommentsQuery.Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
@@ -200,7 +206,8 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			keywordUpdatesQuery := applyPageOrPool(db.Model(&models.Update{}).
 				Select("updates.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Order("rank DESC"), semanticAvailable, pool, limit, offset)
+				// See the animals query above for why a tie-breaker on id is required.
+				Order("rank DESC, updates.id ASC"), semanticAvailable, pool, limit, offset)
 			var keywordUpdateRows []updateSearchResult
 			if err := keywordUpdatesQuery.Find(&keywordUpdateRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search updates"})

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -5,12 +5,18 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/pgvector/pgvector-go"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-// animalSearchResult is an animal match with its full-text relevance rank.
+// animalSearchResult is an animal match with its full-text/semantic
+// relevance rank (the Reciprocal Rank Fusion score once fused; see
+// fuseAnimalResults).
 type animalSearchResult struct {
 	models.Animal
 	Rank float64 `json:"rank"`
@@ -18,19 +24,25 @@ type animalSearchResult struct {
 
 // commentSearchResult is a comment match with its parent animal's name/id
 // (comments are meaningless out of the context of which animal they're on)
-// and its full-text relevance rank.
+// and its relevance rank.
 type commentSearchResult struct {
 	models.AnimalComment
 	AnimalName string  `json:"animal_name"`
 	Rank       float64 `json:"rank"`
 }
 
-// Search performs keyword/phrase search over a group's animals and comments
-// using Postgres full-text search (tsvector columns populated by generated
-// columns — see createCustomIndexes in internal/database/database.go).
-// Scoped to the requesting user's group access, matching every other
-// /groups/:id route in this file set.
-func Search(db *gorm.DB) gin.HandlerFunc {
+// Search performs hybrid keyword + semantic search over a group's animals
+// and comments. Keyword matching uses Postgres full-text search
+// (tsvector/websearch_to_tsquery, unchanged from the original keyword-search
+// feature); semantic matching uses pgvector cosine similarity against
+// embeddings populated by internal/embedding's write-path goroutine and
+// reconciliation sweep. The two ranked candidate lists are merged via
+// Reciprocal Rank Fusion (see search_rank.go) before the client's
+// limit/offset is applied. Semantic search is a ranking enhancement, never a
+// hard dependency: if SEMANTIC_SEARCH_ENABLED is off, the query-embedding
+// call fails, or a row has no embedding yet, results degrade to keyword-only
+// ranking rather than failing the request.
+func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := middleware.GetDB(c, db)
 		groupID := c.Param("id")
@@ -71,12 +83,23 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 			}
 		}
 
+		pool := candidatePoolSize(offset, limit)
+
+		var queryVector pgvector.Vector
+		semanticAvailable := false
+		if embedding.SemanticSearchEnabled() {
+			if vec, err := embedder.EmbedQuery(c.Request.Context(), query); err == nil {
+				queryVector = pgvector.NewVector(vec)
+				semanticAvailable = true
+			} else {
+				logging.WithField("error", err.Error()).Warn("Failed to embed search query; falling back to keyword-only results")
+			}
+		}
+
 		response := gin.H{}
 
 		if searchType == "all" || searchType == "animals" {
-			var animals []animalSearchResult
 			var totalAnimals int64
-
 			if err := db.Model(&models.Animal{}).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
 				Count(&totalAnimals).Error; err != nil {
@@ -84,52 +107,155 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 				return
 			}
 
+			var keywordRows []animalSearchResult
 			if err := db.Model(&models.Animal{}).
 				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
 				Order("rank DESC").
-				Limit(limit).
-				Offset(offset).
-				Find(&animals).Error; err != nil {
+				Limit(pool).
+				Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
 				return
 			}
 
-			response["animals"] = animals
+			var semanticRows []animalSearchResult
+			if semanticAvailable {
+				if err := db.Model(&models.Animal{}).
+					Select("animals.*, 0::float8 AS rank").
+					Where("group_id = ? AND embedding IS NOT NULL", groupID).
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?", Vars: []interface{}{queryVector}}}).
+					Limit(pool).
+					Find(&semanticRows).Error; err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search animals"})
+					return
+				}
+			}
+
+			response["animals"] = fuseAnimalResults(keywordRows, semanticRows, offset, limit)
 			response["total_animals"] = totalAnimals
 		}
 
 		if searchType == "all" || searchType == "comments" {
-			var comments []commentSearchResult
 			var totalComments int64
 
 			// GORM's soft-delete scope only auto-applies to the query's primary
 			// model (animal_comments) — the joined animals table needs an
 			// explicit deleted_at check, or comments on a deleted animal leak
 			// through search.
-			base := db.Model(&models.AnimalComment{}).
+			keywordBase := db.Model(&models.AnimalComment{}).
 				Joins("JOIN animals ON animals.id = animal_comments.animal_id").
 				Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
 
-			if err := base.Session(&gorm.Session{}).Count(&totalComments).Error; err != nil {
+			if err := keywordBase.Session(&gorm.Session{}).Count(&totalComments).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count matching comments"})
 				return
 			}
 
-			if err := base.Session(&gorm.Session{}).
+			var keywordRows []commentSearchResult
+			if err := keywordBase.Session(&gorm.Session{}).
 				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Order("rank DESC").
-				Limit(limit).
-				Offset(offset).
-				Find(&comments).Error; err != nil {
+				Limit(pool).
+				Find(&keywordRows).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
 				return
 			}
 
-			response["comments"] = comments
+			var semanticRows []commentSearchResult
+			if semanticAvailable {
+				semanticBase := db.Model(&models.AnimalComment{}).
+					Joins("JOIN animals ON animals.id = animal_comments.animal_id").
+					Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.embedding IS NOT NULL", groupID)
+
+				if err := semanticBase.
+					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
+					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?", Vars: []interface{}{queryVector}}}).
+					Limit(pool).
+					Find(&semanticRows).Error; err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to semantically search comments"})
+					return
+				}
+			}
+
+			response["comments"] = fuseCommentResults(keywordRows, semanticRows, offset, limit)
 			response["total_comments"] = totalComments
 		}
 
 		c.JSON(http.StatusOK, response)
 	}
+}
+
+// fuseAnimalResults merges keyword and semantic animal matches via
+// Reciprocal Rank Fusion and returns the requested page. A row present in
+// both lists is deduplicated (its full data is taken from whichever list is
+// checked first — identical either way, since it's the same database row);
+// only its combined score changes.
+func fuseAnimalResults(keyword, semantic []animalSearchResult, offset, limit int) []animalSearchResult {
+	rows := make(map[uint]animalSearchResult, len(keyword)+len(semantic))
+	keywordIDs := make([]uint, len(keyword))
+	for i, r := range keyword {
+		keywordIDs[i] = r.ID
+		rows[r.ID] = r
+	}
+	semanticIDs := make([]uint, len(semantic))
+	for i, r := range semantic {
+		semanticIDs[i] = r.ID
+		if _, ok := rows[r.ID]; !ok {
+			rows[r.ID] = r
+		}
+	}
+
+	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
+	page := paginateIDs(ordered, offset, limit)
+
+	result := make([]animalSearchResult, 0, len(page))
+	for _, id := range page {
+		row := rows[id]
+		row.Rank = scores[id]
+		result = append(result, row)
+	}
+	return result
+}
+
+// fuseCommentResults mirrors fuseAnimalResults for commentSearchResult.
+func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit int) []commentSearchResult {
+	rows := make(map[uint]commentSearchResult, len(keyword)+len(semantic))
+	keywordIDs := make([]uint, len(keyword))
+	for i, r := range keyword {
+		keywordIDs[i] = r.ID
+		rows[r.ID] = r
+	}
+	semanticIDs := make([]uint, len(semantic))
+	for i, r := range semantic {
+		semanticIDs[i] = r.ID
+		if _, ok := rows[r.ID]; !ok {
+			rows[r.ID] = r
+		}
+	}
+
+	ordered, scores := fuseRankedIDs(keywordIDs, semanticIDs)
+	page := paginateIDs(ordered, offset, limit)
+
+	result := make([]commentSearchResult, 0, len(page))
+	for _, id := range page {
+		row := rows[id]
+		row.Rank = scores[id]
+		result = append(result, row)
+	}
+	return result
+}
+
+// paginateIDs slices a fused ID order to the client's requested page,
+// clamping so an offset beyond the end of the fused candidates returns an
+// empty page instead of panicking.
+func paginateIDs(ordered []uint, offset, limit int) []uint {
+	start := offset
+	if start > len(ordered) {
+		start = len(ordered)
+	}
+	end := start + limit
+	if end > len(ordered) {
+		end = len(ordered)
+	}
+	return ordered[start:end]
 }

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -138,8 +138,18 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				}
 			}
 
-			response["animals"] = fuseAnimalResults(keywordRows, semanticRows, offset, limit)
-			response["total_animals"] = totalAnimals
+			animals, fusedAnimalTotal := fuseAnimalResults(keywordRows, semanticRows, offset, limit)
+			response["animals"] = animals
+			// totalAnimals alone undercounts once semantic search is enabled: it's a
+			// keyword-only Count(), but the returned page also includes semantic-only
+			// matches (no shared vocabulary with the query). Without this max(), a
+			// semantic-only match would appear in the results yet total_animals could
+			// read 0, and the frontend's canLoadMore (animals.length < totalAnimals)
+			// would then never fire — hiding any further semantic-only matches beyond
+			// this page. fusedAnimalTotal (bounded by the candidate pool, same as the
+			// results themselves) covers that gap; the keyword Count() still covers
+			// the rare case where keyword matches alone exceed the pool.
+			response["total_animals"] = max(totalAnimals, int64(fusedAnimalTotal))
 		}
 
 		if searchType == "all" || searchType == "comments" {
@@ -184,8 +194,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				}
 			}
 
-			response["comments"] = fuseCommentResults(keywordRows, semanticRows, offset, limit)
-			response["total_comments"] = totalComments
+			comments, fusedCommentTotal := fuseCommentResults(keywordRows, semanticRows, offset, limit)
+			response["comments"] = comments
+			// See the matching comment on total_animals above: a keyword-only Count()
+			// undercounts once semantic-only matches are in the results.
+			response["total_comments"] = max(totalComments, int64(fusedCommentTotal))
 		}
 
 		if searchType == "all" || searchType == "updates" {
@@ -221,8 +234,11 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 				}
 			}
 
-			response["updates"] = fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
-			response["total_updates"] = totalUpdates
+			updates, fusedUpdateTotal := fuseUpdateResults(keywordUpdateRows, semanticUpdateRows, offset, limit)
+			response["updates"] = updates
+			// See the matching comment on total_animals above: a keyword-only Count()
+			// undercounts once semantic-only matches are in the results.
+			response["total_updates"] = max(totalUpdates, int64(fusedUpdateTotal))
 		}
 
 		c.JSON(http.StatusOK, response)
@@ -230,11 +246,13 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 }
 
 // fuseAnimalResults merges keyword and semantic animal matches via
-// Reciprocal Rank Fusion and returns the requested page. A row present in
-// both lists is deduplicated (its full data is taken from whichever list is
-// checked first — identical either way, since it's the same database row);
-// only its combined score changes.
-func fuseAnimalResults(keyword, semantic []animalSearchResult, offset, limit int) []animalSearchResult {
+// Reciprocal Rank Fusion and returns the requested page, plus the size of
+// the full fused candidate set (before pagination) — the caller uses this
+// to correct total_animals for semantic-only matches a keyword-only Count()
+// would miss. A row present in both lists is deduplicated (its full data is
+// taken from whichever list is checked first — identical either way, since
+// it's the same database row); only its combined score changes.
+func fuseAnimalResults(keyword, semantic []animalSearchResult, offset, limit int) ([]animalSearchResult, int) {
 	rows := make(map[uint]animalSearchResult, len(keyword)+len(semantic))
 	keywordIDs := make([]uint, len(keyword))
 	for i, r := range keyword {
@@ -258,11 +276,11 @@ func fuseAnimalResults(keyword, semantic []animalSearchResult, offset, limit int
 		row.Rank = scores[id]
 		result = append(result, row)
 	}
-	return result
+	return result, len(ordered)
 }
 
 // fuseCommentResults mirrors fuseAnimalResults for commentSearchResult.
-func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit int) []commentSearchResult {
+func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit int) ([]commentSearchResult, int) {
 	rows := make(map[uint]commentSearchResult, len(keyword)+len(semantic))
 	keywordIDs := make([]uint, len(keyword))
 	for i, r := range keyword {
@@ -286,11 +304,11 @@ func fuseCommentResults(keyword, semantic []commentSearchResult, offset, limit i
 		row.Rank = scores[id]
 		result = append(result, row)
 	}
-	return result
+	return result, len(ordered)
 }
 
 // fuseUpdateResults mirrors fuseAnimalResults for updateSearchResult.
-func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int) []updateSearchResult {
+func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int) ([]updateSearchResult, int) {
 	rows := make(map[uint]updateSearchResult, len(keyword)+len(semantic))
 	keywordIDs := make([]uint, len(keyword))
 	for i, r := range keyword {
@@ -314,7 +332,7 @@ func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int
 		row.Rank = scores[id]
 		result = append(result, row)
 	}
-	return result
+	return result, len(ordered)
 }
 
 // paginateIDs slices a fused ID order to the client's requested page,

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -27,8 +27,9 @@ type commentSearchResult struct {
 
 // Search performs keyword/phrase search over a group's animals and comments
 // using Postgres full-text search (tsvector columns populated by generated
-// columns — see createSearchIndexes). Scoped to the requesting user's group
-// access, matching every other /groups/:id route in this file set.
+// columns — see createCustomIndexes in internal/database/database.go).
+// Scoped to the requesting user's group access, matching every other
+// /groups/:id route in this file set.
 func Search(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := middleware.GetDB(c, db)
@@ -77,7 +78,6 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 			var totalAnimals int64
 
 			db.Model(&models.Animal{}).
-				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
 				Count(&totalAnimals)
 
@@ -100,9 +100,13 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 			var comments []commentSearchResult
 			var totalComments int64
 
+			// GORM's soft-delete scope only auto-applies to the query's primary
+			// model (animal_comments) — the joined animals table needs an
+			// explicit deleted_at check, or comments on a deleted animal leak
+			// through search.
 			base := db.Model(&models.AnimalComment{}).
 				Joins("JOIN animals ON animals.id = animal_comments.animal_id").
-				Where("animals.group_id = ? AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
+				Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
 
 			base.Session(&gorm.Session{}).Count(&totalComments)
 

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
+)
+
+// animalSearchResult is an animal match with its full-text relevance rank.
+type animalSearchResult struct {
+	models.Animal
+	Rank float64 `json:"rank"`
+}
+
+// commentSearchResult is a comment match with its parent animal's name/id
+// (comments are meaningless out of the context of which animal they're on)
+// and its full-text relevance rank.
+type commentSearchResult struct {
+	models.AnimalComment
+	AnimalName string  `json:"animal_name"`
+	Rank       float64 `json:"rank"`
+}
+
+// Search performs keyword/phrase search over a group's animals and comments
+// using Postgres full-text search (tsvector columns populated by generated
+// columns — see createSearchIndexes). Scoped to the requesting user's group
+// access, matching every other /groups/:id route in this file set.
+func Search(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupID := c.Param("id")
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		query := c.Query("q")
+		if query == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "q parameter is required"})
+			return
+		}
+
+		searchType := c.DefaultQuery("type", "all")
+		if searchType != "all" && searchType != "animals" && searchType != "comments" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "type must be one of: all, animals, comments"})
+			return
+		}
+
+		limit := 20
+		if limitParam := c.Query("limit"); limitParam != "" {
+			if parsed, err := strconv.Atoi(limitParam); err == nil && parsed > 0 {
+				limit = parsed
+				if limit > 100 {
+					limit = 100
+				}
+			}
+		}
+
+		offset := 0
+		if offsetParam := c.Query("offset"); offsetParam != "" {
+			if parsed, err := strconv.Atoi(offsetParam); err == nil && parsed >= 0 {
+				offset = parsed
+			}
+		}
+
+		response := gin.H{}
+
+		if searchType == "all" || searchType == "animals" {
+			var animals []animalSearchResult
+			var totalAnimals int64
+
+			db.Model(&models.Animal{}).
+				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+				Count(&totalAnimals)
+
+			if err := db.Model(&models.Animal{}).
+				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
+				Order("rank DESC").
+				Limit(limit).
+				Offset(offset).
+				Find(&animals).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search animals"})
+				return
+			}
+
+			response["animals"] = animals
+			response["total_animals"] = totalAnimals
+		}
+
+		if searchType == "all" || searchType == "comments" {
+			var comments []commentSearchResult
+			var totalComments int64
+
+			base := db.Model(&models.AnimalComment{}).
+				Joins("JOIN animals ON animals.id = animal_comments.animal_id").
+				Where("animals.group_id = ? AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
+
+			base.Session(&gorm.Session{}).Count(&totalComments)
+
+			if err := base.Session(&gorm.Session{}).
+				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
+				Order("rank DESC").
+				Limit(limit).
+				Offset(offset).
+				Find(&comments).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search comments"})
+				return
+			}
+
+			response["comments"] = comments
+			response["total_comments"] = totalComments
+		}
+
+		c.JSON(http.StatusOK, response)
+	}
+}

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -77,9 +77,12 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 			var animals []animalSearchResult
 			var totalAnimals int64
 
-			db.Model(&models.Animal{}).
+			if err := db.Model(&models.Animal{}).
 				Where("group_id = ? AND search_vector @@ websearch_to_tsquery('english', ?)", groupID, query).
-				Count(&totalAnimals)
+				Count(&totalAnimals).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count matching animals"})
+				return
+			}
 
 			if err := db.Model(&models.Animal{}).
 				Select("animals.*, ts_rank(search_vector, websearch_to_tsquery('english', ?)) AS rank", query).
@@ -108,7 +111,10 @@ func Search(db *gorm.DB) gin.HandlerFunc {
 				Joins("JOIN animals ON animals.id = animal_comments.animal_id").
 				Where("animals.group_id = ? AND animals.deleted_at IS NULL AND animal_comments.search_vector @@ websearch_to_tsquery('english', ?)", groupID, query)
 
-			base.Session(&gorm.Session{}).Count(&totalComments)
+			if err := base.Session(&gorm.Session{}).Count(&totalComments).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count matching comments"})
+				return
+			}
 
 			if err := base.Session(&gorm.Session{}).
 				Select("animal_comments.*, animals.name AS animal_name, ts_rank(animal_comments.search_vector, websearch_to_tsquery('english', ?)) AS rank", query).

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -78,3 +78,37 @@ func embedCommentNow(rawDB *gorm.DB, embedder embedding.Embedder, comment models
 	}
 	return nil
 }
+
+// updateEmbeddingText builds the same searchable text used by updates'
+// search_vector generated column (title + content).
+func updateEmbeddingText(update models.Update) string {
+	return update.Title + " " + update.Content
+}
+
+// embedUpdateAsync mirrors embedAnimalAsync for updates. Update has no edit
+// endpoint (create/delete only), so this is only ever called from CreateUpdate.
+func embedUpdateAsync(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) {
+	if !embedding.SemanticSearchEnabled() {
+		return
+	}
+	go func() {
+		if err := embedUpdateNow(rawDB, embedder, update); err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to embed update on write; reconciliation sweep will retry")
+		}
+	}()
+}
+
+// embedUpdateNow is embedUpdateAsync's synchronous core.
+func embedUpdateNow(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) error {
+	vec, err := embedder.EmbedDocument(context.Background(), updateEmbeddingText(update))
+	if err != nil {
+		return fmt.Errorf("failed to embed update %d: %w", update.ID, err)
+	}
+	if err := rawDB.Exec(
+		"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vec), update.ID,
+	).Error; err != nil {
+		return fmt.Errorf("failed to persist embedding for update %d: %w", update.ID, err)
+	}
+	return nil
+}

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -7,15 +7,16 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
-	"github.com/pgvector/pgvector-go"
 	"gorm.io/gorm"
 )
 
 // animalEmbeddingText builds the same searchable text used by the
 // search_vector generated column (name/species/breed/description/
 // trainer_notes), so keyword and semantic search index the same content.
+// Delegates to embedding.AnimalEmbeddingText, the single source of truth
+// for the formula shared with the reconciliation sweep.
 func animalEmbeddingText(animal models.Animal) string {
-	return animal.Name + " " + animal.Species + " " + animal.Breed + " " + animal.Description + " " + animal.TrainerNotes
+	return embedding.AnimalEmbeddingText(animal.Name, animal.Species, animal.Breed, animal.Description, animal.TrainerNotes)
 }
 
 // embedAnimalAsync embeds an animal's searchable text and persists it in a
@@ -39,28 +40,26 @@ func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models
 // embedAnimalNow is embedAnimalAsync's synchronous core, factored out so
 // tests can call it directly instead of racing a goroutine.
 //
-// The UPDATE's "AND updated_at = ?" guard is an optimistic-concurrency check
-// against the row version this specific text was captured from: two edits
-// to the same animal in quick succession each spawn their own goroutine, and
-// nothing else serializes them, so the earlier edit's (slower) embed call
-// can complete after the later edit's (faster) one. Without this guard, the
-// earlier goroutine's write would silently overwrite the newer embedding
-// with a stale one while still stamping embedding_updated_at = now() —
-// making the row look "freshly embedded" to the sweep's staleness check
-// (embedding_updated_at < updated_at) even though it holds outdated
-// content. With the guard, a write whose captured version no longer matches
-// the row's current updated_at simply matches zero rows and is silently
-// skipped; the sweep's normal staleness check picks the row up again later
-// exactly as it would for any other stale row.
+// embedding.PersistEmbedding's "AND updated_at = ?" guard is an
+// optimistic-concurrency check against the row version this specific text
+// was captured from: two edits to the same animal in quick succession each
+// spawn their own goroutine, and nothing else serializes them, so the
+// earlier edit's (slower) embed call can complete after the later edit's
+// (faster) one. Without this guard, the earlier goroutine's write would
+// silently overwrite the newer embedding with a stale one while still
+// stamping embedding_updated_at = now() — making the row look "freshly
+// embedded" to the sweep's staleness check (embedding_updated_at <
+// updated_at) even though it holds outdated content. With the guard, a
+// write whose captured version no longer matches the row's current
+// updated_at simply matches zero rows and is silently skipped; the sweep's
+// normal staleness check picks the row up again later exactly as it would
+// for any other stale row.
 func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) error {
 	vec, err := embedder.EmbedDocument(context.Background(), animalEmbeddingText(animal))
 	if err != nil {
 		return fmt.Errorf("failed to embed animal %d: %w", animal.ID, err)
 	}
-	if err := rawDB.Exec(
-		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
-		pgvector.NewVector(vec), animal.ID, animal.UpdatedAt,
-	).Error; err != nil {
+	if err := embedding.PersistEmbedding(rawDB, "animals", animal.ID, animal.UpdatedAt, vec); err != nil {
 		return fmt.Errorf("failed to persist embedding for animal %d: %w", animal.ID, err)
 	}
 	return nil
@@ -79,26 +78,25 @@ func embedCommentAsync(rawDB *gorm.DB, embedder embedding.Embedder, comment mode
 }
 
 // embedCommentNow is embedCommentAsync's synchronous core. See
-// embedAnimalNow's comment for why the UPDATE guards on the row's captured
-// updated_at.
+// embedAnimalNow's comment for why the persisted UPDATE guards on the row's
+// captured updated_at.
 func embedCommentNow(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) error {
 	vec, err := embedder.EmbedDocument(context.Background(), comment.Content)
 	if err != nil {
 		return fmt.Errorf("failed to embed comment %d: %w", comment.ID, err)
 	}
-	if err := rawDB.Exec(
-		"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
-		pgvector.NewVector(vec), comment.ID, comment.UpdatedAt,
-	).Error; err != nil {
+	if err := embedding.PersistEmbedding(rawDB, "animal_comments", comment.ID, comment.UpdatedAt, vec); err != nil {
 		return fmt.Errorf("failed to persist embedding for comment %d: %w", comment.ID, err)
 	}
 	return nil
 }
 
 // updateEmbeddingText builds the same searchable text used by updates'
-// search_vector generated column (title + content).
+// search_vector generated column (title + content). Delegates to
+// embedding.UpdateEmbeddingText, the single source of truth for the formula
+// shared with the reconciliation sweep.
 func updateEmbeddingText(update models.Update) string {
-	return update.Title + " " + update.Content
+	return embedding.UpdateEmbeddingText(update.Title, update.Content)
 }
 
 // embedUpdateAsync mirrors embedAnimalAsync for updates. Update has no edit
@@ -115,20 +113,17 @@ func embedUpdateAsync(rawDB *gorm.DB, embedder embedding.Embedder, update models
 }
 
 // embedUpdateNow is embedUpdateAsync's synchronous core. See
-// embedAnimalNow's comment for why the UPDATE guards on the row's captured
-// updated_at. (Update has no edit endpoint, so this race is theoretical for
-// updates specifically today — kept consistent with the other two resources
-// anyway, since a future edit endpoint would otherwise silently reintroduce
-// the gap this guard closes.)
+// embedAnimalNow's comment for why the persisted UPDATE guards on the row's
+// captured updated_at. (Update has no edit endpoint, so this race is
+// theoretical for updates specifically today — kept consistent with the
+// other two resources anyway, since a future edit endpoint would otherwise
+// silently reintroduce the gap this guard closes.)
 func embedUpdateNow(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) error {
 	vec, err := embedder.EmbedDocument(context.Background(), updateEmbeddingText(update))
 	if err != nil {
 		return fmt.Errorf("failed to embed update %d: %w", update.ID, err)
 	}
-	if err := rawDB.Exec(
-		"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
-		pgvector.NewVector(vec), update.ID, update.UpdatedAt,
-	).Error; err != nil {
+	if err := embedding.PersistEmbedding(rawDB, "updates", update.ID, update.UpdatedAt, vec); err != nil {
 		return fmt.Errorf("failed to persist embedding for update %d: %w", update.ID, err)
 	}
 	return nil

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -3,12 +3,45 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/gorm"
 )
+
+// embedWriteWG tracks every in-flight write-path embed goroutine spawned by
+// embedAsync, so WaitForPendingEmbeds can drain them during graceful
+// shutdown — mirroring the reconciliation sweep's own stop/drain mechanism
+// (internal/embedding/sweep.go's StartReconciliationSweep). Without this, a
+// goroutine spawned by a request that returns just before shutdown could
+// still be calling embedding.PersistEmbedding after cmd/api/main.go closes
+// the DB connection pool.
+var embedWriteWG sync.WaitGroup
+
+// embedWriteDrainTimeout bounds how long WaitForPendingEmbeds waits for
+// in-flight embed goroutines to finish before giving up, mirroring
+// sweepStopTimeout's bounded wait in internal/embedding/sweep.go.
+const embedWriteDrainTimeout = 10 * time.Second
+
+// WaitForPendingEmbeds blocks (up to embedWriteDrainTimeout) until every
+// write-path embed goroutine spawned so far has finished. Call during
+// graceful shutdown, after the HTTP server has stopped accepting new
+// requests but before closing the DB connection pool.
+func WaitForPendingEmbeds() {
+	done := make(chan struct{})
+	go func() {
+		embedWriteWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(embedWriteDrainTimeout):
+		logging.Warn(fmt.Sprintf("Write-path embed goroutines did not finish within %s of shutdown signal; proceeding with shutdown anyway", embedWriteDrainTimeout))
+	}
+}
 
 // animalEmbeddingText builds the same searchable text used by the
 // search_vector generated column (name/species/breed/description/
@@ -19,30 +52,34 @@ func animalEmbeddingText(animal models.Animal) string {
 	return embedding.AnimalEmbeddingText(animal.Name, animal.Species, animal.Breed, animal.Description, animal.TrainerNotes)
 }
 
-// embedAnimalAsync embeds an animal's searchable text and persists it in a
-// detached goroutine that outlives the request. rawDB must be the unscoped
-// *gorm.DB (not middleware.GetDB(c, db)) since the request context is
-// canceled the instant the handler returns — see the same pattern in
-// animal_crud.go's sendQuarantineNotificationEmail usage. Failures are
-// logged and left for the reconciliation sweep to retry; never surfaced to
-// the write request.
-func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) {
-	if !embedding.Usable(embedder) {
-		return
-	}
-	go func() {
-		if err := embedAnimalNow(rawDB, embedder, animal); err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to embed animal on write; reconciliation sweep will retry")
-		}
-	}()
+// updateEmbeddingText builds the same searchable text used by updates'
+// search_vector generated column (title + content). Delegates to
+// embedding.UpdateEmbeddingText, the single source of truth for the formula
+// shared with the reconciliation sweep.
+func updateEmbeddingText(update models.Update) string {
+	return embedding.UpdateEmbeddingText(update.Title, update.Content)
 }
 
-// embedAnimalNow is embedAnimalAsync's synchronous core, factored out so
-// tests can call it directly instead of racing a goroutine.
+// embedWriteConcurrencyLimit bounds how many write-path embed goroutines can
+// be mid-flight at once, mirroring the reconciliation sweep's sweepBatchSize
+// discipline (internal/embedding/sweep.go) — without a cap, a burst of
+// concurrent writes (e.g. many users commenting at once) would fire as many
+// unbounded concurrent Voyage API requests as there are writes, with no
+// backpressure.
+const embedWriteConcurrencyLimit = 10
+
+var embedWriteSemaphore = make(chan struct{}, embedWriteConcurrencyLimit)
+
+// embedNow is the shared synchronous core of embedAnimalNow/embedCommentNow/
+// embedUpdateNow: embeds the given text and persists it via
+// embedding.PersistEmbedding (the same function the reconciliation sweep
+// uses, see internal/embedding/sweep.go's embedAndPersist), so a fix to
+// embed/persist handling only needs to be made in one place instead of
+// risking the three resources' write-path helpers drifting out of sync.
 //
 // embedding.PersistEmbedding's "AND updated_at = ?" guard is an
 // optimistic-concurrency check against the row version this specific text
-// was captured from: two edits to the same animal in quick succession each
+// was captured from: two edits to the same row in quick succession each
 // spawn their own goroutine, and nothing else serializes them, so the
 // earlier edit's (slower) embed call can complete after the later edit's
 // (faster) one. Without this guard, the earlier goroutine's write would
@@ -54,77 +91,71 @@ func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models
 // updated_at simply matches zero rows and is silently skipped; the sweep's
 // normal staleness check picks the row up again later exactly as it would
 // for any other stale row.
-func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) error {
-	vec, err := embedder.EmbedDocument(context.Background(), animalEmbeddingText(animal))
+func embedNow(rawDB *gorm.DB, embedder embedding.Embedder, table, resourceName string, id uint, updatedAt time.Time, text string) error {
+	vec, err := embedder.EmbedDocument(context.Background(), text)
 	if err != nil {
-		return fmt.Errorf("failed to embed animal %d: %w", animal.ID, err)
+		return fmt.Errorf("failed to embed %s %d: %w", resourceName, id, err)
 	}
-	if err := embedding.PersistEmbedding(rawDB, "animals", animal.ID, animal.UpdatedAt, vec); err != nil {
-		return fmt.Errorf("failed to persist embedding for animal %d: %w", animal.ID, err)
+	if err := embedding.PersistEmbedding(rawDB, table, id, updatedAt, vec); err != nil {
+		return fmt.Errorf("failed to persist embedding for %s %d: %w", resourceName, id, err)
 	}
 	return nil
+}
+
+// embedAsync runs embedNow in a detached goroutine that outlives the
+// request, bounded by embedWriteSemaphore. rawDB must be the unscoped
+// *gorm.DB (not middleware.GetDB(c, db)) since the request context is
+// canceled the instant the handler returns — see the same pattern in
+// animal_crud.go's sendQuarantineNotificationEmail usage. Failures are
+// logged and left for the reconciliation sweep to retry; never surfaced to
+// the write request.
+func embedAsync(rawDB *gorm.DB, embedder embedding.Embedder, table, resourceName string, id uint, updatedAt time.Time, text string) {
+	if !embedding.Usable(embedder) {
+		return
+	}
+	embedWriteWG.Go(func() {
+		embedWriteSemaphore <- struct{}{}
+		defer func() { <-embedWriteSemaphore }()
+		if err := embedNow(rawDB, embedder, table, resourceName, id, updatedAt, text); err != nil {
+			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to embed %s on write; reconciliation sweep will retry", resourceName))
+		}
+	})
+}
+
+// embedAnimalAsync embeds an animal's searchable text and persists it
+// asynchronously. See embedAsync's doc comment for the concurrency/rawDB
+// contract.
+func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) {
+	embedAsync(rawDB, embedder, "animals", "animal", animal.ID, animal.UpdatedAt, animalEmbeddingText(animal))
+}
+
+// embedAnimalNow is embedAnimalAsync's synchronous core, factored out so
+// tests can call it directly instead of racing a goroutine.
+func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) error {
+	return embedNow(rawDB, embedder, "animals", "animal", animal.ID, animal.UpdatedAt, animalEmbeddingText(animal))
 }
 
 // embedCommentAsync mirrors embedAnimalAsync for comments.
 func embedCommentAsync(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) {
-	if !embedding.Usable(embedder) {
-		return
-	}
-	go func() {
-		if err := embedCommentNow(rawDB, embedder, comment); err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to embed comment on write; reconciliation sweep will retry")
-		}
-	}()
+	embedAsync(rawDB, embedder, "animal_comments", "comment", comment.ID, comment.UpdatedAt, comment.Content)
 }
 
-// embedCommentNow is embedCommentAsync's synchronous core. See
-// embedAnimalNow's comment for why the persisted UPDATE guards on the row's
-// captured updated_at.
+// embedCommentNow is embedCommentAsync's synchronous core.
 func embedCommentNow(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) error {
-	vec, err := embedder.EmbedDocument(context.Background(), comment.Content)
-	if err != nil {
-		return fmt.Errorf("failed to embed comment %d: %w", comment.ID, err)
-	}
-	if err := embedding.PersistEmbedding(rawDB, "animal_comments", comment.ID, comment.UpdatedAt, vec); err != nil {
-		return fmt.Errorf("failed to persist embedding for comment %d: %w", comment.ID, err)
-	}
-	return nil
-}
-
-// updateEmbeddingText builds the same searchable text used by updates'
-// search_vector generated column (title + content). Delegates to
-// embedding.UpdateEmbeddingText, the single source of truth for the formula
-// shared with the reconciliation sweep.
-func updateEmbeddingText(update models.Update) string {
-	return embedding.UpdateEmbeddingText(update.Title, update.Content)
+	return embedNow(rawDB, embedder, "animal_comments", "comment", comment.ID, comment.UpdatedAt, comment.Content)
 }
 
 // embedUpdateAsync mirrors embedAnimalAsync for updates. Update has no edit
 // endpoint (create/delete only), so this is only ever called from CreateUpdate.
 func embedUpdateAsync(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) {
-	if !embedding.Usable(embedder) {
-		return
-	}
-	go func() {
-		if err := embedUpdateNow(rawDB, embedder, update); err != nil {
-			logging.WithField("error", err.Error()).Warn("Failed to embed update on write; reconciliation sweep will retry")
-		}
-	}()
+	embedAsync(rawDB, embedder, "updates", "update", update.ID, update.UpdatedAt, updateEmbeddingText(update))
 }
 
-// embedUpdateNow is embedUpdateAsync's synchronous core. See
-// embedAnimalNow's comment for why the persisted UPDATE guards on the row's
-// captured updated_at. (Update has no edit endpoint, so this race is
+// embedUpdateNow is embedUpdateAsync's synchronous core. (Update has no edit
+// endpoint, so the optimistic-concurrency race embedNow guards against is
 // theoretical for updates specifically today — kept consistent with the
 // other two resources anyway, since a future edit endpoint would otherwise
 // silently reintroduce the gap this guard closes.)
 func embedUpdateNow(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) error {
-	vec, err := embedder.EmbedDocument(context.Background(), updateEmbeddingText(update))
-	if err != nil {
-		return fmt.Errorf("failed to embed update %d: %w", update.ID, err)
-	}
-	if err := embedding.PersistEmbedding(rawDB, "updates", update.ID, update.UpdatedAt, vec); err != nil {
-		return fmt.Errorf("failed to persist embedding for update %d: %w", update.ID, err)
-	}
-	return nil
+	return embedNow(rawDB, embedder, "updates", "update", update.ID, update.UpdatedAt, updateEmbeddingText(update))
 }

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/pgvector/pgvector-go"
+	"gorm.io/gorm"
+)
+
+// animalEmbeddingText builds the same searchable text used by the
+// search_vector generated column (name/species/breed/description/
+// trainer_notes), so keyword and semantic search index the same content.
+func animalEmbeddingText(animal models.Animal) string {
+	return animal.Name + " " + animal.Species + " " + animal.Breed + " " + animal.Description + " " + animal.TrainerNotes
+}
+
+// embedAnimalAsync embeds an animal's searchable text and persists it in a
+// detached goroutine that outlives the request. rawDB must be the unscoped
+// *gorm.DB (not middleware.GetDB(c, db)) since the request context is
+// canceled the instant the handler returns — see the same pattern in
+// animal_crud.go's sendQuarantineNotificationEmail usage. Failures are
+// logged and left for the reconciliation sweep to retry; never surfaced to
+// the write request.
+func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) {
+	if !embedding.SemanticSearchEnabled() {
+		return
+	}
+	go func() {
+		if err := embedAnimalNow(rawDB, embedder, animal); err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to embed animal on write; reconciliation sweep will retry")
+		}
+	}()
+}
+
+// embedAnimalNow is embedAnimalAsync's synchronous core, factored out so
+// tests can call it directly instead of racing a goroutine.
+func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) error {
+	vec, err := embedder.EmbedDocument(context.Background(), animalEmbeddingText(animal))
+	if err != nil {
+		return fmt.Errorf("failed to embed animal %d: %w", animal.ID, err)
+	}
+	if err := rawDB.Exec(
+		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vec), animal.ID,
+	).Error; err != nil {
+		return fmt.Errorf("failed to persist embedding for animal %d: %w", animal.ID, err)
+	}
+	return nil
+}
+
+// embedCommentAsync mirrors embedAnimalAsync for comments.
+func embedCommentAsync(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) {
+	if !embedding.SemanticSearchEnabled() {
+		return
+	}
+	go func() {
+		if err := embedCommentNow(rawDB, embedder, comment); err != nil {
+			logging.WithField("error", err.Error()).Warn("Failed to embed comment on write; reconciliation sweep will retry")
+		}
+	}()
+}
+
+// embedCommentNow is embedCommentAsync's synchronous core.
+func embedCommentNow(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) error {
+	vec, err := embedder.EmbedDocument(context.Background(), comment.Content)
+	if err != nil {
+		return fmt.Errorf("failed to embed comment %d: %w", comment.ID, err)
+	}
+	if err := rawDB.Exec(
+		"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vec), comment.ID,
+	).Error; err != nil {
+		return fmt.Errorf("failed to persist embedding for comment %d: %w", comment.ID, err)
+	}
+	return nil
+}

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -113,8 +113,25 @@ func embedAsync(rawDB *gorm.DB, embedder embedding.Embedder, table, resourceName
 	if !embedding.Usable(embedder) {
 		return
 	}
+	// Acquire a semaphore slot synchronously, before spawning the goroutine
+	// — not after. Spawning first and blocking on the semaphore only
+	// inside the goroutine would mean a burst of writes (e.g. bulk CSV
+	// import calling this once per row) spawns one goroutine per row
+	// immediately, with all but embedWriteConcurrencyLimit of them sitting
+	// blocked in memory waiting for a slot — the "concurrency limit" would
+	// bound in-flight embeds but not the goroutine/memory footprint itself.
+	// A non-blocking try-acquire here keeps embedAsync's fire-and-forget
+	// contract (never blocks the caller/request) while actually bounding
+	// live goroutines to the semaphore's capacity: at capacity, this
+	// write's embed is skipped entirely and left for the reconciliation
+	// sweep to pick up, exactly like any other embed failure.
+	select {
+	case embedWriteSemaphore <- struct{}{}:
+	default:
+		logging.WithField("resource", resourceName).Warn("Skipping write-path embed; concurrency limit reached, reconciliation sweep will retry")
+		return
+	}
 	embedWriteWG.Go(func() {
-		embedWriteSemaphore <- struct{}{}
 		defer func() { <-embedWriteSemaphore }()
 		if err := embedNow(rawDB, embedder, table, resourceName, id, updatedAt, text); err != nil {
 			logging.WithField("error", err.Error()).Warn(fmt.Sprintf("Failed to embed %s on write; reconciliation sweep will retry", resourceName))

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -23,8 +23,13 @@ var embedWriteWG sync.WaitGroup
 
 // embedWriteDrainTimeout bounds how long WaitForPendingEmbeds waits for
 // in-flight embed goroutines to finish before giving up, mirroring
-// sweepStopTimeout's bounded wait in internal/embedding/sweep.go.
-const embedWriteDrainTimeout = 10 * time.Second
+// sweepStopTimeout's bounded wait in internal/embedding/sweep.go. Must
+// exceed embedding.RequestTimeout (the longest a single embed call itself
+// is allowed to take, per embedNow's context deadline below) with margin
+// for the subsequent PersistEmbedding write — otherwise this would almost
+// always time out and proceed while a goroutine mid-request is still
+// running, defeating the point of draining before the DB pool closes.
+const embedWriteDrainTimeout = embedding.RequestTimeout + 10*time.Second
 
 // WaitForPendingEmbeds blocks (up to embedWriteDrainTimeout) until every
 // write-path embed goroutine spawned so far has finished. Call during
@@ -92,7 +97,16 @@ var embedWriteSemaphore = make(chan struct{}, embedWriteConcurrencyLimit)
 // normal staleness check picks the row up again later exactly as it would
 // for any other stale row.
 func embedNow(rawDB *gorm.DB, embedder embedding.Embedder, table, resourceName string, id uint, updatedAt time.Time, text string) error {
-	vec, err := embedder.EmbedDocument(context.Background(), text)
+	// A deadline here — rather than a bare context.Background() — bounds
+	// the call regardless of what the concrete Embedder implementation
+	// does internally: VoyageEmbedder already enforces this via its own
+	// http.Client.Timeout, but embedWriteDrainTimeout's guarantee (that
+	// shutdown won't proceed while a goroutine using this function is
+	// still running) shouldn't depend on every current and future Embedder
+	// implementation happening to self-bound the same way.
+	ctx, cancel := context.WithTimeout(context.Background(), embedding.RequestTimeout)
+	defer cancel()
+	vec, err := embedder.EmbedDocument(ctx, text)
 	if err != nil {
 		return fmt.Errorf("failed to embed %s %d: %w", resourceName, id, err)
 	}

--- a/internal/handlers/search_embed.go
+++ b/internal/handlers/search_embed.go
@@ -26,7 +26,7 @@ func animalEmbeddingText(animal models.Animal) string {
 // logged and left for the reconciliation sweep to retry; never surfaced to
 // the write request.
 func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) {
-	if !embedding.SemanticSearchEnabled() {
+	if !embedding.Usable(embedder) {
 		return
 	}
 	go func() {
@@ -38,14 +38,28 @@ func embedAnimalAsync(rawDB *gorm.DB, embedder embedding.Embedder, animal models
 
 // embedAnimalNow is embedAnimalAsync's synchronous core, factored out so
 // tests can call it directly instead of racing a goroutine.
+//
+// The UPDATE's "AND updated_at = ?" guard is an optimistic-concurrency check
+// against the row version this specific text was captured from: two edits
+// to the same animal in quick succession each spawn their own goroutine, and
+// nothing else serializes them, so the earlier edit's (slower) embed call
+// can complete after the later edit's (faster) one. Without this guard, the
+// earlier goroutine's write would silently overwrite the newer embedding
+// with a stale one while still stamping embedding_updated_at = now() —
+// making the row look "freshly embedded" to the sweep's staleness check
+// (embedding_updated_at < updated_at) even though it holds outdated
+// content. With the guard, a write whose captured version no longer matches
+// the row's current updated_at simply matches zero rows and is silently
+// skipped; the sweep's normal staleness check picks the row up again later
+// exactly as it would for any other stale row.
 func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.Animal) error {
 	vec, err := embedder.EmbedDocument(context.Background(), animalEmbeddingText(animal))
 	if err != nil {
 		return fmt.Errorf("failed to embed animal %d: %w", animal.ID, err)
 	}
 	if err := rawDB.Exec(
-		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-		pgvector.NewVector(vec), animal.ID,
+		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
+		pgvector.NewVector(vec), animal.ID, animal.UpdatedAt,
 	).Error; err != nil {
 		return fmt.Errorf("failed to persist embedding for animal %d: %w", animal.ID, err)
 	}
@@ -54,7 +68,7 @@ func embedAnimalNow(rawDB *gorm.DB, embedder embedding.Embedder, animal models.A
 
 // embedCommentAsync mirrors embedAnimalAsync for comments.
 func embedCommentAsync(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) {
-	if !embedding.SemanticSearchEnabled() {
+	if !embedding.Usable(embedder) {
 		return
 	}
 	go func() {
@@ -64,15 +78,17 @@ func embedCommentAsync(rawDB *gorm.DB, embedder embedding.Embedder, comment mode
 	}()
 }
 
-// embedCommentNow is embedCommentAsync's synchronous core.
+// embedCommentNow is embedCommentAsync's synchronous core. See
+// embedAnimalNow's comment for why the UPDATE guards on the row's captured
+// updated_at.
 func embedCommentNow(rawDB *gorm.DB, embedder embedding.Embedder, comment models.AnimalComment) error {
 	vec, err := embedder.EmbedDocument(context.Background(), comment.Content)
 	if err != nil {
 		return fmt.Errorf("failed to embed comment %d: %w", comment.ID, err)
 	}
 	if err := rawDB.Exec(
-		"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-		pgvector.NewVector(vec), comment.ID,
+		"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
+		pgvector.NewVector(vec), comment.ID, comment.UpdatedAt,
 	).Error; err != nil {
 		return fmt.Errorf("failed to persist embedding for comment %d: %w", comment.ID, err)
 	}
@@ -88,7 +104,7 @@ func updateEmbeddingText(update models.Update) string {
 // embedUpdateAsync mirrors embedAnimalAsync for updates. Update has no edit
 // endpoint (create/delete only), so this is only ever called from CreateUpdate.
 func embedUpdateAsync(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) {
-	if !embedding.SemanticSearchEnabled() {
+	if !embedding.Usable(embedder) {
 		return
 	}
 	go func() {
@@ -98,15 +114,20 @@ func embedUpdateAsync(rawDB *gorm.DB, embedder embedding.Embedder, update models
 	}()
 }
 
-// embedUpdateNow is embedUpdateAsync's synchronous core.
+// embedUpdateNow is embedUpdateAsync's synchronous core. See
+// embedAnimalNow's comment for why the UPDATE guards on the row's captured
+// updated_at. (Update has no edit endpoint, so this race is theoretical for
+// updates specifically today — kept consistent with the other two resources
+// anyway, since a future edit endpoint would otherwise silently reintroduce
+// the gap this guard closes.)
 func embedUpdateNow(rawDB *gorm.DB, embedder embedding.Embedder, update models.Update) error {
 	vec, err := embedder.EmbedDocument(context.Background(), updateEmbeddingText(update))
 	if err != nil {
 		return fmt.Errorf("failed to embed update %d: %w", update.ID, err)
 	}
 	if err := rawDB.Exec(
-		"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
-		pgvector.NewVector(vec), update.ID,
+		"UPDATE updates SET embedding = ?, embedding_updated_at = now() WHERE id = ? AND updated_at = ?",
+		pgvector.NewVector(vec), update.ID, update.UpdatedAt,
 	).Error; err != nil {
 		return fmt.Errorf("failed to persist embedding for update %d: %w", update.ID, err)
 	}

--- a/internal/handlers/search_embed_test.go
+++ b/internal/handlers/search_embed_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+)
+
+var errTestEmbedFailure = errors.New("simulated embed failure")
+
+func TestEmbedAnimalNow_PersistsEmbedding(t *testing.T) {
+	// This test targets the SQLite-backed SetupTestDB used throughout this
+	// package's non-Postgres tests. SQLite has no vector column type, so it
+	// only verifies embedAnimalNow doesn't error when the embedder succeeds
+	// and that it attempts the UPDATE — full persistence is verified by the
+	// Postgres-gated test in Task 11's sweep tests, which exercises a real
+	// vector column end to end.
+	db := SetupTestDB(t)
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available", Description: "Loves belly rubs."}
+	if err := db.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	// embedAnimalNow issues a raw "UPDATE animals SET embedding = ..." which
+	// requires a real vector column — skip the UPDATE assertion on SQLite
+	// and only assert embedAnimalNow doesn't panic/error before that point
+	// when the embedder itself succeeds.
+	err := embedAnimalNow(db, &embedding.StubEmbedder{}, animal)
+	if err != nil {
+		t.Logf("embedAnimalNow returned an error against SQLite (expected — no vector column type): %v", err)
+	}
+}
+
+func TestEmbedAnimalNow_EmbedderFailureReturnsError(t *testing.T) {
+	db := SetupTestDB(t)
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := db.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	failingEmbedder := &embedding.StubEmbedder{Err: errTestEmbedFailure}
+	if err := embedAnimalNow(db, failingEmbedder, animal); err == nil {
+		t.Fatal("expected an error when the embedder fails")
+	}
+}
+
+func TestEmbedCommentNow_EmbedderFailureReturnsError(t *testing.T) {
+	db := SetupTestDB(t)
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	user := CreateTestUser(t, db, "member", "member@example.com", "password123", false)
+	animal := models.Animal{GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := db.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	comment := models.AnimalComment{AnimalID: animal.ID, UserID: user.ID, Content: "Great session today."}
+	if err := db.Create(&comment).Error; err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	failingEmbedder := &embedding.StubEmbedder{Err: errTestEmbedFailure}
+	if err := embedCommentNow(db, failingEmbedder, comment); err == nil {
+		t.Fatal("expected an error when the embedder fails")
+	}
+}

--- a/internal/handlers/search_embed_test.go
+++ b/internal/handlers/search_embed_test.go
@@ -66,3 +66,18 @@ func TestEmbedCommentNow_EmbedderFailureReturnsError(t *testing.T) {
 		t.Fatal("expected an error when the embedder fails")
 	}
 }
+
+func TestEmbedUpdateNow_EmbedderFailureReturnsError(t *testing.T) {
+	db := SetupTestDB(t)
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	user := CreateTestUser(t, db, "member", "member@example.com", "password123", false)
+	update := models.Update{GroupID: group.ID, UserID: user.ID, Title: "Playgroup Saturday", Content: "10am at the field."}
+	if err := db.Create(&update).Error; err != nil {
+		t.Fatalf("create update: %v", err)
+	}
+
+	failingEmbedder := &embedding.StubEmbedder{Err: errTestEmbedFailure}
+	if err := embedUpdateNow(db, failingEmbedder, update); err == nil {
+		t.Fatal("expected an error when the embedder fails")
+	}
+}

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/database"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/postgres"
@@ -176,7 +177,7 @@ func TestSearch_Postgres_MatchReturnsExpectedResults(t *testing.T) {
 	}
 
 	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
-	Search(f.tx)(c)
+	Search(f.tx, &embedding.StubEmbedder{})(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -226,7 +227,7 @@ func TestSearch_Postgres_ExcludesCommentsOnDeletedAnimal(t *testing.T) {
 	}
 
 	c, w := f.searchRequest(t, f.groupA.ID, "playgroup")
-	Search(f.tx)(c)
+	Search(f.tx, &embedding.StubEmbedder{})(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -256,7 +257,7 @@ func TestSearch_Postgres_DoesNotLeakAcrossGroups(t *testing.T) {
 	}
 
 	c, w := f.searchRequest(t, f.groupA.ID, "playgroup")
-	Search(f.tx)(c)
+	Search(f.tx, &embedding.StubEmbedder{})(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -294,7 +295,7 @@ func TestSearch_Postgres_TypeFilterScopesToRequestedResource(t *testing.T) {
 
 	t.Run("type=animals returns only animals, omits comments entirely", func(t *testing.T) {
 		c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "type": {"animals"}})
-		Search(f.tx)(c)
+		Search(f.tx, &embedding.StubEmbedder{})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		body := decodeSearchResponse(t, w)
@@ -314,7 +315,7 @@ func TestSearch_Postgres_TypeFilterScopesToRequestedResource(t *testing.T) {
 
 	t.Run("type=comments returns only comments, omits animals entirely", func(t *testing.T) {
 		c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "type": {"comments"}})
-		Search(f.tx)(c)
+		Search(f.tx, &embedding.StubEmbedder{})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		body := decodeSearchResponse(t, w)
@@ -345,7 +346,7 @@ func TestSearch_Postgres_PaginatesWithLimitAndOffset(t *testing.T) {
 	}
 
 	c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "limit": {"2"}, "offset": {"0"}})
-	Search(f.tx)(c)
+	Search(f.tx, &embedding.StubEmbedder{})(c)
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := decodeSearchResponse(t, w)
 	assert.Equal(t, float64(3), body["total_animals"], "total_animals must reflect the full match count, not the page size")
@@ -355,7 +356,7 @@ func TestSearch_Postgres_PaginatesWithLimitAndOffset(t *testing.T) {
 	}
 
 	c2, w2 := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "limit": {"2"}, "offset": {"2"}})
-	Search(f.tx)(c2)
+	Search(f.tx, &embedding.StubEmbedder{})(c2)
 	assert.Equal(t, http.StatusOK, w2.Code)
 	body2 := decodeSearchResponse(t, w2)
 	assert.Equal(t, float64(3), body2["total_animals"], "total_animals on the second page must still reflect the full match count")
@@ -407,7 +408,7 @@ func TestSearch_Postgres_RanksMultipleMatchesByRelevance(t *testing.T) {
 	}
 
 	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
-	Search(f.tx)(c)
+	Search(f.tx, &embedding.StubEmbedder{})(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := decodeSearchResponse(t, w)

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -558,6 +558,40 @@ func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
 	}
 }
 
+func TestSearch_Postgres_MatchesUpdatesByKeyword(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	update := models.Update{
+		GroupID: f.groupA.ID, UserID: f.user.ID,
+		Title: "Playgroup Saturday", Content: "Pairings: Rex+Fido, Bella+Max. 10am at the field.",
+	}
+	if err := f.tx.Create(&update).Error; err != nil {
+		t.Fatalf("create update: %v", err)
+	}
+	other := models.Update{
+		GroupID: f.groupA.ID, UserID: f.user.ID,
+		Title: "Unrelated", Content: "Reminder to restock supplies.",
+	}
+	if err := f.tx.Create(&other).Error; err != nil {
+		t.Fatalf("create other update: %v", err)
+	}
+
+	c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"pairings"}, "type": {"updates"}})
+	Search(f.tx, &embedding.StubEmbedder{})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(1), body["total_updates"])
+	updates, _ := body["updates"].([]interface{})
+	if len(updates) != 1 || updates[0].(map[string]interface{})["title"] != "Playgroup Saturday" {
+		t.Fatalf("expected exactly the matching update, got: %v", updates)
+	}
+	if _, present := body["animals"]; present {
+		t.Fatalf("expected no 'animals' key when type=updates, got %v", body["animals"])
+	}
+}
+
 func TestSearch_Postgres_DeepPaginationCoversResultsBeyondDefaultPool(t *testing.T) {
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -532,6 +532,16 @@ func TestSearch_Postgres_SemanticMatchSurfacesResultWithNoKeywordOverlap(t *test
 	if !found {
 		t.Fatalf("expected semantic match \"Bowl\" to surface despite no keyword overlap, got animals: %v", animals)
 	}
+
+	// Regression check: a keyword-only Count() would report 0 here (neither
+	// animal matches "resource guarding" by keyword), even though a semantic
+	// match is genuinely present in the results above. total_animals must
+	// reflect the fused result set, not just the keyword count, or the
+	// frontend's canLoadMore (animals.length < totalAnimals) can never fire
+	// for a page made entirely of semantic-only matches.
+	if body["total_animals"].(float64) < 1 {
+		t.Fatalf("expected total_animals to count the semantic-only match, got %v", body["total_animals"])
+	}
 }
 
 func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -571,6 +571,94 @@ func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
 	}
 }
 
+// TestSearch_Postgres_DegradesToKeywordOnlyWhenSemanticQueryFails covers a
+// different failure point than the test above: the query embedding itself
+// succeeds (semanticAvailable is true), but the per-resource semantic SELECT
+// against the embedding column fails — simulated here via a dimension
+// mismatch (the query vector is a different size than the stored one),
+// which pgvector rejects at execution time. Before the fix, this branch
+// fused the already-fetched, pool-limited keywordRows (no real Offset
+// applied) instead of falling back to a genuine keyword-only page, which
+// silently broke pagination once offset+limit exceeded the candidate pool.
+//
+// This test deliberately does NOT use the shared f.tx fixture the rest of
+// this file uses: once a statement inside an explicit Postgres transaction
+// errors, the *whole transaction* is aborted and every later statement on
+// it fails too ("current transaction is aborted"), which would make the
+// fixed code's keyword-only re-query fail regardless of correctness — an
+// artifact of the transaction-per-test isolation technique, not of
+// production behavior. Production never wraps a request in an explicit
+// transaction (middleware.GetDB only does WithContext, never Begin), so
+// this test commits real rows and cleans them up manually instead.
+func TestSearch_Postgres_DegradesToKeywordOnlyWhenSemanticQueryFails(t *testing.T) {
+	db := openSearchTestPostgres(t)
+
+	unique := time.Now().UnixNano()
+	group := models.Group{Name: fmt.Sprintf("SearchTest-SemFail-%d", unique)}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	user := models.User{
+		Username: fmt.Sprintf("searchtest-semfail-%d", unique),
+		Email:    fmt.Sprintf("searchtest-semfail-%d@example.com", unique),
+		Password: "x",
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Create(&models.UserGroup{UserID: user.ID, GroupID: group.ID}).Error; err != nil {
+		t.Fatalf("add user to group: %v", err)
+	}
+	match := models.Animal{
+		GroupID: group.ID, Name: "Rex", Species: "Dog", Status: "available",
+		Description: "Shows resource guarding around food bowls.",
+	}
+	if err := db.Create(&match).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Unscoped().Delete(&match)
+		db.Unscoped().Where("user_id = ? AND group_id = ?", user.ID, group.ID).Delete(&models.UserGroup{})
+		db.Unscoped().Delete(&user)
+		db.Unscoped().Delete(&group)
+	})
+
+	// A real, correctly-sized embedding so the semantic query has at least
+	// one row to actually evaluate `embedding <=> ?` against — otherwise a
+	// dimension-mismatched query vector could return zero rows without
+	// Postgres ever raising the mismatch error.
+	if err := db.Exec(
+		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vectorWithOneAt(0)), match.ID,
+	).Error; err != nil {
+		t.Fatalf("failed to set animal embedding: %v", err)
+	}
+
+	// EmbedQuery succeeds (unlike the test above), but returns a vector of
+	// the wrong dimension, so the per-resource semantic query fails at the
+	// database level rather than at the embedding-call level.
+	wrongDimEmbedder := &fixedVectorEmbedder{vector: make([]float32, embedding.Dimension/2)}
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", user.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?"+url.Values{"q": {"resource guarding"}}.Encode(), nil)
+
+	Search(db, wrongDimEmbedder)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a failed semantic query must degrade to keyword-only results, not fail the request: %s", w.Body.String())
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 1 || animals[0].(map[string]interface{})["name"] != "Rex" {
+		t.Fatalf("expected keyword-only match for Rex despite semantic query failure, got: %v", animals)
+	}
+	if total, _ := body["total_animals"].(float64); total != 1 {
+		t.Fatalf("expected total_animals=1 (real keyword count), got %v", body["total_animals"])
+	}
+}
+
 func TestSearch_Postgres_KeywordOnlyModePreservesRealTsRankAndUnboundedPagination(t *testing.T) {
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -129,13 +129,21 @@ func newSearchTestFixture(t *testing.T, db *gorm.DB) *searchTestFixture {
 
 func (f *searchTestFixture) searchRequest(t *testing.T, groupID uint, query string) (*gin.Context, *httptest.ResponseRecorder) {
 	t.Helper()
+	return f.searchRequestWithParams(t, groupID, url.Values{"q": {query}})
+}
+
+// searchRequestWithParams builds a request with arbitrary query params (q,
+// type, limit, offset, ...), for tests that need more than the default
+// type=all search.
+func (f *searchTestFixture) searchRequestWithParams(t *testing.T, groupID uint, params url.Values) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Set("user_id", f.user.ID)
 	c.Set("is_admin", false)
 	c.Params = gin.Params{{Key: "id", Value: itoa(groupID)}}
-	c.Request = httptest.NewRequest(http.MethodGet, "/test?q="+url.QueryEscape(query), nil)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?"+params.Encode(), nil)
 	return c, w
 }
 
@@ -173,6 +181,7 @@ func TestSearch_Postgres_MatchReturnsExpectedResults(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(1), body["total_animals"], "total_animals must reflect the match count")
 	animals, _ := body["animals"].([]interface{})
 	if len(animals) != 1 {
 		t.Fatalf("expected exactly 1 matching animal, got %d: %v", len(animals), animals)
@@ -222,6 +231,7 @@ func TestSearch_Postgres_ExcludesCommentsOnDeletedAnimal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(1), body["total_comments"], "total_comments must exclude the deleted animal's comment, not just the returned page")
 	comments, _ := body["comments"].([]interface{})
 	if len(comments) != 1 {
 		t.Fatalf("expected exactly 1 comment (deleted animal's comment excluded), got %d: %v", len(comments), comments)
@@ -251,6 +261,7 @@ func TestSearch_Postgres_DoesNotLeakAcrossGroups(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(1), body["total_animals"], "total_animals must not count group B's matching animal")
 	animals, _ := body["animals"].([]interface{})
 	if len(animals) != 1 {
 		t.Fatalf("expected exactly 1 animal (only group A's), got %d: %v", len(animals), animals)
@@ -258,5 +269,166 @@ func TestSearch_Postgres_DoesNotLeakAcrossGroups(t *testing.T) {
 	got := animals[0].(map[string]interface{})
 	if got["name"] != "Rex" {
 		t.Fatalf("expected group A's Rex only — group B's Max must not leak into group A's search, got %v", got["name"])
+	}
+}
+
+func TestSearch_Postgres_TypeFilterScopesToRequestedResource(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	matchingAnimal := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Description: "Loves the playgroup.", Status: "available"}
+	if err := f.tx.Create(&matchingAnimal).Error; err != nil {
+		t.Fatalf("create matching animal: %v", err)
+	}
+	otherAnimal := models.Animal{GroupID: f.groupA.ID, Name: "Fido", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&otherAnimal).Error; err != nil {
+		t.Fatalf("create other animal: %v", err)
+	}
+	if err := f.tx.Create(&models.AnimalComment{
+		AnimalID: otherAnimal.ID,
+		UserID:   f.user.ID,
+		Content:  "Fido had a great playgroup session today.",
+	}).Error; err != nil {
+		t.Fatalf("create matching comment: %v", err)
+	}
+
+	t.Run("type=animals returns only animals, omits comments entirely", func(t *testing.T) {
+		c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "type": {"animals"}})
+		Search(f.tx)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := decodeSearchResponse(t, w)
+
+		assert.Equal(t, float64(1), body["total_animals"])
+		animals, _ := body["animals"].([]interface{})
+		if len(animals) != 1 {
+			t.Fatalf("expected exactly 1 animal, got %d: %v", len(animals), animals)
+		}
+		if _, present := body["comments"]; present {
+			t.Fatalf("expected no 'comments' key at all when type=animals, got %v", body["comments"])
+		}
+		if _, present := body["total_comments"]; present {
+			t.Fatalf("expected no 'total_comments' key at all when type=animals, got %v", body["total_comments"])
+		}
+	})
+
+	t.Run("type=comments returns only comments, omits animals entirely", func(t *testing.T) {
+		c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "type": {"comments"}})
+		Search(f.tx)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := decodeSearchResponse(t, w)
+
+		assert.Equal(t, float64(1), body["total_comments"])
+		comments, _ := body["comments"].([]interface{})
+		if len(comments) != 1 {
+			t.Fatalf("expected exactly 1 comment, got %d: %v", len(comments), comments)
+		}
+		if _, present := body["animals"]; present {
+			t.Fatalf("expected no 'animals' key at all when type=comments, got %v", body["animals"])
+		}
+		if _, present := body["total_animals"]; present {
+			t.Fatalf("expected no 'total_animals' key at all when type=comments, got %v", body["total_animals"])
+		}
+	})
+}
+
+func TestSearch_Postgres_PaginatesWithLimitAndOffset(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	for _, name := range []string{"Alpha", "Bravo", "Charlie"} {
+		a := models.Animal{GroupID: f.groupA.ID, Name: name, Species: "Dog", Description: "Loves the playgroup.", Status: "available"}
+		if err := f.tx.Create(&a).Error; err != nil {
+			t.Fatalf("create animal %s: %v", name, err)
+		}
+	}
+
+	c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "limit": {"2"}, "offset": {"0"}})
+	Search(f.tx)(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(3), body["total_animals"], "total_animals must reflect the full match count, not the page size")
+	firstPage, _ := body["animals"].([]interface{})
+	if len(firstPage) != 2 {
+		t.Fatalf("expected 2 animals on first page (limit=2, offset=0), got %d: %v", len(firstPage), firstPage)
+	}
+
+	c2, w2 := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "limit": {"2"}, "offset": {"2"}})
+	Search(f.tx)(c2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	body2 := decodeSearchResponse(t, w2)
+	assert.Equal(t, float64(3), body2["total_animals"], "total_animals on the second page must still reflect the full match count")
+	secondPage, _ := body2["animals"].([]interface{})
+	if len(secondPage) != 1 {
+		t.Fatalf("expected 1 animal on second page (limit=2, offset=2), got %d: %v", len(secondPage), secondPage)
+	}
+
+	// Ranks may legitimately tie here (all three descriptions are identical),
+	// so we don't assert which specific animals land on which page — only
+	// that limit/offset correctly partition the 3 matches with no overlap.
+	seenOnFirstPage := map[string]bool{}
+	for _, a := range firstPage {
+		seenOnFirstPage[a.(map[string]interface{})["name"].(string)] = true
+	}
+	for _, a := range secondPage {
+		name := a.(map[string]interface{})["name"].(string)
+		if seenOnFirstPage[name] {
+			t.Fatalf("animal %q appeared on both pages — limit/offset are not partitioning results correctly", name)
+		}
+	}
+}
+
+func TestSearch_Postgres_RanksMultipleMatchesByRelevance(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	// Distinct term-frequency of "resource guarding" in each animal's
+	// concatenated tsvector source gives ts_rank distinctly different (not
+	// tied) scores, so the resulting order is deterministic.
+	low := models.Animal{
+		GroupID: f.groupA.ID, Name: "LowRank", Species: "Dog", Status: "available",
+		Description: "Occasional resource guarding noted around mealtime.",
+	}
+	mid := models.Animal{
+		GroupID: f.groupA.ID, Name: "MidRank", Species: "Dog", Status: "available",
+		Description:  "Resource guarding around food.",
+		TrainerNotes: "Watch for resource guarding during group play.",
+	}
+	high := models.Animal{
+		GroupID: f.groupA.ID, Name: "HighRank", Species: "Dog", Status: "available",
+		Description:  "Severe resource guarding. Resource guarding around food, toys, and beds.",
+		TrainerNotes: "Resource guarding resource guarding — handle with extreme care.",
+	}
+	for _, a := range []*models.Animal{&low, &mid, &high} {
+		if err := f.tx.Create(a).Error; err != nil {
+			t.Fatalf("create animal %s: %v", a.Name, err)
+		}
+	}
+
+	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
+	Search(f.tx)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(3), body["total_animals"])
+
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 3 {
+		t.Fatalf("expected 3 matching animals, got %d: %v", len(animals), animals)
+	}
+	names := make([]string, len(animals))
+	ranks := make([]float64, len(animals))
+	for i, a := range animals {
+		row := a.(map[string]interface{})
+		names[i] = row["name"].(string)
+		ranks[i] = row["rank"].(float64)
+	}
+
+	if names[0] != "HighRank" || names[1] != "MidRank" || names[2] != "LowRank" {
+		t.Fatalf("expected rank order [HighRank, MidRank, LowRank], got %v (ranks: %v)", names, ranks)
+	}
+	if !(ranks[0] > ranks[1] && ranks[1] > ranks[2]) {
+		t.Fatalf("expected strictly decreasing ranks matching the returned order, got %v for %v", ranks, names)
 	}
 }

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -496,6 +496,10 @@ func TestSearch_Postgres_RanksMultipleMatchesByRelevance(t *testing.T) {
 }
 
 func TestSearch_Postgres_SemanticMatchSurfacesResultWithNoKeywordOverlap(t *testing.T) {
+	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — this test
+	// specifically needs semantic search active to exercise RRF fusion.
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)
 
@@ -548,6 +552,12 @@ func TestSearch_Postgres_SemanticMatchSurfacesResultWithNoKeywordOverlap(t *test
 }
 
 func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
+	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — must be
+	// explicitly enabled here, or Usable(embedder) would short-circuit on
+	// the flag alone and this test would never actually reach (and
+	// exercise) failingEmbedder's EmbedQuery failure below.
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)
 
@@ -591,6 +601,12 @@ func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
 // transaction (middleware.GetDB only does WithContext, never Begin), so
 // this test commits real rows and cleans them up manually instead.
 func TestSearch_Postgres_DegradesToKeywordOnlyWhenSemanticQueryFails(t *testing.T) {
+	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — must be
+	// explicitly enabled here, or Usable(embedder) would short-circuit on
+	// the flag alone and this test would never reach the per-resource
+	// semantic query it's meant to fail.
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
 	db := openSearchTestPostgres(t)
 
 	unique := time.Now().UnixNano()
@@ -813,6 +829,12 @@ func TestSearch_Postgres_MatchesUpdatesByKeyword(t *testing.T) {
 }
 
 func TestSearch_Postgres_DeepPaginationCoversResultsBeyondDefaultPool(t *testing.T) {
+	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — this test
+	// specifically exercises candidatePoolSize's growth, which only matters
+	// on the semantic/RRF-fusion path (applyPageOrPool ignores pool
+	// entirely once semanticAvailable is false), so it must be enabled here.
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)
 

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -663,6 +663,33 @@ func TestEmbedAnimalNow_Postgres_SkipsStaleWriteAfterConcurrentEdit(t *testing.T
 	}
 }
 
+// TestEmbedAnimalNow_Postgres_PersistsWhenNoConcurrentEdit complements
+// TestEmbedAnimalNow_Postgres_SkipsStaleWriteAfterConcurrentEdit's reject
+// path: it proves the "AND updated_at = ?" guard isn't so strict it also
+// discards the normal, non-conflicting case where nothing else has touched
+// the row since the embed text was captured.
+func TestEmbedAnimalNow_Postgres_PersistsWhenNoConcurrentEdit(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	animal := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	if err := embedAnimalNow(f.tx, &embedding.StubEmbedder{}, animal); err != nil {
+		t.Fatalf("embedAnimalNow returned an unexpected error: %v", err)
+	}
+
+	var embeddingIsNull bool
+	if err := f.tx.Raw("SELECT embedding IS NULL FROM animals WHERE id = ?", animal.ID).Scan(&embeddingIsNull).Error; err != nil {
+		t.Fatalf("query embedding: %v", err)
+	}
+	if embeddingIsNull {
+		t.Fatal("expected the embed write to persist since no concurrent edit landed, but embedding is still NULL")
+	}
+}
+
 func TestSearch_Postgres_MatchesUpdatesByKeyword(t *testing.T) {
 	db := openSearchTestPostgres(t)
 	f := newSearchTestFixture(t, db)

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -214,6 +214,9 @@ func (f *fixedVectorEmbedder) EmbedDocuments(ctx context.Context, texts []string
 func (f *fixedVectorEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
 	return f.vector, nil
 }
+func (f *fixedVectorEmbedder) IsConfigured() bool {
+	return true
+}
 
 func TestSearch_Postgres_MatchReturnsExpectedResults(t *testing.T) {
 	db := openSearchTestPostgres(t)
@@ -565,6 +568,98 @@ func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
 	animals, _ := body["animals"].([]interface{})
 	if len(animals) != 1 || animals[0].(map[string]interface{})["name"] != "Rex" {
 		t.Fatalf("expected keyword-only match for Rex despite embedder failure, got: %v", animals)
+	}
+}
+
+func TestSearch_Postgres_KeywordOnlyModePreservesRealTsRankAndUnboundedPagination(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	// Distinct term-frequency gives distinctly different (not tied) ts_rank
+	// values, so a position-only RRF score (which would only ever be
+	// 1/(60+1), 1/(60+2), ...) is distinguishable from the real ts_rank.
+	low := models.Animal{
+		GroupID: f.groupA.ID, Name: "LowRank", Species: "Dog", Status: "available",
+		Description: "Occasional resource guarding noted around mealtime.",
+	}
+	high := models.Animal{
+		GroupID: f.groupA.ID, Name: "HighRank", Species: "Dog", Status: "available",
+		Description:  "Severe resource guarding. Resource guarding around food, toys, and beds.",
+		TrainerNotes: "Resource guarding resource guarding — handle with extreme care.",
+	}
+	for _, a := range []*models.Animal{&low, &high} {
+		if err := f.tx.Create(a).Error; err != nil {
+			t.Fatalf("create animal %s: %v", a.Name, err)
+		}
+	}
+
+	// SEMANTIC_SEARCH_ENABLED=false forces the keyword-only path regardless
+	// of the embedder passed in, exercising the "flag off" degrade case
+	// specifically (as opposed to "embedder call failed").
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "false")
+
+	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
+	Search(f.tx, &embedding.StubEmbedder{})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 2 {
+		t.Fatalf("expected 2 matching animals, got %d: %v", len(animals), animals)
+	}
+
+	ranksByName := map[string]float64{}
+	for _, a := range animals {
+		row := a.(map[string]interface{})
+		ranksByName[row["name"].(string)] = row["rank"].(float64)
+	}
+
+	// A position-only RRF score for a 2-row keyword-only list would be
+	// 1/(60+1) ≈ 0.01639 and 1/(60+2) ≈ 0.01613 — close together regardless
+	// of actual relevance. The real ts_rank values for these two animals
+	// differ far more sharply (HighRank repeats the term many more times),
+	// so asserting the gap is larger than the RRF position-score gap proves
+	// the real ts_rank survived, not a position-derived substitute.
+	rrfPositionGap := 1.0/61.0 - 1.0/62.0
+	actualGap := ranksByName["HighRank"] - ranksByName["LowRank"]
+	if actualGap <= rrfPositionGap {
+		t.Fatalf("expected real ts_rank values (gap should exceed the RRF position-score gap of %v), got HighRank=%v LowRank=%v (gap=%v) — looks like a position-only score, not real ts_rank",
+			rrfPositionGap, ranksByName["HighRank"], ranksByName["LowRank"], actualGap)
+	}
+}
+
+func TestEmbedAnimalNow_Postgres_SkipsStaleWriteAfterConcurrentEdit(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	animal := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	// Capture the row's state as of creation — this simulates what a
+	// write-path embed goroutine captures before its (slow) embed API call.
+	staleAnimal := animal
+
+	// Simulate a second edit landing before that goroutine's embed call
+	// completes: bump updated_at by saving again.
+	if err := f.tx.Model(&animal).Update("name", "Rex Updated").Error; err != nil {
+		t.Fatalf("update animal: %v", err)
+	}
+
+	// Embed using the STALE captured copy (older updated_at) — this must be
+	// silently discarded rather than overwrite the row, since a newer edit
+	// has landed since this text was captured.
+	if err := embedAnimalNow(f.tx, &embedding.StubEmbedder{}, staleAnimal); err != nil {
+		t.Fatalf("embedAnimalNow returned an unexpected error: %v", err)
+	}
+
+	var embeddingIsNull bool
+	if err := f.tx.Raw("SELECT embedding IS NULL FROM animals WHERE id = ?", animal.ID).Scan(&embeddingIsNull).Error; err != nil {
+		t.Fatalf("query embedding: %v", err)
+	}
+	if !embeddingIsNull {
+		t.Fatal("expected the stale embed write to be discarded (embedding should still be NULL) since a newer edit landed after the embedded text was captured, but it was persisted anyway")
 	}
 }
 

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -1,0 +1,262 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/database"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// These tests exercise the Postgres-specific full-text search behavior
+// (tsvector/websearch_to_tsquery/GIN) that SQLite — used by every other test
+// in this package — can't run. They connect to a real Postgres instance
+// using the same DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_SSLMODE env vars the
+// app itself reads (see internal/database.Initialize), defaulting to a
+// dedicated "volunteer_media_test" database so a developer's real dev DB is
+// never touched by default. If nothing is listening, the whole suite skips —
+// `go test ./...` stays green without a database, matching how the e2e job
+// (.github/workflows/test.yml) is the only place in CI that provisions
+// Postgres. To run these locally: `docker compose up -d postgres_dev`, then
+// `DB_NAME=volunteer_media_dev go test ./internal/handlers/... -run Postgres -v`
+// (or create/point at a scratch "volunteer_media_test" database).
+func openSearchTestPostgres(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	host := envOrDefault("DB_HOST", "localhost")
+	port := envOrDefault("DB_PORT", "5432")
+
+	if !tcpReachable(host, port, 2*time.Second) {
+		t.Skipf("skipping: no Postgres reachable at %s:%s (run `docker compose up -d postgres_dev` to enable this test)", host, port)
+	}
+
+	user := envOrDefault("DB_USER", "postgres")
+	password := envOrDefault("DB_PASSWORD", "postgres")
+	dbname := envOrDefault("DB_NAME", "volunteer_media_test")
+	sslmode := envOrDefault("DB_SSLMODE", "disable")
+
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s connect_timeout=5",
+		host, port, user, password, dbname, sslmode)
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Skipf("skipping: could not connect to postgres database %q (%v) — create it or set DB_NAME to an existing scratch database", dbname, err)
+	}
+
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("failed to run migrations against test postgres: %v", err)
+	}
+
+	return db
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// tcpReachable is a fast pre-check so the common "no Postgres running"
+// case skips near-instantly (connection refused) instead of waiting out
+// the full Postgres client connect_timeout on every `go test ./...` run.
+func tcpReachable(host, port string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// searchTestFixture holds transaction-scoped test data. The transaction is
+// always rolled back (registered via t.Cleanup), so these tests never leave
+// data behind even when pointed at a real, shared database.
+type searchTestFixture struct {
+	tx     *gorm.DB
+	groupA models.Group
+	groupB models.Group
+	user   models.User
+}
+
+func newSearchTestFixture(t *testing.T, db *gorm.DB) *searchTestFixture {
+	t.Helper()
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+
+	unique := time.Now().UnixNano()
+
+	groupA := models.Group{Name: fmt.Sprintf("SearchTest-A-%d", unique)}
+	if err := tx.Create(&groupA).Error; err != nil {
+		t.Fatalf("create groupA: %v", err)
+	}
+	groupB := models.Group{Name: fmt.Sprintf("SearchTest-B-%d", unique)}
+	if err := tx.Create(&groupB).Error; err != nil {
+		t.Fatalf("create groupB: %v", err)
+	}
+
+	user := models.User{
+		Username: fmt.Sprintf("searchtest-%d", unique),
+		Email:    fmt.Sprintf("searchtest-%d@example.com", unique),
+		Password: "x",
+	}
+	if err := tx.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := tx.Create(&models.UserGroup{UserID: user.ID, GroupID: groupA.ID}).Error; err != nil {
+		t.Fatalf("add user to groupA: %v", err)
+	}
+	if err := tx.Create(&models.UserGroup{UserID: user.ID, GroupID: groupB.ID}).Error; err != nil {
+		t.Fatalf("add user to groupB: %v", err)
+	}
+
+	return &searchTestFixture{tx: tx, groupA: groupA, groupB: groupB, user: user}
+}
+
+func (f *searchTestFixture) searchRequest(t *testing.T, groupID uint, query string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", f.user.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(groupID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?q="+url.QueryEscape(query), nil)
+	return c, w
+}
+
+func decodeSearchResponse(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, w.Body.String())
+	}
+	return body
+}
+
+func TestSearch_Postgres_MatchReturnsExpectedResults(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	match := models.Animal{
+		GroupID:     f.groupA.ID,
+		Name:        "Rex",
+		Species:     "Dog",
+		Description: "Shows resource guarding around food bowls.",
+		Status:      "available",
+	}
+	if err := f.tx.Create(&match).Error; err != nil {
+		t.Fatalf("create matching animal: %v", err)
+	}
+	nonMatch := models.Animal{GroupID: f.groupA.ID, Name: "Fido", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&nonMatch).Error; err != nil {
+		t.Fatalf("create non-matching animal: %v", err)
+	}
+
+	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
+	Search(f.tx)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 1 {
+		t.Fatalf("expected exactly 1 matching animal, got %d: %v", len(animals), animals)
+	}
+	got := animals[0].(map[string]interface{})
+	if got["name"] != "Rex" {
+		t.Fatalf("expected match to be Rex, got %v", got["name"])
+	}
+}
+
+func TestSearch_Postgres_ExcludesCommentsOnDeletedAnimal(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	keptAnimal := models.Animal{GroupID: f.groupA.ID, Name: "Buddy", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&keptAnimal).Error; err != nil {
+		t.Fatalf("create kept animal: %v", err)
+	}
+	deletedAnimal := models.Animal{GroupID: f.groupA.ID, Name: "Ghost", Species: "Dog", Status: "available"}
+	if err := f.tx.Create(&deletedAnimal).Error; err != nil {
+		t.Fatalf("create animal to be deleted: %v", err)
+	}
+
+	if err := f.tx.Create(&models.AnimalComment{
+		AnimalID: keptAnimal.ID,
+		UserID:   f.user.ID,
+		Content:  "Great playgroup session today, no issues.",
+	}).Error; err != nil {
+		t.Fatalf("create comment on kept animal: %v", err)
+	}
+	if err := f.tx.Create(&models.AnimalComment{
+		AnimalID: deletedAnimal.ID,
+		UserID:   f.user.ID,
+		Content:  "Great playgroup session today, no issues either.",
+	}).Error; err != nil {
+		t.Fatalf("create comment on animal to be deleted: %v", err)
+	}
+
+	// Soft-delete, exactly as DeleteAnimal does.
+	if err := f.tx.Delete(&deletedAnimal).Error; err != nil {
+		t.Fatalf("soft-delete animal: %v", err)
+	}
+
+	c, w := f.searchRequest(t, f.groupA.ID, "playgroup")
+	Search(f.tx)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body := decodeSearchResponse(t, w)
+	comments, _ := body["comments"].([]interface{})
+	if len(comments) != 1 {
+		t.Fatalf("expected exactly 1 comment (deleted animal's comment excluded), got %d: %v", len(comments), comments)
+	}
+	got := comments[0].(map[string]interface{})
+	if got["animal_name"] != "Buddy" {
+		t.Fatalf("expected surviving comment to belong to Buddy, got %v", got["animal_name"])
+	}
+}
+
+func TestSearch_Postgres_DoesNotLeakAcrossGroups(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	inGroupA := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Description: "Loves the playgroup.", Status: "available"}
+	if err := f.tx.Create(&inGroupA).Error; err != nil {
+		t.Fatalf("create animal in group A: %v", err)
+	}
+	inGroupB := models.Animal{GroupID: f.groupB.ID, Name: "Max", Species: "Dog", Description: "Loves the playgroup.", Status: "available"}
+	if err := f.tx.Create(&inGroupB).Error; err != nil {
+		t.Fatalf("create animal in group B: %v", err)
+	}
+
+	c, w := f.searchRequest(t, f.groupA.ID, "playgroup")
+	Search(f.tx)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 1 {
+		t.Fatalf("expected exactly 1 animal (only group A's), got %d: %v", len(animals), animals)
+	}
+	got := animals[0].(map[string]interface{})
+	if got["name"] != "Rex" {
+		t.Fatalf("expected group A's Rex only — group B's Max must not leak into group A's search, got %v", got["name"])
+	}
+}

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/database"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -155,6 +157,62 @@ func decodeSearchResponse(t *testing.T, w *httptest.ResponseRecorder) map[string
 		t.Fatalf("decode response: %v (body: %s)", err, w.Body.String())
 	}
 	return body
+}
+
+// setAnimalEmbedding directly UPDATEs an animal's embedding column with a
+// hand-crafted vector, bypassing the real embedding pipeline so tests get
+// deterministic, controllable nearest-neighbor behavior instead of depending
+// on a real Voyage call or model output.
+func (f *searchTestFixture) setAnimalEmbedding(t *testing.T, animalID uint, vec []float32) {
+	t.Helper()
+	if err := f.tx.Exec(
+		"UPDATE animals SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vec), animalID,
+	).Error; err != nil {
+		t.Fatalf("failed to set animal embedding: %v", err)
+	}
+}
+
+func (f *searchTestFixture) setCommentEmbedding(t *testing.T, commentID uint, vec []float32) {
+	t.Helper()
+	if err := f.tx.Exec(
+		"UPDATE animal_comments SET embedding = ?, embedding_updated_at = now() WHERE id = ?",
+		pgvector.NewVector(vec), commentID,
+	).Error; err != nil {
+		t.Fatalf("failed to set comment embedding: %v", err)
+	}
+}
+
+// vectorWithOneAt returns a Dimension-length vector that is 1.0 at the given
+// index and 0 elsewhere — an orthogonal basis vector, so cosine distance
+// between vectorWithOneAt(i) and vectorWithOneAt(j) is deterministic and
+// maximal for i != j, and zero for i == i.
+func vectorWithOneAt(index int) []float32 {
+	v := make([]float32, embedding.Dimension)
+	v[index] = 1.0
+	return v
+}
+
+// fixedVectorEmbedder is an Embedder stub whose EmbedQuery always returns a
+// fixed vector, for tests that need to control exactly what the "query
+// embedding" is (rather than deriving it from the query text like
+// StubEmbedder does), to make a specific semantic match deterministic.
+type fixedVectorEmbedder struct {
+	vector []float32
+}
+
+func (f *fixedVectorEmbedder) EmbedDocument(ctx context.Context, text string) ([]float32, error) {
+	return f.vector, nil
+}
+func (f *fixedVectorEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = f.vector
+	}
+	return out, nil
+}
+func (f *fixedVectorEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	return f.vector, nil
 }
 
 func TestSearch_Postgres_MatchReturnsExpectedResults(t *testing.T) {
@@ -431,5 +489,99 @@ func TestSearch_Postgres_RanksMultipleMatchesByRelevance(t *testing.T) {
 	}
 	if !(ranks[0] > ranks[1] && ranks[1] > ranks[2]) {
 		t.Fatalf("expected strictly decreasing ranks matching the returned order, got %v for %v", ranks, names)
+	}
+}
+
+func TestSearch_Postgres_SemanticMatchSurfacesResultWithNoKeywordOverlap(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	// "Gets snappy near his bowl" shares zero keyword-search vocabulary with
+	// "resource guarding" — a pure keyword search would miss it. Its
+	// embedding is set to be identical to the query embedding.
+	semanticOnly := models.Animal{
+		GroupID: f.groupA.ID, Name: "Bowl", Species: "Dog", Status: "available",
+		Description: "Gets snappy near his bowl during mealtime.",
+	}
+	if err := f.tx.Create(&semanticOnly).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	f.setAnimalEmbedding(t, semanticOnly.ID, vectorWithOneAt(0))
+
+	noOverlap := models.Animal{GroupID: f.groupA.ID, Name: "Unrelated", Species: "Cat", Status: "available"}
+	if err := f.tx.Create(&noOverlap).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	f.setAnimalEmbedding(t, noOverlap.ID, vectorWithOneAt(500)) // orthogonal, far away
+
+	// fixedVectorEmbedder (defined above) forces the query embedding to
+	// exactly match semanticOnly's stored vector, making the semantic match
+	// deterministic without a real Voyage call.
+	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
+	Search(f.tx, &fixedVectorEmbedder{vector: vectorWithOneAt(0)})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	found := false
+	for _, a := range animals {
+		if a.(map[string]interface{})["name"] == "Bowl" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected semantic match \"Bowl\" to surface despite no keyword overlap, got animals: %v", animals)
+	}
+}
+
+func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	match := models.Animal{
+		GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Status: "available",
+		Description: "Shows resource guarding around food bowls.",
+	}
+	if err := f.tx.Create(&match).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+
+	failingEmbedder := &embedding.StubEmbedder{Err: fmt.Errorf("simulated Voyage outage")}
+	c, w := f.searchRequest(t, f.groupA.ID, "resource guarding")
+	Search(f.tx, failingEmbedder)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a failed query embedding must degrade to keyword-only results, not fail the request")
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 1 || animals[0].(map[string]interface{})["name"] != "Rex" {
+		t.Fatalf("expected keyword-only match for Rex despite embedder failure, got: %v", animals)
+	}
+}
+
+func TestSearch_Postgres_DeepPaginationCoversResultsBeyondDefaultPool(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	// 60 matching animals — more than the 50-row default candidate pool
+	// floor — to prove candidatePoolSize actually grows for a deep offset.
+	for i := 0; i < 60; i++ {
+		a := models.Animal{
+			GroupID: f.groupA.ID, Name: fmt.Sprintf("Animal%02d", i), Species: "Dog", Status: "available",
+			Description: "Loves the playgroup.",
+		}
+		if err := f.tx.Create(&a).Error; err != nil {
+			t.Fatalf("create animal %d: %v", i, err)
+		}
+	}
+
+	c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"playgroup"}, "limit": {"10"}, "offset": {"55"}})
+	Search(f.tx, &embedding.StubEmbedder{})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	assert.Equal(t, float64(60), body["total_animals"])
+	animals, _ := body["animals"].([]interface{})
+	if len(animals) != 5 {
+		t.Fatalf("expected 5 animals on the last partial page (60 total, offset=55, limit=10), got %d: %v", len(animals), animals)
 	}
 }

--- a/internal/handlers/search_rank.go
+++ b/internal/handlers/search_rank.go
@@ -46,9 +46,14 @@ const (
 )
 
 // candidatePoolSize returns how many top matches to fetch from each of the
-// keyword and semantic queries before fusing. It must cover the requested
-// page (offset+limit), or a deep "load more" page would run out of fused
-// candidates even though more matches exist in the database.
+// keyword and semantic queries before fusing. Ideally it covers the
+// requested page (offset+limit), so a "load more" page doesn't run out of
+// fused candidates even though more matches exist in the database — but
+// it's capped at maxCandidatePool regardless, trading unbounded pagination
+// depth in semantic mode (once offset+limit exceeds the cap, results
+// beyond position maxCandidatePool become unreachable, unlike keyword-only
+// mode's real, uncapped Limit/Offset pagination) for a bounded per-request
+// cost against the two source queries.
 func candidatePoolSize(offset, limit int) int {
 	needed := offset + limit
 	switch {

--- a/internal/handlers/search_rank.go
+++ b/internal/handlers/search_rank.go
@@ -1,0 +1,62 @@
+package handlers
+
+import "sort"
+
+// rrfK is Reciprocal Rank Fusion's standard smoothing constant. RRF combines
+// two differently-scaled ranked lists (ts_rank and cosine distance aren't on
+// comparable scales) by rank position instead of raw score, so no tuning is
+// needed to start.
+const rrfK = 60
+
+// fuseRankedIDs merges two rank-ordered ID lists (best match first) via
+// Reciprocal Rank Fusion: score(id) = sum over lists containing id of
+// 1/(rrfK + rank), where rank is the 1-based position in that list. An ID
+// absent from a list contributes 0 for that list's term. Returns IDs ordered
+// by combined score highest-first, ties broken by ID ascending so the result
+// is deterministic, plus the score behind each ID (exposed so callers can
+// surface it, e.g. as the API's per-row "rank" field).
+func fuseRankedIDs(keywordIDs, semanticIDs []uint) (ordered []uint, scores map[uint]float64) {
+	scores = make(map[uint]float64, len(keywordIDs)+len(semanticIDs))
+	for i, id := range keywordIDs {
+		scores[id] += 1.0 / float64(rrfK+i+1)
+	}
+	for i, id := range semanticIDs {
+		scores[id] += 1.0 / float64(rrfK+i+1)
+	}
+
+	ordered = make([]uint, 0, len(scores))
+	for id := range scores {
+		ordered = append(ordered, id)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if scores[ordered[i]] != scores[ordered[j]] {
+			return scores[ordered[i]] > scores[ordered[j]]
+		}
+		return ordered[i] < ordered[j]
+	})
+	return ordered, scores
+}
+
+// Candidate pool bounds: floor covers the common case (a first page of
+// normal-sized results) with room for the two ranked lists to actually
+// overlap; cap bounds the cost of a very large offset.
+const (
+	minCandidatePool = 50
+	maxCandidatePool = 500
+)
+
+// candidatePoolSize returns how many top matches to fetch from each of the
+// keyword and semantic queries before fusing. It must cover the requested
+// page (offset+limit), or a deep "load more" page would run out of fused
+// candidates even though more matches exist in the database.
+func candidatePoolSize(offset, limit int) int {
+	needed := offset + limit
+	switch {
+	case needed < minCandidatePool:
+		return minCandidatePool
+	case needed > maxCandidatePool:
+		return maxCandidatePool
+	default:
+		return needed
+	}
+}

--- a/internal/handlers/search_rank_test.go
+++ b/internal/handlers/search_rank_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuseRankedIDs_UnionsAndOrdersByCombinedScore(t *testing.T) {
+	// ID 1: keyword rank 1 (best), absent from semantic.
+	// ID 2: keyword rank 2, semantic rank 1 (best) — should outrank ID 1
+	//       since it scores on both lists.
+	// ID 3: absent from keyword, semantic rank 2.
+	keyword := []uint{1, 2}
+	semantic := []uint{2, 3}
+
+	ordered, scores := fuseRankedIDs(keyword, semantic)
+
+	want := []uint{2, 1, 3}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("expected order %v, got %v", want, ordered)
+	}
+
+	// ID 2's score: keyword rank 2 (1/(60+2)) + semantic rank 1 (1/(60+1)).
+	expectedID2 := 1.0/62.0 + 1.0/61.0
+	if got := scores[2]; got < expectedID2-1e-15 || got > expectedID2+1e-15 {
+		t.Fatalf("expected score[2] == %v, got %v", expectedID2, got)
+	}
+}
+
+func TestFuseRankedIDs_TiesBrokenByIDAscending(t *testing.T) {
+	// Two IDs that appear in neither list together — same score (both rank 1
+	// in their respective single list) — must be ordered deterministically.
+	ordered, _ := fuseRankedIDs([]uint{5}, []uint{3})
+	want := []uint{3, 5}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("expected tie-break order %v, got %v", want, ordered)
+	}
+}
+
+func TestFuseRankedIDs_EmptyListsReturnEmpty(t *testing.T) {
+	ordered, scores := fuseRankedIDs(nil, nil)
+	if len(ordered) != 0 {
+		t.Fatalf("expected empty result, got %v", ordered)
+	}
+	if len(scores) != 0 {
+		t.Fatalf("expected empty scores map, got %v", scores)
+	}
+}
+
+func TestFuseRankedIDs_OnlyKeyword(t *testing.T) {
+	ordered, _ := fuseRankedIDs([]uint{10, 20, 30}, nil)
+	want := []uint{10, 20, 30}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("expected keyword-only order preserved: %v, got %v", want, ordered)
+	}
+}
+
+func TestCandidatePoolSize_FloorsAtMinimum(t *testing.T) {
+	if got := candidatePoolSize(0, 10); got != 50 {
+		t.Fatalf("expected floor of 50 for offset=0,limit=10, got %d", got)
+	}
+}
+
+func TestCandidatePoolSize_GrowsToCoverDeepPage(t *testing.T) {
+	if got := candidatePoolSize(200, 10); got != 210 {
+		t.Fatalf("expected pool of 210 to cover offset=200,limit=10, got %d", got)
+	}
+}
+
+func TestCandidatePoolSize_CapsAtMaximum(t *testing.T) {
+	if got := candidatePoolSize(10000, 100); got != 500 {
+		t.Fatalf("expected pool capped at 500, got %d", got)
+	}
+}

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSearch_ForbiddenWhenNoGroupAccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := SetupTestDB(t)
+
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	CreateTestUser(t, db, "outsider", "outsider@example.com", "password123", false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", uint(999))
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?q=guarding", nil)
+
+	Search(db)(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestSearch_BadRequestWhenTypeInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := SetupTestDB(t)
+
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	user := CreateTestUser(t, db, "member", "member@example.com", "password123", false)
+	AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", user.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?q=guarding&type=bogus", nil)
+
+	Search(db)(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSearch_BadRequestWhenQueryMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := SetupTestDB(t)
+
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	user := CreateTestUser(t, db, "member", "member@example.com", "password123", false)
+	AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", user.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	Search(db)(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 )
 
 func TestSearch_ForbiddenWhenNoGroupAccess(t *testing.T) {
@@ -22,7 +23,7 @@ func TestSearch_ForbiddenWhenNoGroupAccess(t *testing.T) {
 	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
 	c.Request = httptest.NewRequest(http.MethodGet, "/test?q=guarding", nil)
 
-	Search(db)(c)
+	Search(db, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", w.Code)
@@ -44,7 +45,7 @@ func TestSearch_BadRequestWhenTypeInvalid(t *testing.T) {
 	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
 	c.Request = httptest.NewRequest(http.MethodGet, "/test?q=guarding&type=bogus", nil)
 
-	Search(db)(c)
+	Search(db, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -66,7 +67,7 @@ func TestSearch_BadRequestWhenQueryMissing(t *testing.T) {
 	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
 	c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
 
-	Search(db)(c)
+	Search(db, &embedding.StubEmbedder{})(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -52,6 +52,28 @@ func TestSearch_BadRequestWhenTypeInvalid(t *testing.T) {
 	}
 }
 
+func TestSearch_TypeUpdatesIsAccepted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := SetupTestDB(t)
+
+	group := CreateTestGroup(t, db, "Dogs", "Dog group")
+	user := CreateTestUser(t, db, "member", "member@example.com", "password123", false)
+	AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("user_id", user.ID)
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: itoa(group.ID)}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/test?q=guarding&type=updates", nil)
+
+	Search(db, &embedding.StubEmbedder{})(c)
+
+	if w.Code == http.StatusBadRequest {
+		t.Fatalf("expected type=updates to be accepted, got 400: %s", w.Body.String())
+	}
+}
+
 func TestSearch_BadRequestWhenQueryMissing(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := SetupTestDB(t)

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -69,8 +70,18 @@ func TestSearch_TypeUpdatesIsAccepted(t *testing.T) {
 
 	Search(db, &embedding.StubEmbedder{})(c)
 
-	if w.Code == http.StatusBadRequest {
-		t.Fatalf("expected type=updates to be accepted, got 400: %s", w.Body.String())
+	// This only exercises the request-validation layer (the validTypes map
+	// in Search): SetupTestDB is SQLite, which can't execute the
+	// Postgres-only search_vector/websearch_to_tsquery SQL the handler runs
+	// past validation, so a DB-layer 500 here is expected and not itself a
+	// failure — checking w.Code != 400 alone can't distinguish "updates
+	// passed validation" from "updates was rejected as invalid," so assert
+	// specifically against the type-validation error message. Full
+	// end-to-end coverage of type=updates (real matches, real ranking) is
+	// in search_postgres_test.go's TestSearch_Postgres_MatchesUpdatesByKeyword,
+	// which runs against a real Postgres instance.
+	if w.Code == http.StatusBadRequest && strings.Contains(w.Body.String(), "type must be one of") {
+		t.Fatalf("expected type=updates to pass validation, got 400: %s", w.Body.String())
 	}
 }
 

--- a/internal/handlers/update.go
+++ b/internal/handlers/update.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/groupme"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
@@ -48,8 +49,14 @@ func GetUpdates(db *gorm.DB) gin.HandlerFunc {
 }
 
 // CreateUpdate creates a new update/post in a group
-func CreateUpdate(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service) gin.HandlerFunc {
+func CreateUpdate(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service, embedder embedding.Embedder) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// rawDB is captured before the shadow below so the detached goroutine
+		// spawned by embedUpdateAsync gets the unscoped db, not one bound to
+		// this request's context (which is canceled the instant this handler
+		// returns). See the same pattern in animal_crud.go's
+		// sendQuarantineNotificationEmail usage.
+		rawDB := db
 		db := middleware.GetDB(c, db)
 		groupID := c.Param("id")
 		userID, _ := c.Get("user_id")
@@ -107,6 +114,8 @@ func CreateUpdate(db *gorm.DB, emailService *email.Service, groupMeService *grou
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create update"})
 			return
 		}
+
+		embedUpdateAsync(rawDB, embedder, update)
 
 		// Reload with user info
 		if err := db.Preload("User").First(&update, update.ID).Error; err != nil {

--- a/internal/handlers/update.go
+++ b/internal/handlers/update.go
@@ -126,7 +126,7 @@ func CreateUpdate(db *gorm.DB, emailService *email.Service, groupMeService *grou
 		if req.SendEmail && emailService != nil && emailService.IsConfigured() {
 			go func() {
 				bgCtx := context.Background()
-				if err := sendGroupAnnouncementEmails(bgCtx, db, emailService, uint(gid), update.Title, update.Content); err != nil {
+				if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, uint(gid), update.Title, update.Content); err != nil {
 					logging.WithContext(bgCtx).Error("Error sending group update emails", err)
 				}
 			}()
@@ -137,7 +137,7 @@ func CreateUpdate(db *gorm.DB, emailService *email.Service, groupMeService *grou
 			// Use background context for async GroupMe sending
 			go func() {
 				bgCtx := context.Background()
-				if err := sendUpdateToGroupMe(bgCtx, db, groupMeService, uint(gid), update.Title, update.Content); err != nil {
+				if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, uint(gid), update.Title, update.Content); err != nil {
 					logging.WithContext(bgCtx).Error("Error sending update to GroupMe", err)
 				}
 			}()

--- a/internal/handlers/update_test.go
+++ b/internal/handlers/update_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/groupme"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,22 @@ func setupUpdateTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)
 	}
+
+	// IMPORTANT: SQLite in-memory databases are per-connection. Without
+	// capping the pool to a single connection, database/sql may open a
+	// second physical connection to service a concurrent caller (e.g. the
+	// detached goroutine embedUpdateAsync spawns) — and since ":memory:"
+	// isn't shared-cache here, that second connection is a distinct, blank,
+	// unmigrated database, producing intermittent "no such table: updates"
+	// errors. Forcing a single connection makes the pool serialize access
+	// instead, matching the pattern in setupAnimalCommentTestDB
+	// (animal_comment_test.go).
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get database instance: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 
 	// Migrate models
 	err = db.AutoMigrate(
@@ -203,7 +220,7 @@ func TestCreateUpdate(t *testing.T) {
 			tt.setupContext(c)
 
 			// Execute
-			handler := CreateUpdate(db, email.NewService(db), groupme.NewService())
+			handler := CreateUpdate(db, email.NewService(db), groupme.NewService(), &embedding.StubEmbedder{})
 			handler(c)
 
 			// Assert
@@ -240,7 +257,7 @@ func TestCreateUpdateWithSendEmailFlagForNonAdminIsForcedFalse(t *testing.T) {
 	c.Set("is_admin", false)
 	c.Params = gin.Params{{Key: "id", Value: "1"}}
 
-	handler := CreateUpdate(db, email.NewService(db), groupme.NewService())
+	handler := CreateUpdate(db, email.NewService(db), groupme.NewService(), &embedding.StubEmbedder{})
 	handler(c)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -264,6 +281,14 @@ func TestCreateUpdateWithSendEmailFlagForGroupAdminIsAllowed(t *testing.T) {
 		sqlDB, _ := db.DB()
 		sqlDB.Close()
 	}()
+
+	// See setupUpdateTestDB's comment: caps the pool to a single connection
+	// so the embedUpdateAsync goroutine can't race this test onto a second,
+	// unmigrated in-memory SQLite connection.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Group{}, &models.Update{}, &models.UserGroup{}))
 
@@ -290,7 +315,7 @@ func TestCreateUpdateWithSendEmailFlagForGroupAdminIsAllowed(t *testing.T) {
 	c.Set("is_admin", false)
 	c.Params = gin.Params{{Key: "id", Value: strconv.FormatUint(uint64(group.ID), 10)}}
 
-	handler := CreateUpdate(db, email.NewService(db), groupme.NewService())
+	handler := CreateUpdate(db, email.NewService(db), groupme.NewService(), &embedding.StubEmbedder{})
 	handler(c)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -325,7 +350,7 @@ func TestCreateUpdateWithSendEmailFlagForSiteAdminIsAllowed(t *testing.T) {
 	c.Set("is_admin", true)
 	c.Params = gin.Params{{Key: "id", Value: "1"}}
 
-	handler := CreateUpdate(db, email.NewService(db), groupme.NewService())
+	handler := CreateUpdate(db, email.NewService(db), groupme.NewService(), &embedding.StubEmbedder{})
 	handler(c)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -341,6 +366,14 @@ func setupDeleteUpdateTestDB(t *testing.T) (*gorm.DB, models.User, models.User, 
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+
+	// See setupUpdateTestDB's comment: caps the pool to a single connection
+	// for consistency with the other Update test helpers, even though
+	// DeleteUpdate itself doesn't spawn the embedding goroutine.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 
 	err = db.AutoMigrate(
 		&models.User{},

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -255,6 +255,39 @@ type AnimalComment struct {
 	User      User             `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }
 
+// NonDeletedAnimalCommentsQuery scopes a query to AnimalComment rows whose
+// parent animal is not soft-deleted. GORM's soft-delete scope only
+// auto-applies to the query's primary model (animal_comments) — the joined
+// animals table needs this explicit check, or comments on a deleted animal
+// leak through. Shared by internal/handlers/search.go and
+// internal/embedding/sweep.go (which can't import each other) so the two
+// call sites can't drift out of sync with each other.
+func NonDeletedAnimalCommentsQuery(db *gorm.DB) *gorm.DB {
+	return db.Model(&AnimalComment{}).
+		Joins("JOIN animals ON animals.id = animal_comments.animal_id").
+		Where("animals.deleted_at IS NULL")
+}
+
+// NonDeletedGroupAnimalsQuery scopes a query to Animal rows whose parent
+// group is not soft-deleted. GORM's soft-delete scope only auto-applies to
+// the query's primary model (animals) — DeleteGroup soft-deletes only the
+// Group row with no cascade to its animals, so without this join an
+// animal under a deleted group is never itself soft-deleted and stays
+// perpetually visible (e.g. to the reconciliation sweep, which would
+// otherwise re-embed it forever).
+func NonDeletedGroupAnimalsQuery(db *gorm.DB) *gorm.DB {
+	return db.Model(&Animal{}).
+		Joins("JOIN groups ON groups.id = animals.group_id").
+		Where("groups.deleted_at IS NULL")
+}
+
+// NonDeletedGroupUpdatesQuery mirrors NonDeletedGroupAnimalsQuery for updates.
+func NonDeletedGroupUpdatesQuery(db *gorm.DB) *gorm.DB {
+	return db.Model(&Update{}).
+		Joins("JOIN groups ON groups.id = updates.group_id").
+		Where("groups.deleted_at IS NULL")
+}
+
 // CommentHistory stores the history of comment edits
 // Each entry is a snapshot of a previous version of the comment
 type CommentHistory struct {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -348,6 +348,17 @@ resource "azurerm_container_app" "main" {
         value = var.resend_from_email
       }
 
+      # Semantic Search (Voyage AI embeddings)
+      env {
+        name        = "VOYAGE_API_KEY"
+        secret_name = "voyage-api-key"
+      }
+
+      env {
+        name  = "SEMANTIC_SEARCH_ENABLED"
+        value = var.semantic_search_enabled ? "true" : "false"
+      }
+
       # Azure Storage Configuration
       env {
         name  = "AZURE_STORAGE_ACCOUNT"
@@ -420,6 +431,11 @@ resource "azurerm_container_app" "main" {
   secret {
     name  = "resend-api-key"
     value = var.resend_api_key
+  }
+
+  secret {
+    name  = "voyage-api-key"
+    value = var.voyage_api_key
   }
 
   secret {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -181,6 +181,21 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
   collation = "en_US.utf8"
 }
 
+# Extension allow-list. Azure Flexible Server only permits CREATE EXTENSION
+# for extensions named here — the app's migrations (internal/database's
+# createCustomIndexes) run `CREATE EXTENSION IF NOT EXISTS pg_trgm` (typo-
+# tolerant search) and `CREATE EXTENSION IF NOT EXISTS vector` (pgvector,
+# semantic search) as best-effort/warn-only DDL, so without this the
+# extensions silently fail to create and the features they back silently
+# degrade — no deploy failure, no obvious error, just a missing index. This
+# resource is a full replace, not additive: any extension the app needs must
+# be listed here, not appended via `az postgres flexible-server parameter set`.
+resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "pg_trgm,vector"
+}
+
 # Storage Account for image uploads
 resource "azurerm_storage_account" "main" {
   name                = "st${replace(var.project_name, "-", "")}${var.environment}"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -196,6 +196,20 @@ variable "resend_from_email" {
   }
 }
 
+# Semantic Search (Voyage AI embeddings)
+variable "voyage_api_key" {
+  type        = string
+  description = "Voyage AI API key for semantic search embeddings. Optional — leave empty to keep semantic search disabled (keyword-only search still works)."
+  sensitive   = true
+  default     = ""
+}
+
+variable "semantic_search_enabled" {
+  type        = bool
+  description = "Whether to enable semantic (embedding-based) search. Defaults to false so setting voyage_api_key alone doesn't silently turn it on — flip explicitly once ready."
+  default     = false
+}
+
 # Axiom / OpenTelemetry Configuration
 variable "axiom_api_token" {
   type        = string

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -349,6 +349,17 @@ resource "azurerm_container_app" "main" {
         value = var.frontend_url
       }
 
+      # Semantic Search (Voyage AI embeddings)
+      env {
+        name        = "VOYAGE_API_KEY"
+        secret_name = "voyage-api-key"
+      }
+
+      env {
+        name  = "SEMANTIC_SEARCH_ENABLED"
+        value = var.semantic_search_enabled ? "true" : "false"
+      }
+
       # Storage (Azure Blob)
       env {
         name  = "STORAGE_PROVIDER"
@@ -411,6 +422,11 @@ resource "azurerm_container_app" "main" {
   secret {
     name  = "resend-api-key"
     value = var.resend_api_key
+  }
+
+  secret {
+    name  = "voyage-api-key"
+    value = var.voyage_api_key
   }
 
   secret {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -176,6 +176,21 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
   collation = "en_US.utf8"
 }
 
+# Extension allow-list. Azure Flexible Server only permits CREATE EXTENSION
+# for extensions named here — the app's migrations (internal/database's
+# createCustomIndexes) run `CREATE EXTENSION IF NOT EXISTS pg_trgm` (typo-
+# tolerant search) and `CREATE EXTENSION IF NOT EXISTS vector` (pgvector,
+# semantic search) as best-effort/warn-only DDL, so without this the
+# extensions silently fail to create and the features they back silently
+# degrade — no deploy failure, no obvious error, just a missing index. This
+# resource is a full replace, not additive: any extension the app needs must
+# be listed here, not appended via `az postgres flexible-server parameter set`.
+resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "pg_trgm,vector"
+}
+
 # Storage Account for image uploads
 resource "azurerm_storage_account" "main" {
   name                = "st${replace(var.project_name, "-", "")}${var.environment}"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -200,6 +200,20 @@ variable "resend_from_name" {
   default     = "MyHAWS"
 }
 
+# Semantic Search (Voyage AI embeddings)
+variable "voyage_api_key" {
+  type        = string
+  description = "Voyage AI API key for semantic search embeddings. Optional — leave empty to keep semantic search disabled (keyword-only search still works)."
+  sensitive   = true
+  default     = ""
+}
+
+variable "semantic_search_enabled" {
+  type        = bool
+  description = "Whether to enable semantic (embedding-based) search. Defaults to false so setting voyage_api_key alone doesn't silently turn it on — flip explicitly once ready."
+  default     = false
+}
+
 # Axiom / OpenTelemetry Configuration
 variable "axiom_api_token" {
   type        = string


### PR DESCRIPTION
## Summary

- Adds Postgres full-text keyword search over animals and comments (`GET /groups/:id/search`), with a `GroupSearch` UI mounted on the activity and animals tabs.
- Extends that endpoint with semantic (embedding) search: a new `internal/embedding` package wraps Voyage AI behind a provider-agnostic `Embedder` interface, pgvector columns on `animals`/`animal_comments`/`updates` are populated by an async write-path goroutine plus a periodic reconciliation sweep (handles backfill and retry), and keyword + semantic results per resource are merged via Reciprocal Rank Fusion before pagination.
- Adds `updates` (the group page's "Post Announcement" button) as a third searchable resource, alongside animals and comments. The separate, unrelated `Announcement` admin broadcast tool is explicitly out of scope.
- `SEMANTIC_SEARCH_ENABLED` env var acts as a cost kill switch — disables all Voyage calls and degrades cleanly to keyword-only search; re-enabling requires no manual backfill.
- No hard dependency on Voyage anywhere: a disabled flag, an unconfigured embedder, or a failed embed call all degrade to keyword-only ranking rather than failing the request.

## Test plan

- [x] `go build -tags dev ./...` and `go vet -tags dev ./...` clean
- [x] Full `go test ./...` passes (one pre-existing, unrelated failure: `TestCreateGroup/accepts_valid_GroupMe_bot_id`)
- [x] Postgres-gated test suites (`internal/handlers`, `internal/database`, `internal/embedding`) pass against a real `pgvector/pgvector:pg15` instance — keyword matching, semantic matching with no shared vocabulary, degrade-on-embedder-failure, deep pagination, reconciliation sweep backfill/retry, and the optimistic-concurrency lost-update guard are all covered
- [x] Frontend `GroupSearch.test.tsx` (13/13) and `tsc -b` (no new errors) pass
- [x] Manual end-to-end verification against a live server + real Postgres: migration boot logs, authenticated search over animals/updates via real HTTP, and the kill switch's degrade path
- [x] Two independent multi-angle code reviews (a final whole-branch review, then a dedicated 8-angle `/code-review` pass) — all findings addressed or explicitly deferred with documented tradeoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)