### PR TITLE
Make voyage-api-key Container App secret optional

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -366,9 +366,12 @@ resource "azurerm_container_app" "main" {
       }
 
       # Semantic Search (Voyage AI embeddings)
-      env {
-        name        = "VOYAGE_API_KEY"
-        secret_name = "voyage-api-key"
+      dynamic "env" {
+        for_each = var.voyage_api_key != "" ? [1] : []
+        content {
+          name        = "VOYAGE_API_KEY"
+          secret_name = "voyage-api-key"
+        }
       }
 
       env {
@@ -455,9 +458,12 @@ resource "azurerm_container_app" "main" {
     value = var.resend_api_key
   }
 
-  secret {
-    name  = "voyage-api-key"
-    value = var.voyage_api_key
+  dynamic "secret" {
+    for_each = var.voyage_api_key != "" ? [var.voyage_api_key] : []
+    content {
+      name  = "voyage-api-key"
+      value = secret.value
+    }
   }
 
   secret {


### PR DESCRIPTION
## Summary
- Dev's Container App apply was failing with `ContainerAppSecretInvalid` because the `voyage-api-key` secret was always declared with `var.voyage_api_key`'s value, but that variable is documented as optional (empty string disables semantic search) — Azure rejects a secret with an empty value.
- Wraps the `voyage-api-key` `secret` block and the `VOYAGE_API_KEY` `env` block in `dynamic` blocks so they're only created when `var.voyage_api_key` is non-empty.

Root cause of the specific failed run was actually a case-mismatch in the Terraform Cloud workspace variables (`VOYAGE_API_KEY`/`SEMANTIC_SEARCH_ENABLED` vs. the declared `voyage_api_key`/`semantic_search_enabled`), which the user has already corrected in the workspace. This PR fixes the underlying code so an unset key doesn't break the deploy going forward, regardless of workspace config.

## Test plan
- [x] `terraform validate` passes in `terraform/environments/dev`
- [ ] Terraform Cloud apply succeeds in dev with `voyage_api_key` set
- [ ] Terraform Cloud apply succeeds in dev with `voyage_api_key` left empty (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)