### PR TITLE
Fix semantic search relevance and comment search deep-linking

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -396,6 +396,7 @@ func main() {
 			group.PUT("/animals/:animalId/comments/:commentId", handlers.UpdateAnimalComment(db, embedder))
 			group.DELETE("/animals/:animalId/comments/:commentId", handlers.DeleteAnimalComment(db))
 			group.GET("/animals/:animalId/comments/:commentId/history", handlers.GetCommentHistory(db))
+			group.GET("/animals/:animalId/comments/:commentId/position", handlers.GetAnimalCommentPosition(db))
 
 			// Latest comments across the group
 			group.GET("/latest-comments", handlers.GetGroupLatestComments(db))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -357,6 +357,10 @@ export interface PaginatedCommentsResponse {
   hasMore: boolean;
 }
 
+export type CommentPositionResponse =
+  | { found: true; offset: number }
+  | { found: false };
+
 export interface CommentWithAnimal extends AnimalComment {
   animal: Animal;
 }
@@ -758,6 +762,18 @@ export const animalCommentsApi = {
     api.get<AnimalComment[]>('/admin/groups/' + groupId + '/deleted-comments'),
   getHistory: (groupId: number, animalId: number, commentId: number) =>
     api.get<CommentHistory[]>('/groups/' + groupId + '/animals/' + animalId + '/comments/' + commentId + '/history'),
+  // Looks up which page a comment falls on under a given tagFilter/order, so
+  // a deep link to a specific comment can jump straight to its page in one
+  // request instead of paging through every prior page to find it.
+  getPosition: (groupId: number, animalId: number, commentId: number, options?: {
+    tagFilter?: string;
+    order?: 'asc' | 'desc';
+  }) => {
+    const params: Record<string, string> = {};
+    if (options?.tagFilter) params.tags = options.tagFilter;
+    if (options?.order) params.order = options.order;
+    return api.get<CommentPositionResponse>('/groups/' + groupId + '/animals/' + animalId + '/comments/' + commentId + '/position', { params });
+  },
 };
 
 // Comment Tags API - Group-specific tags

--- a/frontend/src/components/ActivityItem.tsx
+++ b/frontend/src/components/ActivityItem.tsx
@@ -86,8 +86,8 @@ const ActivityItem: React.FC<ActivityItemProps> = ({ item, groupId, onImageClick
         {/* Animal link for comments */}
         {item.type === 'comment' && item.animal && (
           <div className="activity-item__animal-link">
-            <Link 
-              to={`/groups/${groupId}/animals/${item.animal_id}/view`}
+            <Link
+              to={`/groups/${groupId}/animals/${item.animal_id}/view?comment=${item.id}`}
               className="activity-item__animal-name"
             >
               {item.animal.image_url && (
@@ -149,8 +149,8 @@ const ActivityItem: React.FC<ActivityItemProps> = ({ item, groupId, onImageClick
       {/* Footer with action buttons */}
       <div className="activity-item__footer">
         {item.type === 'comment' && item.animal && (
-          <Link 
-            to={`/groups/${groupId}/animals/${item.animal_id}/view`}
+          <Link
+            to={`/groups/${groupId}/animals/${item.animal_id}/view?comment=${item.id}`}
             className="activity-item__action-link"
           >
             View animal

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -261,7 +261,7 @@ const GroupSearch: React.FC<GroupSearchProps> = ({ groupId }) => {
                 {comments.map((comment) => (
                   <li key={comment.id}>
                     <Link
-                      to={`/groups/${groupId}/animals/${comment.animal_id}/view`}
+                      to={`/groups/${groupId}/animals/${comment.animal_id}/view?comment=${comment.id}`}
                       className="group-search__comment-result"
                     >
                       <span className="group-search__comment-animal">on {comment.animal_name}</span>

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -719,33 +719,27 @@
 }
 
 .comment-card--highlighted {
+  --comment-highlight-bg: var(--brand-100, #d7f0e8);
+  --comment-highlight-ring: var(--brand, #0e6c55);
+  --comment-highlight-end-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   animation: comment-highlight-fade 2.5s ease-out;
 }
 
 @keyframes comment-highlight-fade {
   0% {
-    background: var(--brand-100, #d7f0e8);
-    box-shadow: 0 0 0 2px var(--brand, #0e6c55);
+    background: var(--comment-highlight-bg);
+    box-shadow: 0 0 0 2px var(--comment-highlight-ring);
   }
   100% {
     background: var(--surface);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--comment-highlight-end-shadow);
   }
 }
 
 [data-theme='dark'] .comment-card--highlighted {
-  animation-name: comment-highlight-fade-dark;
-}
-
-@keyframes comment-highlight-fade-dark {
-  0% {
-    background: var(--brand-900, #123d32);
-    box-shadow: 0 0 0 2px var(--brand-400, #1a9c7f);
-  }
-  100% {
-    background: var(--surface);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  }
+  --comment-highlight-bg: var(--brand-900, #123d32);
+  --comment-highlight-ring: var(--brand-400, #1a9c7f);
+  --comment-highlight-end-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
 .comment-header {

--- a/frontend/src/pages/AnimalDetailPage.css
+++ b/frontend/src/pages/AnimalDetailPage.css
@@ -718,6 +718,36 @@
   box-shadow: 0 4px 12px rgba(26, 156, 127, 0.3);
 }
 
+.comment-card--highlighted {
+  animation: comment-highlight-fade 2.5s ease-out;
+}
+
+@keyframes comment-highlight-fade {
+  0% {
+    background: var(--brand-100, #d7f0e8);
+    box-shadow: 0 0 0 2px var(--brand, #0e6c55);
+  }
+  100% {
+    background: var(--surface);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  }
+}
+
+[data-theme='dark'] .comment-card--highlighted {
+  animation-name: comment-highlight-fade-dark;
+}
+
+@keyframes comment-highlight-fade-dark {
+  0% {
+    background: var(--brand-900, #123d32);
+    box-shadow: 0 0 0 2px var(--brand-400, #1a9c7f);
+  }
+  100% {
+    background: var(--surface);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  }
+}
+
 .comment-header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -231,23 +231,25 @@ describe('AnimalDetailPage', () => {
 
     it('jumps straight to the page containing a deep-linked comment that is not already loaded', async () => {
       const earlierComments = Array.from({ length: 10 }, (_, i) => mockComment({ id: 100 + i, content: `comment ${i}` }));
+      const deltaComments = [
+        ...Array.from({ length: 5 }, (_, i) => mockComment({ id: 200 + i, content: `later ${i}` })),
+        mockComment({ id: 2, content: 'deep comment' }),
+        ...Array.from({ length: 4 }, (_, i) => mockComment({ id: 300 + i, content: `even later ${i}` })),
+      ];
 
       vi.mocked(animalCommentsApi.getAll)
         .mockResolvedValueOnce({
           data: { comments: earlierComments, total: 21, limit: 10, offset: 0, hasMore: true },
         } as AxiosResponse)
         .mockResolvedValueOnce({
-          data: {
-            comments: [...earlierComments, ...Array.from({ length: 5 }, (_, i) => mockComment({ id: 200 + i, content: `later ${i}` })), mockComment({ id: 2, content: 'deep comment' })],
-            total: 21,
-            limit: 20,
-            offset: 0,
-            hasMore: true,
-          },
+          data: { comments: deltaComments, total: 21, limit: 10, offset: 10, hasMore: true },
         } as AxiosResponse);
 
       // Position 15 (0-based) puts the target on the second page (index 1)
-      // under COMMENTS_PER_PAGE=10, so fetching it in one shot needs limit=20.
+      // under COMMENTS_PER_PAGE=10, so reaching it needs comments through
+      // offset 20 (limitNeeded=20). 10 are already loaded, so only the
+      // remaining 10 (offset 10, limit 10) should be fetched and appended —
+      // not a full re-fetch from offset 0.
       vi.mocked(animalCommentsApi.getPosition).mockResolvedValue({
         data: { found: true, offset: 15 },
       } as AxiosResponse);
@@ -259,10 +261,92 @@ describe('AnimalDetailPage', () => {
       await waitFor(() => {
         expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
       });
+      // The already-loaded first page is still present — proving this was
+      // an append, not a replace-from-offset-0.
+      expect(screen.getByText('comment 0')).toBeInTheDocument();
 
       expect(animalCommentsApi.getPosition).toHaveBeenCalledWith(1, 1, 2, { order: 'desc' });
       expect(animalCommentsApi.getAll).toHaveBeenCalledTimes(2);
-      expect(animalCommentsApi.getAll).toHaveBeenLastCalledWith(1, 1, expect.objectContaining({ limit: 20, offset: 0 }));
+      expect(animalCommentsApi.getAll).toHaveBeenLastCalledWith(1, 1, expect.objectContaining({ limit: 10, offset: 10 }));
+    });
+
+    it('tracks the true global offset after a deep link jumps past MAX_COMMENTS_LIMIT, so a later "Load More" click continues from the right position', async () => {
+      // Position 150 exceeds MAX_COMMENTS_LIMIT (100), so the locate effect
+      // takes the page-jump fallback: a non-append fetch straight to the
+      // comment's own page (offset 150, since targetPage=15 under
+      // COMMENTS_PER_PAGE=10), replacing `comments` with just that page's
+      // rows instead of everything from offset 0.
+      const targetPageComments = Array.from({ length: 10 }, (_, i) =>
+        i === 5 ? mockComment({ id: 2, content: 'deep comment' }) : mockComment({ id: 400 + i, content: `page comment ${i}` })
+      );
+
+      vi.mocked(animalCommentsApi.getAll)
+        .mockResolvedValueOnce({
+          data: { comments: [mockComment({ id: 1, content: 'first page comment' })], total: 500, limit: 10, offset: 0, hasMore: true },
+        } as AxiosResponse)
+        .mockResolvedValueOnce({
+          data: { comments: targetPageComments, total: 500, limit: 10, offset: 150, hasMore: true },
+        } as AxiosResponse)
+        .mockResolvedValueOnce({
+          // The "Load More" click after the jump: correct behavior appends
+          // starting at offset 160 (150 + 10 already-loaded), continuing
+          // from where the jumped-to page actually ended — not offset 10,
+          // which comments.length alone would incorrectly suggest.
+          data: { comments: [mockComment({ id: 999, content: 'next page comment' })], total: 500, limit: 10, offset: 160, hasMore: true },
+        } as AxiosResponse);
+
+      vi.mocked(animalCommentsApi.getPosition).mockResolvedValue({
+        data: { found: true, offset: 150 },
+      } as AxiosResponse);
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
+      renderDetailPage();
+
+      await screen.findByText('deep comment');
+      await waitFor(() => {
+        expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      });
+      expect(animalCommentsApi.getAll).toHaveBeenLastCalledWith(1, 1, expect.objectContaining({ offset: 150 }));
+
+      const loadMoreButton = await screen.findByLabelText('Load more comments');
+      fireEvent.click(loadMoreButton);
+
+      await screen.findByText('next page comment');
+      expect(animalCommentsApi.getAll).toHaveBeenLastCalledWith(1, 1, expect.objectContaining({ offset: 160 }));
+    });
+
+    it('does not get stuck on a genuinely slow position lookup (regression: the locate effect used to cancel its own in-flight request)', async () => {
+      // A mockResolvedValue-backed promise resolves within a microtask,
+      // fast enough that it doesn't reliably expose a same-tick effect
+      // self-cancellation race. A real, non-trivial delay is needed to
+      // reproduce it: the locate effect used to call setLoadingMore(true)
+      // with `loadingMore` in its own dependency array, so React would
+      // re-run the effect (cancelling this in-flight lookup via cleanup)
+      // before the delayed response ever arrived — permanently stranding
+      // loadingMore at true and never resolving the deep link.
+      vi.mocked(animalCommentsApi.getAll)
+        .mockResolvedValueOnce({
+          data: { comments: [mockComment({ id: 1, content: 'first page comment' })], total: 2, limit: 10, offset: 0, hasMore: false },
+        } as AxiosResponse)
+        .mockResolvedValueOnce({
+          data: { comments: [mockComment({ id: 1, content: 'first page comment' }), mockComment({ id: 2, content: 'deep comment' })], total: 2, limit: 10, offset: 0, hasMore: false },
+        } as AxiosResponse);
+
+      vi.mocked(animalCommentsApi.getPosition).mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ data: { found: true, offset: 1 } } as AxiosResponse), 20))
+      );
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
+      renderDetailPage();
+
+      await screen.findByText('first page comment');
+
+      await waitFor(
+        () => {
+          expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+        },
+        { timeout: 1000 }
+      );
     });
 
     it("shows a message when the deep-linked comment can't be located", async () => {

--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AnimalDetailPage from './AnimalDetailPage';
@@ -58,6 +58,18 @@ const mockAnimal = (overrides: Partial<Animal>) => {
     data: { ...baseAnimal, ...overrides },
   } as AxiosResponse<Animal>);
 };
+
+const mockComment = (overrides: Partial<AnimalComment>): AnimalComment => ({
+  id: 1,
+  animal_id: 1,
+  user_id: 1,
+  content: 'a comment',
+  image_url: '',
+  is_edited: false,
+  created_at: '2026-06-22T00:00:00Z',
+  updated_at: '2026-06-22T00:00:00Z',
+  ...overrides,
+});
 
 const mockDeletedComment = (overrides: Partial<AnimalComment>): AnimalComment => ({
   id: 1,
@@ -165,6 +177,73 @@ describe('AnimalDetailPage', () => {
     renderDetailPage();
 
     expect(await screen.findByText(/End: June 13, 2024/)).toBeInTheDocument();
+  });
+
+  describe('comment deep-linking from search (?comment=<id>)', () => {
+    beforeEach(() => {
+      // jsdom doesn't implement scrollIntoView.
+      Element.prototype.scrollIntoView = vi.fn();
+      mockAnimal({ status: 'available' });
+    });
+
+    afterEach(() => {
+      window.history.pushState({}, '', '/');
+    });
+
+    it('scrolls to and highlights the comment named in the ?comment= query param', async () => {
+      vi.mocked(animalCommentsApi.getAll).mockResolvedValue({
+        data: {
+          comments: [
+            mockComment({ id: 1, content: 'first comment' }),
+            mockComment({ id: 2, content: 'second comment' }),
+          ],
+          total: 2,
+          limit: 10,
+          offset: 0,
+          hasMore: false,
+        },
+      } as AxiosResponse);
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
+      renderDetailPage();
+
+      await screen.findByText('second comment');
+      const highlighted = document.getElementById('comment-2');
+      expect(highlighted).toHaveClass('comment-card--highlighted');
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+      const notHighlighted = document.getElementById('comment-1');
+      expect(notHighlighted).not.toHaveClass('comment-card--highlighted');
+    });
+
+    it('auto-loads further pages until the deep-linked comment is found', async () => {
+      vi.mocked(animalCommentsApi.getAll)
+        .mockResolvedValueOnce({
+          data: {
+            comments: [mockComment({ id: 1, content: 'page one comment' })],
+            total: 2,
+            limit: 10,
+            offset: 0,
+            hasMore: true,
+          },
+        } as AxiosResponse)
+        .mockResolvedValueOnce({
+          data: {
+            comments: [mockComment({ id: 2, content: 'page two comment' })],
+            total: 2,
+            limit: 10,
+            offset: 1,
+            hasMore: false,
+          },
+        } as AxiosResponse);
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
+      renderDetailPage();
+
+      await screen.findByText('page two comment');
+      expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      expect(animalCommentsApi.getAll).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('admin deleted comments scoping', () => {

--- a/frontend/src/pages/AnimalDetailPage.test.tsx
+++ b/frontend/src/pages/AnimalDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AnimalDetailPage from './AnimalDetailPage';
 import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, authApi } from '../api/client';
@@ -21,6 +21,7 @@ vi.mock('../api/client', () => ({
   animalCommentsApi: {
     getAll: vi.fn(),
     getDeleted: vi.fn(),
+    getPosition: vi.fn(),
   },
   commentTagsApi: {
     getAll: vi.fn(),
@@ -184,6 +185,12 @@ describe('AnimalDetailPage', () => {
       // jsdom doesn't implement scrollIntoView.
       Element.prototype.scrollIntoView = vi.fn();
       mockAnimal({ status: 'available' });
+      // Only tests that actually exercise the "not on the loaded page(s)"
+      // path override this; default to "not found" so an accidental call
+      // elsewhere doesn't hang on an unresolved mock.
+      vi.mocked(animalCommentsApi.getPosition).mockResolvedValue({
+        data: { found: false },
+      } as AxiosResponse);
     });
 
     afterEach(() => {
@@ -208,41 +215,101 @@ describe('AnimalDetailPage', () => {
       renderDetailPage();
 
       await screen.findByText('second comment');
-      const highlighted = document.getElementById('comment-2');
-      expect(highlighted).toHaveClass('comment-card--highlighted');
+      // The highlight class is applied by a useEffect that runs after the
+      // comments state update commits — a separate render pass from the one
+      // findByText observes — so wait for it rather than asserting inline.
+      await waitFor(() => {
+        expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      });
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
 
       const notHighlighted = document.getElementById('comment-1');
       expect(notHighlighted).not.toHaveClass('comment-card--highlighted');
+      // Already on the loaded page — no need to ask the backend for it.
+      expect(animalCommentsApi.getPosition).not.toHaveBeenCalled();
     });
 
-    it('auto-loads further pages until the deep-linked comment is found', async () => {
+    it('jumps straight to the page containing a deep-linked comment that is not already loaded', async () => {
+      const earlierComments = Array.from({ length: 10 }, (_, i) => mockComment({ id: 100 + i, content: `comment ${i}` }));
+
       vi.mocked(animalCommentsApi.getAll)
         .mockResolvedValueOnce({
-          data: {
-            comments: [mockComment({ id: 1, content: 'page one comment' })],
-            total: 2,
-            limit: 10,
-            offset: 0,
-            hasMore: true,
-          },
+          data: { comments: earlierComments, total: 21, limit: 10, offset: 0, hasMore: true },
         } as AxiosResponse)
         .mockResolvedValueOnce({
           data: {
-            comments: [mockComment({ id: 2, content: 'page two comment' })],
-            total: 2,
-            limit: 10,
-            offset: 1,
-            hasMore: false,
+            comments: [...earlierComments, ...Array.from({ length: 5 }, (_, i) => mockComment({ id: 200 + i, content: `later ${i}` })), mockComment({ id: 2, content: 'deep comment' })],
+            total: 21,
+            limit: 20,
+            offset: 0,
+            hasMore: true,
           },
         } as AxiosResponse);
+
+      // Position 15 (0-based) puts the target on the second page (index 1)
+      // under COMMENTS_PER_PAGE=10, so fetching it in one shot needs limit=20.
+      vi.mocked(animalCommentsApi.getPosition).mockResolvedValue({
+        data: { found: true, offset: 15 },
+      } as AxiosResponse);
 
       window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
       renderDetailPage();
 
-      await screen.findByText('page two comment');
-      expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      await screen.findByText('deep comment');
+      await waitFor(() => {
+        expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      });
+
+      expect(animalCommentsApi.getPosition).toHaveBeenCalledWith(1, 1, 2, { order: 'desc' });
       expect(animalCommentsApi.getAll).toHaveBeenCalledTimes(2);
+      expect(animalCommentsApi.getAll).toHaveBeenLastCalledWith(1, 1, expect.objectContaining({ limit: 20, offset: 0 }));
+    });
+
+    it("shows a message when the deep-linked comment can't be located", async () => {
+      vi.mocked(animalCommentsApi.getAll).mockResolvedValue({
+        data: { comments: [], total: 0, limit: 10, offset: 0, hasMore: false },
+      } as AxiosResponse);
+      vi.mocked(animalCommentsApi.getPosition).mockResolvedValue({
+        data: { found: false },
+      } as AxiosResponse);
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=999');
+      renderDetailPage();
+
+      expect(await screen.findByText(/couldn.t be found/i)).toBeInTheDocument();
+    });
+
+    it('only clears the tag filter once per deep-linked id, so a filter picked afterward sticks', async () => {
+      vi.mocked(animalCommentsApi.getAll).mockResolvedValue({
+        data: {
+          comments: [mockComment({ id: 2, content: 'unfiltered comment' })],
+          total: 1,
+          limit: 10,
+          offset: 0,
+          hasMore: false,
+        },
+      } as AxiosResponse);
+      vi.mocked(commentTagsApi.getAll).mockResolvedValue({
+        data: [{ id: 1, group_id: 1, name: 'urgent', color: '#FF0000' }],
+      } as AxiosResponse);
+
+      window.history.pushState({}, '', '/groups/1/animals/1/view?comment=2');
+      renderDetailPage();
+
+      await screen.findByText('unfiltered comment');
+      await waitFor(() => {
+        expect(document.getElementById('comment-2')).toHaveClass('comment-card--highlighted');
+      });
+
+      // Deep-link resolution is done for id 2 (locatedCommentIdRef is set) —
+      // a filter the user picks afterward should stick, not get silently
+      // cleared again by the same effect on its next run.
+      const filterButton = await screen.findByLabelText('Filter by urgent');
+      fireEvent.click(filterButton);
+
+      await waitFor(() => {
+        expect(filterButton).toHaveAttribute('aria-pressed', 'true');
+      });
     });
   });
 

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo, Suspense, lazy } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { animalsApi, animalCommentsApi, commentTagsApi, groupsApi, scriptsApi } from '../api/client';
 import type { Animal, AnimalComment, CommentTag, CommentHistory, Group, GroupMembership, SessionMetadata, Script } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
@@ -28,6 +28,7 @@ const ProtocolViewer = lazy(() => import('../components/ProtocolViewer'));
 const AnimalDetailPage: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { isAdmin, user } = useAuth();
   const toast = useToast();
   const [animal, setAnimal] = useState<Animal | null>(null);
@@ -67,6 +68,17 @@ const AnimalDetailPage: React.FC = () => {
   const [scriptFilter, setScriptFilter] = useState('');
   const commentsTopRef = useRef<HTMLDivElement>(null);
   const COMMENTS_PER_PAGE = 10;
+
+  // Deep-link support from search results (GroupSearch links to
+  // `?comment=<id>`): the target comment may be several pages deep (or on a
+  // different sort order) from what loadAnimalData's initial page fetches,
+  // so scrolledToHighlightRef tracks whether *this* comment id has already
+  // been located/scrolled-to, distinct from highlightedCommentId (which also
+  // drives the CSS highlight and is cleared after the highlight fades).
+  const highlightCommentParam = searchParams.get('comment');
+  const highlightCommentId = highlightCommentParam ? Number(highlightCommentParam) : null;
+  const [highlightedCommentId, setHighlightedCommentId] = useState<number | null>(null);
+  const scrolledToHighlightRef = useRef<number | null>(null);
 
   const loadComments = useCallback(async (
     gId: number, 
@@ -316,6 +328,34 @@ const AnimalDetailPage: React.FC = () => {
       setLoadingMore(false);
     }
   };
+
+  // Locate a comment deep-linked from search: keep paging until it shows up
+  // or we run out of pages, then scroll to and briefly highlight it. Calls
+  // loadComments directly (rather than handleLoadMore) so this effect's
+  // dependency list stays exhaustive-deps clean — handleLoadMore is
+  // redefined every render and isn't memoized. Resets
+  // scrolledToHighlightRef whenever the target id changes so navigating
+  // between two search results re-triggers.
+  useEffect(() => {
+    if (!highlightCommentId || !groupId || !id) return;
+    if (scrolledToHighlightRef.current === highlightCommentId) return;
+
+    const target = comments.find((c) => c.id === highlightCommentId);
+    if (target) {
+      scrolledToHighlightRef.current = highlightCommentId;
+      const el = document.getElementById(`comment-${highlightCommentId}`);
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setHighlightedCommentId(highlightCommentId);
+      const timeout = setTimeout(() => setHighlightedCommentId(null), 2500);
+      return () => clearTimeout(timeout);
+    }
+
+    if (hasMore && !loadingMore) {
+      setLoadingMore(true);
+      loadComments(Number(groupId), Number(id), filterTags.join(','), comments.length, sortOrder, true)
+        .finally(() => setLoadingMore(false));
+    }
+  }, [comments, hasMore, loadingMore, highlightCommentId, groupId, id, filterTags, sortOrder, loadComments]);
 
   const handleSortChange = () => {
     const newOrder = sortOrder === 'desc' ? 'asc' : 'desc';
@@ -920,7 +960,11 @@ const AnimalDetailPage: React.FC = () => {
                   const isCommentOwner = comment.user?.id === user?.id;
                   
                   return (
-                    <div key={comment.id} className={`comment-card ${isEditing ? 'editing' : ''}`}>
+                    <div
+                      key={comment.id}
+                      id={`comment-${comment.id}`}
+                      className={`comment-card ${isEditing ? 'editing' : ''} ${highlightedCommentId === comment.id ? 'comment-card--highlighted' : ''}`}
+                    >
                       {isEditing ? (
                         // Inline editing form
                         <SessionReportForm

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -274,11 +274,13 @@ const AnimalDetailPage: React.FC = () => {
   }, [id]);
 
   useEffect(() => {
-    if (groupId && id) {
-      const tagFilterString = filterTags.join(',');
-      loadComments(Number(groupId), Number(id), tagFilterString, 0, sortOrder);
-    }
-  }, [filterTags, groupId, id, loadComments, sortOrder]);
+    // Gated on `animal` so a failed/forbidden animal fetch (loadAnimalData
+    // never calling setAnimal) doesn't also fire a doomed GetAnimalComments
+    // request and surface a second, redundant error toast for the same bad id.
+    if (!groupId || !id || !animal) return;
+    const tagFilterString = filterTags.join(',');
+    loadComments(Number(groupId), Number(id), tagFilterString, 0, sortOrder);
+  }, [filterTags, groupId, id, loadComments, sortOrder, animal]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -311,7 +313,12 @@ const AnimalDetailPage: React.FC = () => {
       } else {
         setComments([...comments, newComment.data]);
       }
-      
+      // One more item is now in `comments` without having gone through
+      // loadComments, so commentsOffsetRef must advance to match — otherwise
+      // it stays stale and the next "Load More" re-fetches an already-shown
+      // comment (see the desc-order shift this causes).
+      commentsOffsetRef.current += 1;
+
       setTotalComments(prev => prev + 1);
       toast.showSuccess('Comment posted successfully!');
     } catch (error: unknown) {
@@ -1249,7 +1256,7 @@ const AnimalDetailPage: React.FC = () => {
                         <>
                           Load More Comments
                           <span className="remaining-count">
-                            ({totalComments - comments.length} more • {Math.ceil((totalComments - comments.length) / COMMENTS_PER_PAGE)} pages)
+                            ({totalComments - commentsOffsetRef.current} more • {Math.ceil((totalComments - commentsOffsetRef.current) / COMMENTS_PER_PAGE)} pages)
                           </span>
                         </>
                       )}

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -25,6 +25,12 @@ import '../components/ScriptsList.css';
 // Lazy load ProtocolViewer to reduce initial bundle size (~350KB savings)
 const ProtocolViewer = lazy(() => import('../components/ProtocolViewer'));
 
+// Shared by scrollToComments' 'top' case and the deep-link locate effect —
+// both ultimately just want to smooth-scroll a specific element into view.
+const scrollElementIntoView = (el: Element | null, block: ScrollLogicalPosition) => {
+  el?.scrollIntoView({ behavior: 'smooth', block });
+};
+
 const AnimalDetailPage: React.FC = () => {
   const { groupId, id } = useParams<{ groupId: string; id: string }>();
   const navigate = useNavigate();
@@ -68,43 +74,70 @@ const AnimalDetailPage: React.FC = () => {
   const [scriptFilter, setScriptFilter] = useState('');
   const commentsTopRef = useRef<HTMLDivElement>(null);
   const COMMENTS_PER_PAGE = 10;
+  const commentsRequestIdRef = useRef(0);
 
   // Deep-link support from search results (GroupSearch links to
-  // `?comment=<id>`): the target comment may be several pages deep (or on a
-  // different sort order) from what loadAnimalData's initial page fetches,
-  // so scrolledToHighlightRef tracks whether *this* comment id has already
-  // been located/scrolled-to, distinct from highlightedCommentId (which also
-  // drives the CSS highlight and is cleared after the highlight fades).
+  // `?comment=<id>`): locatedCommentIdRef tracks whether *this* comment id
+  // has already been located (either found in an already-loaded page, or
+  // looked up via animalCommentsApi.getPosition and fetched), distinct from
+  // highlightedCommentId (which drives the CSS highlight and is cleared
+  // after the highlight fades).
   const highlightCommentParam = searchParams.get('comment');
-  const highlightCommentId = highlightCommentParam ? Number(highlightCommentParam) : null;
+  const highlightCommentId = highlightCommentParam !== null && !Number.isNaN(Number(highlightCommentParam))
+    ? Number(highlightCommentParam)
+    : null;
   const [highlightedCommentId, setHighlightedCommentId] = useState<number | null>(null);
-  const scrolledToHighlightRef = useRef<number | null>(null);
+  const locatedCommentIdRef = useRef<number | null>(null);
+  // The backend's GetAnimalComments caps `limit` at 100 — fetching from
+  // offset 0 up to a comment deeper than that would silently get clamped
+  // and never actually reach it (see the locate effect below).
+  const MAX_COMMENTS_LIMIT = 100;
+  // Guards the locate effect against concluding "not on this page, ask the
+  // backend where it is" before the very first comments fetch for this
+  // animal has even landed — comments starts as [] on every mount, which
+  // looks identical to "genuinely not found" unless this is checked too.
+  const initialCommentsLoadedRef = useRef(false);
 
   const loadComments = useCallback(async (
-    gId: number, 
-    animalId: number, 
-    filter: string, 
+    gId: number,
+    animalId: number,
+    filter: string,
     offset: number = 0,
     order: 'asc' | 'desc' = 'desc',
-    append: boolean = false
+    append: boolean = false,
+    limitOverride?: number
   ) => {
+    // Several effects can independently call loadComments close together
+    // (the initial-mount load and the filterTags/sortOrder effect both fire
+    // on mount; the deep-link locate effect can also overlap with either).
+    // Requests aren't guaranteed to resolve in the order they were issued,
+    // so a stale response applying after a newer one would silently clobber
+    // it (e.g. an appended page getting wiped by a slow-to-resolve initial
+    // page-0 load). Track the latest issued request and drop any response
+    // that isn't from it.
+    const requestId = ++commentsRequestIdRef.current;
     try {
       const commentsRes = await animalCommentsApi.getAll(gId, animalId, {
         tagFilter: filter || undefined,
-        limit: COMMENTS_PER_PAGE,
+        limit: limitOverride ?? COMMENTS_PER_PAGE,
         offset,
         order
       });
-      
+
+      if (requestId !== commentsRequestIdRef.current) return;
+
+      initialCommentsLoadedRef.current = true;
+
       if (append) {
         setComments(prev => [...prev, ...commentsRes.data.comments]);
       } else {
         setComments(commentsRes.data.comments);
       }
-      
+
       setTotalComments(commentsRes.data.total);
       setHasMore(commentsRes.data.hasMore);
     } catch (error) {
+      if (requestId !== commentsRequestIdRef.current) return;
       console.error('Failed to load comments:', error);
       toast.showError('Failed to load comments. Please try again.');
     }
@@ -170,7 +203,12 @@ const AnimalDetailPage: React.FC = () => {
       setError('');
       const animalRes = await animalsApi.getById(gId, animalId);
       setAnimal(animalRes.data);
-      await loadComments(gId, animalId, '', 0, sortOrder);
+      // Comments are loaded by the filterTags/sortOrder effect below, which
+      // already re-fires on mount and on groupId/id changes — calling
+      // loadComments here too used to fire a redundant, un-coordinated
+      // second fetch for the same page every time this ran, which could
+      // resolve out of order and clobber state from a legitimate later
+      // request (e.g. the deep-link pagination effect's appended page).
     } catch (error: unknown) {
       console.error('Failed to load animal data:', error);
       const errorMsg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Failed to load animal information. Please try again.';
@@ -178,7 +216,7 @@ const AnimalDetailPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [loadComments, sortOrder]);
+  }, []);
 
   useEffect(() => {
     if (groupId && id) {
@@ -193,6 +231,7 @@ const AnimalDetailPage: React.FC = () => {
 
   useEffect(() => {
     setShowDeleted(false);
+    initialCommentsLoadedRef.current = false;
   }, [id]);
 
   useEffect(() => {
@@ -329,33 +368,92 @@ const AnimalDetailPage: React.FC = () => {
     }
   };
 
-  // Locate a comment deep-linked from search: keep paging until it shows up
-  // or we run out of pages, then scroll to and briefly highlight it. Calls
-  // loadComments directly (rather than handleLoadMore) so this effect's
-  // dependency list stays exhaustive-deps clean — handleLoadMore is
-  // redefined every render and isn't memoized. Resets
-  // scrolledToHighlightRef whenever the target id changes so navigating
-  // between two search results re-triggers.
+  // A deep-linked comment should be reachable regardless of whatever tag
+  // filter happens to be active in this mounted instance — the whole point
+  // of following a search result is to see that specific comment. Clear any
+  // active filter once per highlightCommentId rather than letting the
+  // locate effect below silently page forever against a filter that
+  // excludes the target.
+  const clearedFilterForDeepLinkRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!highlightCommentId || !groupId || !id) return;
-    if (scrolledToHighlightRef.current === highlightCommentId) return;
+    if (highlightCommentId === null || clearedFilterForDeepLinkRef.current === highlightCommentId) return;
+    clearedFilterForDeepLinkRef.current = highlightCommentId;
+    setFilterTags((prev) => (prev.length > 0 ? [] : prev));
+  }, [highlightCommentId]);
+
+  // Locate a comment deep-linked from search: if it's already on a
+  // loaded page, scroll to and briefly highlight it directly. Otherwise ask
+  // the backend which page it's on (animalCommentsApi.getPosition) and fetch
+  // straight to that page in one request, rather than paging through every
+  // prior page client-side just to find it. Waits for filterTags to
+  // actually be cleared (see above) before asking, so it isn't located
+  // relative to a filter that's about to change out from under it.
+  useEffect(() => {
+    if (highlightCommentId === null || !groupId || !id) return;
+    if (locatedCommentIdRef.current === highlightCommentId) return;
 
     const target = comments.find((c) => c.id === highlightCommentId);
     if (target) {
-      scrolledToHighlightRef.current = highlightCommentId;
-      const el = document.getElementById(`comment-${highlightCommentId}`);
-      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      locatedCommentIdRef.current = highlightCommentId;
+      scrollElementIntoView(document.getElementById(`comment-${highlightCommentId}`), 'center');
       setHighlightedCommentId(highlightCommentId);
-      const timeout = setTimeout(() => setHighlightedCommentId(null), 2500);
-      return () => clearTimeout(timeout);
+      return;
     }
 
-    if (hasMore && !loadingMore) {
-      setLoadingMore(true);
-      loadComments(Number(groupId), Number(id), filterTags.join(','), comments.length, sortOrder, true)
-        .finally(() => setLoadingMore(false));
-    }
-  }, [comments, hasMore, loadingMore, highlightCommentId, groupId, id, filterTags, sortOrder, loadComments]);
+    // comments starts as [] on every mount — until the first real fetch for
+    // this animal has landed, "not found above" doesn't mean "not on this
+    // page," just "haven't loaded a page yet." Wait rather than firing a
+    // position lookup that the normal first-page load would make redundant.
+    if (!initialCommentsLoadedRef.current) return;
+    if (filterTags.length > 0 || loadingMore) return;
+
+    let cancelled = false;
+    setLoadingMore(true);
+    (async () => {
+      try {
+        const res = await animalCommentsApi.getPosition(Number(groupId), Number(id), highlightCommentId, { order: sortOrder });
+        if (cancelled) return;
+
+        if (!res.data.found) {
+          locatedCommentIdRef.current = highlightCommentId;
+          toast.showWarning("That comment couldn't be found — it may have been deleted.");
+          return;
+        }
+
+        const targetPage = Math.floor(res.data.offset / COMMENTS_PER_PAGE);
+        const limitNeeded = (targetPage + 1) * COMMENTS_PER_PAGE;
+        if (limitNeeded <= MAX_COMMENTS_LIMIT) {
+          await loadComments(Number(groupId), Number(id), '', 0, sortOrder, false, limitNeeded);
+        } else {
+          // Too deep to fetch from the start in one request — jump to the
+          // comment's own page instead, trading one-shot access to earlier
+          // comments for a bounded request size.
+          await loadComments(Number(groupId), Number(id), '', targetPage * COMMENTS_PER_PAGE, sortOrder, false);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        locatedCommentIdRef.current = highlightCommentId;
+        console.error('Failed to locate deep-linked comment:', error);
+        toast.showWarning("That comment couldn't be found — it may have been deleted.");
+      } finally {
+        if (!cancelled) setLoadingMore(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [comments, highlightCommentId, groupId, id, sortOrder, filterTags, loadingMore, loadComments, toast]);
+
+  // Clears the highlight after its fade animation finishes. Kept as its own
+  // effect, keyed only on highlightedCommentId, so an unrelated comments
+  // change during the fade window (e.g. someone posts a new comment) can't
+  // make React re-run the effect above, cancel this timeout via its cleanup,
+  // and then short-circuit on locatedCommentIdRef without rescheduling —
+  // which would leave the highlight stuck on indefinitely.
+  useEffect(() => {
+    if (highlightedCommentId === null) return;
+    const timeout = setTimeout(() => setHighlightedCommentId(null), 2500);
+    return () => clearTimeout(timeout);
+  }, [highlightedCommentId]);
 
   const handleSortChange = () => {
     const newOrder = sortOrder === 'desc' ? 'asc' : 'desc';
@@ -372,7 +470,7 @@ const AnimalDetailPage: React.FC = () => {
 
   const scrollToComments = (position: 'top' | 'bottom') => {
     if (position === 'top' && commentsTopRef.current) {
-      commentsTopRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollElementIntoView(commentsTopRef.current, 'start');
     } else {
       window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
     }

--- a/frontend/src/pages/AnimalDetailPage.tsx
+++ b/frontend/src/pages/AnimalDetailPage.tsx
@@ -75,6 +75,13 @@ const AnimalDetailPage: React.FC = () => {
   const commentsTopRef = useRef<HTMLDivElement>(null);
   const COMMENTS_PER_PAGE = 10;
   const commentsRequestIdRef = useRef(0);
+  // Tracks the global offset immediately following the last loaded page,
+  // i.e. where the next "load more" or delta fetch should start. comments
+  // .length can't be used for this: once the deep-link locate effect jumps
+  // straight to a later page (see MAX_COMMENTS_LIMIT below), comments holds
+  // only that page's rows, not everything from offset 0, so its length no
+  // longer corresponds to a global offset.
+  const commentsOffsetRef = useRef(0);
 
   // Deep-link support from search results (GroupSearch links to
   // `?comment=<id>`): locatedCommentIdRef tracks whether *this* comment id
@@ -88,6 +95,10 @@ const AnimalDetailPage: React.FC = () => {
     : null;
   const [highlightedCommentId, setHighlightedCommentId] = useState<number | null>(null);
   const locatedCommentIdRef = useRef<number | null>(null);
+  // Tracks which highlightCommentId the filter-clear effect below has
+  // already run for, so it only clears filterTags once per deep-linked id
+  // rather than on every render.
+  const clearedFilterForDeepLinkRef = useRef<number | null>(null);
   // The backend's GetAnimalComments caps `limit` at 100 — fetching from
   // offset 0 up to a comment deeper than that would silently get clamped
   // and never actually reach it (see the locate effect below).
@@ -97,6 +108,16 @@ const AnimalDetailPage: React.FC = () => {
   // animal has even landed — comments starts as [] on every mount, which
   // looks identical to "genuinely not found" unless this is checked too.
   const initialCommentsLoadedRef = useRef(false);
+  // Guards the locate effect's own async lookup against concurrent starts.
+  // Deliberately a ref, not the `loadingMore` state: the effect used to gate
+  // on `loadingMore` itself while also being the one setting it, which put
+  // `loadingMore` in the effect's own dependency array — the effect's
+  // `setLoadingMore(true)` then triggered React to tear the effect down
+  // (running its cleanup, which cancelled the in-flight lookup) and re-run
+  // it before the request could resolve, permanently stranding
+  // `loadingMore` at `true`. A ref sidesteps that: it's read/written for
+  // re-entrancy control without being a reactive dependency.
+  const locatingRef = useRef(false);
 
   const loadComments = useCallback(async (
     gId: number,
@@ -133,6 +154,7 @@ const AnimalDetailPage: React.FC = () => {
       } else {
         setComments(commentsRes.data.comments);
       }
+      commentsOffsetRef.current = offset + commentsRes.data.comments.length;
 
       setTotalComments(commentsRes.data.total);
       setHasMore(commentsRes.data.hasMore);
@@ -209,6 +231,14 @@ const AnimalDetailPage: React.FC = () => {
       // second fetch for the same page every time this ran, which could
       // resolve out of order and clobber state from a legitimate later
       // request (e.g. the deep-link pagination effect's appended page).
+      //
+      // Dropping that loadComments call also (as a side effect, not the
+      // point) made this function's identity stable across sortOrder
+      // changes, which used to indirectly refetch group/tags/deleted-comments
+      // via the mount effect below whenever sort was toggled — group
+      // membership, tags, and deleted comments don't depend on comment sort
+      // order, so no longer refreshing them on a sort toggle is intentional,
+      // not a regression to restore.
     } catch (error: unknown) {
       console.error('Failed to load animal data:', error);
       const errorMsg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Failed to load animal information. Please try again.';
@@ -232,6 +262,15 @@ const AnimalDetailPage: React.FC = () => {
   useEffect(() => {
     setShowDeleted(false);
     initialCommentsLoadedRef.current = false;
+    commentsOffsetRef.current = 0;
+    // Deep-link locate state is scoped to a specific comment id, but that id
+    // could coincidentally match a comment id still relevant to a
+    // *different* animal after navigating here without a full remount (e.g.
+    // clicking another animal's link while `?comment=<id>` happens to repeat
+    // a value already recorded). Reset so the locate effect re-evaluates
+    // fresh for the new animal instead of short-circuiting on stale state.
+    locatedCommentIdRef.current = null;
+    clearedFilterForDeepLinkRef.current = null;
   }, [id]);
 
   useEffect(() => {
@@ -356,10 +395,10 @@ const AnimalDetailPage: React.FC = () => {
     try {
       const tagFilterString = filterTags.join(',');
       await loadComments(
-        Number(groupId), 
-        Number(id), 
-        tagFilterString, 
-        comments.length,
+        Number(groupId),
+        Number(id),
+        tagFilterString,
+        commentsOffsetRef.current,
         sortOrder,
         true // append
       );
@@ -374,7 +413,6 @@ const AnimalDetailPage: React.FC = () => {
   // active filter once per highlightCommentId rather than letting the
   // locate effect below silently page forever against a filter that
   // excludes the target.
-  const clearedFilterForDeepLinkRef = useRef<number | null>(null);
   useEffect(() => {
     if (highlightCommentId === null || clearedFilterForDeepLinkRef.current === highlightCommentId) return;
     clearedFilterForDeepLinkRef.current = highlightCommentId;
@@ -405,9 +443,19 @@ const AnimalDetailPage: React.FC = () => {
     // page," just "haven't loaded a page yet." Wait rather than firing a
     // position lookup that the normal first-page load would make redundant.
     if (!initialCommentsLoadedRef.current) return;
-    if (filterTags.length > 0 || loadingMore) return;
+    // locatingRef (a ref, not the loadingMore *state*) guards re-entrancy
+    // here. loadingMore used to be read directly for this guard, which put
+    // it in this effect's own dependency array — but this effect is also
+    // what calls setLoadingMore(true), so that self-triggered re-run tore
+    // the effect down (cancelling the in-flight lookup via cleanup) before
+    // the request could resolve, permanently stranding loadingMore at true.
+    // A ref sidesteps the problem: it's mutated for control flow without
+    // being reactive, so setting it doesn't cause React to re-run this
+    // effect.
+    if (filterTags.length > 0 || locatingRef.current) return;
 
     let cancelled = false;
+    locatingRef.current = true;
     setLoadingMore(true);
     (async () => {
       try {
@@ -423,11 +471,21 @@ const AnimalDetailPage: React.FC = () => {
         const targetPage = Math.floor(res.data.offset / COMMENTS_PER_PAGE);
         const limitNeeded = (targetPage + 1) * COMMENTS_PER_PAGE;
         if (limitNeeded <= MAX_COMMENTS_LIMIT) {
-          await loadComments(Number(groupId), Number(id), '', 0, sortOrder, false, limitNeeded);
+          // Fetch only the rows not already loaded and append them, rather
+          // than re-fetching (and re-rendering) offset 0 through
+          // limitNeeded every time — commentsOffsetRef.current is where the
+          // currently-loaded range actually ends.
+          const alreadyLoaded = commentsOffsetRef.current;
+          if (limitNeeded > alreadyLoaded) {
+            await loadComments(Number(groupId), Number(id), '', alreadyLoaded, sortOrder, true, limitNeeded - alreadyLoaded);
+          }
         } else {
           // Too deep to fetch from the start in one request — jump to the
           // comment's own page instead, trading one-shot access to earlier
-          // comments for a bounded request size.
+          // comments for a bounded request size. loadComments records the
+          // resulting range in commentsOffsetRef, so a later "Load More"
+          // continues correctly from this new base instead of assuming the
+          // list still starts at offset 0.
           await loadComments(Number(groupId), Number(id), '', targetPage * COMMENTS_PER_PAGE, sortOrder, false);
         }
       } catch (error) {
@@ -436,12 +494,26 @@ const AnimalDetailPage: React.FC = () => {
         console.error('Failed to locate deep-linked comment:', error);
         toast.showWarning("That comment couldn't be found — it may have been deleted.");
       } finally {
-        if (!cancelled) setLoadingMore(false);
+        if (!cancelled) {
+          locatingRef.current = false;
+          setLoadingMore(false);
+        }
       }
     })();
 
-    return () => { cancelled = true; };
-  }, [comments, highlightCommentId, groupId, id, sortOrder, filterTags, loadingMore, loadComments, toast]);
+    // Also resets locatingRef/loadingMore synchronously (not just via the
+    // async branch's own finally): if a real dependency change cancels this
+    // run mid-flight, the busy state must clear here too, or a fresh
+    // invocation that doesn't start a new lookup (e.g. it finds the target
+    // already loaded) would otherwise see locatingRef still true and the
+    // "Load More" button would stay disabled indefinitely. Both paths
+    // resetting the same values to false is idempotent — no conflict.
+    return () => {
+      cancelled = true;
+      locatingRef.current = false;
+      setLoadingMore(false);
+    };
+  }, [comments, highlightCommentId, groupId, id, sortOrder, filterTags, loadComments, toast]);
 
   // Clears the highlight after its fade animation finishes. Kept as its own
   // effect, keyed only on highlightedCommentId, so an unrelated comments

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -287,7 +287,7 @@ const UserProfilePage: React.FC = () => {
               {profile.recent_comments.map((comment) => (
                 <div key={comment.id} className="activity-item">
                   <div className="activity-meta">
-                    <Link to={`/groups/${comment.group_id}/animals/${comment.animal_id}/view`} className="animal-link">
+                    <Link to={`/groups/${comment.group_id}/animals/${comment.animal_id}/view?comment=${comment.id}`} className="animal-link">
                       {comment.animal_name}
                     </Link>
                     <span className="activity-group">in {comment.group_name}</span>

--- a/internal/handlers/activity_feed.go
+++ b/internal/handlers/activity_feed.go
@@ -166,14 +166,7 @@ func GetGroupActivityFeed(db *gorm.DB) gin.HandlerFunc {
 
 				// Apply tag filter if specified
 				if filterTags != "" {
-					tagNames := []string{}
-					for _, tag := range splitAndTrim(filterTags) {
-						tagNames = append(tagNames, tag)
-					}
-					commentQuery = commentQuery.Joins("JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id").
-						Joins("JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id").
-						Where("comment_tags.name IN ?", tagNames).
-						Group("animal_comments.id")
+					commentQuery = applyTagFilter(commentQuery, splitAndTrim(filterTags))
 				}
 
 				err := commentQuery.Preload("User").

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -84,6 +84,31 @@ func sanitizeSessionMetadata(m *models.SessionMetadata) {
 	m.OtherNotes = htmlTagPattern.ReplaceAllString(m.OtherNotes, "")
 }
 
+// parseTagFilterNames splits and trims a comma-separated ?tags= query value
+// into individual tag names, shared by every handler that applies the
+// animal-comments tag filter so the split/trim logic can't drift out of sync
+// across them.
+func parseTagFilterNames(tagFilter string) []string {
+	tagNames := strings.Split(tagFilter, ",")
+	for i, name := range tagNames {
+		tagNames[i] = strings.TrimSpace(name)
+	}
+	return tagNames
+}
+
+// applyTagFilter joins in the tag filter's OR-matched comment_tags rows and
+// groups by comment id to dedupe when a comment matches multiple requested
+// tags. Shared by every animal-comments query that supports ?tags= so the
+// join shape (and its Group, required for the dedupe) can't drift out of
+// sync across them.
+func applyTagFilter(query *gorm.DB, tagNames []string) *gorm.DB {
+	return query.
+		Joins("JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id").
+		Joins("JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id").
+		Where("comment_tags.name IN ?", tagNames).
+		Group("animal_comments.id")
+}
+
 // GetAnimalComments returns comments for an animal with pagination support
 func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -137,30 +162,14 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 
 		// Apply tag filter if provided (multiple tags = OR logic)
 		if tagFilter != "" {
-			tagNames := strings.Split(tagFilter, ",")
-			// Trim whitespace from tag names
-			for i, name := range tagNames {
-				tagNames[i] = strings.TrimSpace(name)
-			}
-
-			query = query.Joins("JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id").
-				Joins("JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id").
-				Where("comment_tags.name IN ?", tagNames).
-				Group("animal_comments.id")
+			query = applyTagFilter(query, parseTagFilterNames(tagFilter))
 		}
 
 		// Get total count
 		var total int64
 		countQuery := db.Model(&models.AnimalComment{}).Where("animal_id = ?", animalID)
 		if tagFilter != "" {
-			tagNames := strings.Split(tagFilter, ",")
-			for i, name := range tagNames {
-				tagNames[i] = strings.TrimSpace(name)
-			}
-			countQuery = countQuery.Joins("JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id").
-				Joins("JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id").
-				Where("comment_tags.name IN ?", tagNames).
-				Group("animal_comments.id")
+			countQuery = applyTagFilter(countQuery, parseTagFilterNames(tagFilter))
 		}
 		if err := countQuery.Count(&total).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count comments"})
@@ -181,6 +190,93 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 			"offset":   offset,
 			"hasMore":  offset+len(comments) < int(total),
 		})
+	}
+}
+
+// commentMatchesTagFilter reports whether comment carries any of the given
+// tag names (the same OR-match semantics as GetAnimalComments' ?tags=
+// filter). tagNames is assumed already parsed via parseTagFilterNames.
+func commentMatchesTagFilter(comment models.AnimalComment, tagNames []string) bool {
+	wanted := make(map[string]bool, len(tagNames))
+	for _, name := range tagNames {
+		wanted[name] = true
+	}
+	for _, tag := range comment.Tags {
+		if wanted[tag.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAnimalCommentPosition returns the 0-based offset a specific comment
+// falls at under the same ?tags=/?order= a client would pass to
+// GetAnimalComments, so a client that only knows a comment id — e.g.
+// deep-linking a search result to a specific comment — can jump straight to
+// the page containing it with one request, instead of paging through every
+// prior page client-side just to locate it.
+func GetAnimalCommentPosition(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupID := c.Param("id")
+		animalID := c.Param("animalId")
+		commentID := c.Param("commentId")
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		var animal models.Animal
+		if err := db.Where("id = ? AND group_id = ?", animalID, groupID).First(&animal).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Animal not found"})
+			return
+		}
+
+		var target models.AnimalComment
+		if err := db.Preload("Tags").Where("id = ? AND animal_id = ?", commentID, animalID).First(&target).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Comment not found"})
+			return
+		}
+
+		sortOrder := "DESC"
+		if order := c.Query("order"); order == "asc" || order == "ASC" {
+			sortOrder = "ASC"
+		}
+
+		tagFilter := c.Query("tags")
+		if tagFilter != "" && !commentMatchesTagFilter(target, parseTagFilterNames(tagFilter)) {
+			// The comment exists, but wouldn't appear in a GetAnimalComments
+			// call using this tag filter — the same outcome the list
+			// endpoint itself would produce (the row just never comes back).
+			// Report it explicitly so the client can tell "filtered out"
+			// apart from "doesn't exist" and act accordingly (e.g. clear the
+			// filter) instead of silently paging forever.
+			c.JSON(http.StatusOK, gin.H{"found": false})
+			return
+		}
+
+		countQuery := db.Model(&models.AnimalComment{}).Where("animal_id = ?", animalID)
+		if tagFilter != "" {
+			countQuery = applyTagFilter(countQuery, parseTagFilterNames(tagFilter))
+		}
+		// Position = how many rows sort strictly before the target under the
+		// same ORDER BY GetAnimalComments uses for this sortOrder.
+		if sortOrder == "ASC" {
+			countQuery = countQuery.Where("animal_comments.created_at < ?", target.CreatedAt)
+		} else {
+			countQuery = countQuery.Where("animal_comments.created_at > ?", target.CreatedAt)
+		}
+
+		var position int64
+		if err := countQuery.Count(&position).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to locate comment"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"found": true, "offset": position})
 	}
 }
 

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
@@ -84,18 +83,6 @@ func sanitizeSessionMetadata(m *models.SessionMetadata) {
 	m.OtherNotes = htmlTagPattern.ReplaceAllString(m.OtherNotes, "")
 }
 
-// parseTagFilterNames splits and trims a comma-separated ?tags= query value
-// into individual tag names, shared by every handler that applies the
-// animal-comments tag filter so the split/trim logic can't drift out of sync
-// across them.
-func parseTagFilterNames(tagFilter string) []string {
-	tagNames := strings.Split(tagFilter, ",")
-	for i, name := range tagNames {
-		tagNames[i] = strings.TrimSpace(name)
-	}
-	return tagNames
-}
-
 // applyTagFilter joins in the tag filter's OR-matched comment_tags rows and
 // groups by comment id to dedupe when a comment matches multiple requested
 // tags. Shared by every animal-comments query that supports ?tags= so the
@@ -162,14 +149,14 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 
 		// Apply tag filter if provided (multiple tags = OR logic)
 		if tagFilter != "" {
-			query = applyTagFilter(query, parseTagFilterNames(tagFilter))
+			query = applyTagFilter(query, splitAndTrim(tagFilter))
 		}
 
 		// Get total count
 		var total int64
 		countQuery := db.Model(&models.AnimalComment{}).Where("animal_id = ?", animalID)
 		if tagFilter != "" {
-			countQuery = applyTagFilter(countQuery, parseTagFilterNames(tagFilter))
+			countQuery = applyTagFilter(countQuery, splitAndTrim(tagFilter))
 		}
 		if err := countQuery.Count(&total).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count comments"})
@@ -177,7 +164,13 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		var comments []models.AnimalComment
-		if err := query.Order("created_at " + sortOrder).Limit(limit).Offset(offset).Find(&comments).Error; err != nil {
+		// A secondary tie-break on id is required: without it, comments
+		// sharing an identical created_at (bulk-inserted/seeded data, or
+		// coarse client clocks) sort in whatever order Postgres happens to
+		// return them in, which can differ from GetAnimalCommentPosition's
+		// offset computation below and misalign which page a given comment
+		// actually lands on.
+		if err := query.Order("animal_comments.created_at " + sortOrder + ", animal_comments.id " + sortOrder).Limit(limit).Offset(offset).Find(&comments).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch comments"})
 			return
 		}
@@ -195,7 +188,7 @@ func GetAnimalComments(db *gorm.DB) gin.HandlerFunc {
 
 // commentMatchesTagFilter reports whether comment carries any of the given
 // tag names (the same OR-match semantics as GetAnimalComments' ?tags=
-// filter). tagNames is assumed already parsed via parseTagFilterNames.
+// filter). tagNames is assumed already parsed via splitAndTrim.
 func commentMatchesTagFilter(comment models.AnimalComment, tagNames []string) bool {
 	wanted := make(map[string]bool, len(tagNames))
 	for _, name := range tagNames {
@@ -235,8 +228,19 @@ func GetAnimalCommentPosition(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// Parsed before the target query below so the Preload("Tags") it needs
+		// can be made conditional — Tags is only read by commentMatchesTagFilter
+		// when a tag filter is actually present; the sole current caller
+		// (the frontend's deep-link locate effect) never sends one, so an
+		// unconditional preload would be a wasted join on every request.
+		tagFilter := c.Query("tags")
+
+		targetQuery := db.Where("id = ? AND animal_id = ?", commentID, animalID)
+		if tagFilter != "" {
+			targetQuery = targetQuery.Preload("Tags")
+		}
 		var target models.AnimalComment
-		if err := db.Preload("Tags").Where("id = ? AND animal_id = ?", commentID, animalID).First(&target).Error; err != nil {
+		if err := targetQuery.First(&target).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Comment not found"})
 			return
 		}
@@ -246,8 +250,7 @@ func GetAnimalCommentPosition(db *gorm.DB) gin.HandlerFunc {
 			sortOrder = "ASC"
 		}
 
-		tagFilter := c.Query("tags")
-		if tagFilter != "" && !commentMatchesTagFilter(target, parseTagFilterNames(tagFilter)) {
+		if tagFilter != "" && !commentMatchesTagFilter(target, splitAndTrim(tagFilter)) {
 			// The comment exists, but wouldn't appear in a GetAnimalComments
 			// call using this tag filter — the same outcome the list
 			// endpoint itself would produce (the row just never comes back).
@@ -260,14 +263,22 @@ func GetAnimalCommentPosition(db *gorm.DB) gin.HandlerFunc {
 
 		countQuery := db.Model(&models.AnimalComment{}).Where("animal_id = ?", animalID)
 		if tagFilter != "" {
-			countQuery = applyTagFilter(countQuery, parseTagFilterNames(tagFilter))
+			countQuery = applyTagFilter(countQuery, splitAndTrim(tagFilter))
 		}
 		// Position = how many rows sort strictly before the target under the
-		// same ORDER BY GetAnimalComments uses for this sortOrder.
+		// same ORDER BY (created_at, id) GetAnimalComments uses for this
+		// sortOrder — the id tie-break matters whenever another comment
+		// shares the target's exact created_at.
 		if sortOrder == "ASC" {
-			countQuery = countQuery.Where("animal_comments.created_at < ?", target.CreatedAt)
+			countQuery = countQuery.Where(
+				"(animal_comments.created_at < ? OR (animal_comments.created_at = ? AND animal_comments.id < ?))",
+				target.CreatedAt, target.CreatedAt, target.ID,
+			)
 		} else {
-			countQuery = countQuery.Where("animal_comments.created_at > ?", target.CreatedAt)
+			countQuery = countQuery.Where(
+				"(animal_comments.created_at > ? OR (animal_comments.created_at = ? AND animal_comments.id > ?))",
+				target.CreatedAt, target.CreatedAt, target.ID,
+			)
 		}
 
 		var position int64

--- a/internal/handlers/animal_comment_test.go
+++ b/internal/handlers/animal_comment_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
@@ -211,6 +212,110 @@ func TestGetAnimalComments_WithTagFilter(t *testing.T) {
 	// Accept either OK (if JOIN works) or error (SQLite limitations with complex JOINs)
 	// The important thing is the handler doesn't crash
 	assert.True(t, w.Code == http.StatusOK || w.Code == http.StatusInternalServerError)
+}
+
+func TestGetAnimalCommentPosition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupAnimalCommentTestDB(t)
+	defer func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	}()
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	oldest := models.AnimalComment{AnimalID: 1, UserID: 1, Content: "oldest", CreatedAt: base}
+	middle := models.AnimalComment{AnimalID: 1, UserID: 1, Content: "middle", CreatedAt: base.Add(time.Hour)}
+	newest := models.AnimalComment{AnimalID: 1, UserID: 1, Content: "newest", CreatedAt: base.Add(2 * time.Hour)}
+	db.Create(&oldest)
+	db.Create(&middle)
+	db.Create(&newest)
+
+	var urgentTag models.CommentTag
+	db.Where("name = ?", "urgent").First(&urgentTag)
+	db.Model(&middle).Association("Tags").Append(&urgentTag)
+
+	requestPosition := func(commentID uint, query string) (int, map[string]interface{}) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", fmt.Sprintf("/groups/1/animals/1/comments/%d/position%s", commentID, query), nil)
+		c.Set("user_id", uint(1))
+		c.Set("is_admin", false)
+		c.Params = gin.Params{
+			{Key: "id", Value: "1"},
+			{Key: "animalId", Value: "1"},
+			{Key: "commentId", Value: fmt.Sprintf("%d", commentID)},
+		}
+
+		handler := GetAnimalCommentPosition(db)
+		handler(c)
+
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		return w.Code, body
+	}
+
+	t.Run("default order (desc) ranks the newest comment first", func(t *testing.T) {
+		status, body := requestPosition(newest.ID, "")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, true, body["found"])
+		assert.Equal(t, float64(0), body["offset"])
+	})
+
+	t.Run("default order (desc) ranks the oldest comment last", func(t *testing.T) {
+		status, body := requestPosition(oldest.ID, "")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, float64(2), body["offset"])
+	})
+
+	t.Run("asc order reverses the ranking", func(t *testing.T) {
+		status, body := requestPosition(oldest.ID, "?order=asc")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, float64(0), body["offset"])
+
+		status, body = requestPosition(newest.ID, "?order=asc")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, float64(2), body["offset"])
+	})
+
+	t.Run("tag filter positions relative to the filtered set only", func(t *testing.T) {
+		// "middle" is the only urgent-tagged comment, so it's position 0
+		// within that filtered set even though it's position 1 overall.
+		status, body := requestPosition(middle.ID, "?tags=urgent")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, true, body["found"])
+		assert.Equal(t, float64(0), body["offset"])
+	})
+
+	t.Run("reports found:false when the comment doesn't match the active tag filter", func(t *testing.T) {
+		status, body := requestPosition(oldest.ID, "?tags=urgent")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, false, body["found"])
+		assert.NotContains(t, body, "offset")
+	})
+
+	t.Run("not found when the comment doesn't exist", func(t *testing.T) {
+		status, body := requestPosition(99999, "")
+		assert.Equal(t, http.StatusNotFound, status)
+		assert.Contains(t, body["error"], "Comment not found")
+	})
+
+	t.Run("forbidden when no group access", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", fmt.Sprintf("/groups/1/animals/1/comments/%d/position", oldest.ID), nil)
+		c.Set("user_id", uint(999))
+		c.Set("is_admin", false)
+		c.Params = gin.Params{
+			{Key: "id", Value: "1"},
+			{Key: "animalId", Value: "1"},
+			{Key: "commentId", Value: fmt.Sprintf("%d", oldest.ID)},
+		}
+
+		handler := GetAnimalCommentPosition(db)
+		handler(c)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
 }
 
 func TestCreateAnimalComment(t *testing.T) {

--- a/internal/handlers/animal_import_export.go
+++ b/internal/handlers/animal_import_export.go
@@ -307,17 +307,7 @@ func ExportAnimalCommentsCSV(db *gorm.DB) gin.HandlerFunc {
 
 		// Apply tag filter if provided (multiple tags = OR logic)
 		if tagFilter != "" {
-			tagNames := strings.Split(tagFilter, ",")
-			// Trim whitespace from tag names
-			for i, name := range tagNames {
-				tagNames[i] = strings.TrimSpace(name)
-			}
-
-			// Join with tag tables to filter by tags
-			query = query.Joins("JOIN animal_comment_tags ON animal_comment_tags.animal_comment_id = animal_comments.id").
-				Joins("JOIN comment_tags ON comment_tags.id = animal_comment_tags.comment_tag_id").
-				Where("comment_tags.name IN ?", tagNames).
-				Group("animal_comments.id")
+			query = applyTagFilter(query, splitAndTrim(tagFilter))
 		}
 
 		var comments []models.AnimalComment

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -147,7 +147,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance).
+					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance()).
 					// A tie-breaker on id is required for the same reason as
 					// the keyword query's: ties in vector distance (e.g.
 					// identical/empty embeddings) can otherwise return in a
@@ -207,7 +207,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := models.NonDeletedAnimalCommentsQuery(db).
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
-					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL AND "+semanticDistanceClause("animal_comments.embedding"), groupID, queryVector, maxSemanticDistance).
+					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL AND "+semanticDistanceClause("animal_comments.embedding"), groupID, queryVector, maxSemanticDistance()).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?, animal_comments.id ASC", Vars: []interface{}{queryVector}}})
 
@@ -252,7 +252,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance).
+					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance()).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?, updates.id ASC", Vars: []interface{}{queryVector}}})
 
@@ -369,8 +369,12 @@ func finishSemanticSearch[T any](resourceName string, keywordRows []T, rebuildKe
 	// embedding output, so log how many candidates survive it per request —
 	// this is the only visibility into whether it's cutting too aggressively
 	// (frequent 0s despite embedded rows existing) without querying
-	// production data directly.
-	logging.WithField("resource", resourceName).WithField("semanticCandidates", len(semanticRows)).Debug("Semantic search candidates within maxSemanticDistance")
+	// production data directly. Gated on logging.Enabled so the WithField
+	// chain's allocations (a new Logger + field map per call) aren't paid on
+	// every search request when DEBUG logging is off, which is the default.
+	if logging.Enabled(logging.DEBUG) {
+		logging.WithField("resource", resourceName).WithField("semanticCandidates", len(semanticRows)).Debug("Semantic search candidates within maxSemanticDistance")
+	}
 
 	rows, fusedTotal := fuse(keywordRows, semanticRows, offset, limit)
 	return rows, cappedTotal(keywordCount, fusedTotal), nil

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -147,7 +147,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL", groupID).
+					Where("group_id = ? AND embedding IS NOT NULL AND embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
 					// A tie-breaker on id is required for the same reason as
 					// the keyword query's: ties in vector distance (e.g.
 					// identical/empty embeddings) can otherwise return in a
@@ -207,7 +207,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := models.NonDeletedAnimalCommentsQuery(db).
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
-					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL", groupID).
+					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL AND animal_comments.embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?, animal_comments.id ASC", Vars: []interface{}{queryVector}}})
 
@@ -252,7 +252,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL", groupID).
+					Where("group_id = ? AND embedding IS NOT NULL AND embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?, updates.id ASC", Vars: []interface{}{queryVector}}})
 

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -147,7 +147,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Animal{}).
 					Select("animals.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL AND embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
+					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance).
 					// A tie-breaker on id is required for the same reason as
 					// the keyword query's: ties in vector distance (e.g.
 					// identical/empty embeddings) can otherwise return in a
@@ -207,7 +207,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := models.NonDeletedAnimalCommentsQuery(db).
 					Select("animal_comments.*, animals.name AS animal_name, 0::float8 AS rank").
-					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL AND animal_comments.embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
+					Where("animals.group_id = ? AND animal_comments.embedding IS NOT NULL AND "+semanticDistanceClause("animal_comments.embedding"), groupID, queryVector, maxSemanticDistance).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "animal_comments.embedding <=> ?, animal_comments.id ASC", Vars: []interface{}{queryVector}}})
 
@@ -252,7 +252,7 @@ func Search(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
 			} else {
 				semanticQuery := db.Model(&models.Update{}).
 					Select("updates.*, 0::float8 AS rank").
-					Where("group_id = ? AND embedding IS NOT NULL AND embedding <=> ? < ?", groupID, queryVector, maxSemanticDistance).
+					Where("group_id = ? AND embedding IS NOT NULL AND "+semanticDistanceClause("embedding"), groupID, queryVector, maxSemanticDistance).
 					// See the animals query above for why a tie-breaker on id is required.
 					Clauses(clause.OrderBy{Expression: clause.Expr{SQL: "embedding <=> ?, updates.id ASC", Vars: []interface{}{queryVector}}})
 
@@ -364,6 +364,13 @@ func finishSemanticSearch[T any](resourceName string, keywordRows []T, rebuildKe
 		}
 		return page, keywordCount, nil
 	}
+
+	// maxSemanticDistance (search_rank.go) hasn't been validated against real
+	// embedding output, so log how many candidates survive it per request —
+	// this is the only visibility into whether it's cutting too aggressively
+	// (frequent 0s despite embedded rows existing) without querying
+	// production data directly.
+	logging.WithField("resource", resourceName).WithField("semanticCandidates", len(semanticRows)).Debug("Semantic search candidates within maxSemanticDistance")
 
 	rows, fusedTotal := fuse(keywordRows, semanticRows, offset, limit)
 	return rows, cappedTotal(keywordCount, fusedTotal), nil

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -551,6 +551,40 @@ func TestSearch_Postgres_SemanticMatchSurfacesResultWithNoKeywordOverlap(t *test
 	}
 }
 
+// TestSearch_Postgres_ExcludesUnrelatedSemanticMatchesBeyondDistanceThreshold
+// guards against the semantic candidate query returning literally every
+// embedded row in the group merely because it has to return *something*: with
+// no keyword overlap and no genuinely similar row, "Unrelated" (orthogonal to
+// the query embedding, i.e. maximally dissimilar) must not appear in results
+// just because it's the least-distant of a small candidate set.
+func TestSearch_Postgres_ExcludesUnrelatedSemanticMatchesBeyondDistanceThreshold(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	noOverlap := models.Animal{GroupID: f.groupA.ID, Name: "Unrelated", Species: "Cat", Status: "available"}
+	if err := f.tx.Create(&noOverlap).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	// Orthogonal to the query embedding below (vectorWithOneAt(0)) — cosine
+	// distance 1.0, the maximum for two non-opposite vectors, i.e. as
+	// unrelated as two embeddings can be.
+	f.setAnimalEmbedding(t, noOverlap.ID, vectorWithOneAt(500))
+
+	c, w := f.searchRequest(t, f.groupA.ID, "tennis ball")
+	Search(f.tx, &fixedVectorEmbedder{vector: vectorWithOneAt(0)})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := decodeSearchResponse(t, w)
+	animals, _ := body["animals"].([]interface{})
+	for _, a := range animals {
+		if a.(map[string]interface{})["name"] == "Unrelated" {
+			t.Fatalf("expected \"Unrelated\" (orthogonal embedding, no keyword overlap) to be excluded as not a real match, got animals: %v", animals)
+		}
+	}
+}
+
 func TestSearch_Postgres_DegradesToKeywordOnlyWhenEmbedderFails(t *testing.T) {
 	// SEMANTIC_SEARCH_ENABLED is opt-in (defaults to disabled) — must be
 	// explicitly enabled here, or Usable(embedder) would short-circuit on

--- a/internal/handlers/search_rank.go
+++ b/internal/handlers/search_rank.go
@@ -45,6 +45,21 @@ const (
 	maxCandidatePool = 500
 )
 
+// maxSemanticDistance bounds the semantic candidate queries (see search.go)
+// to rows genuinely similar to the query embedding. Without it, "embedding IS
+// NOT NULL ORDER BY embedding <=> ? LIMIT pool" always returns `pool` rows
+// regardless of whether any of them are actually related to the query — with
+// a small group (fewer embedded rows than the pool floor), that means every
+// row in the group comes back, merely sorted by how (un)related it is,
+// letting fully irrelevant rows surface as "matches" whenever the keyword
+// query finds nothing to fuse against. Cosine distance ranges 0 (identical)
+// to 2 (opposite); 0.75 is a conservative starting cutoff meant to exclude
+// clearly-unrelated content while still admitting genuinely related matches
+// — it hasn't been validated against real Voyage embedding output (no
+// VOYAGE_API_KEY in dev/test) and should be tuned from production search
+// logs once real query/document embedding distances are observable.
+const maxSemanticDistance = 0.75
+
 // candidatePoolSize returns how many top matches to fetch from each of the
 // keyword and semantic queries before fusing. Ideally it covers the
 // requested page (offset+limit), so a "load more" page doesn't run out of

--- a/internal/handlers/search_rank.go
+++ b/internal/handlers/search_rank.go
@@ -1,6 +1,10 @@
 package handlers
 
-import "sort"
+import (
+	"os"
+	"sort"
+	"strconv"
+)
 
 // rrfK is Reciprocal Rank Fusion's standard smoothing constant. RRF combines
 // two differently-scaled ranked lists (ts_rank and cosine distance aren't on
@@ -45,6 +49,15 @@ const (
 	maxCandidatePool = 500
 )
 
+// defaultMaxSemanticDistance is maxSemanticDistance's value when
+// SEMANTIC_SEARCH_MAX_DISTANCE isn't set. Cosine distance ranges 0
+// (identical) to 2 (opposite); 0.75 is a conservative starting cutoff meant
+// to exclude clearly-unrelated content while still admitting genuinely
+// related matches — it hasn't been validated against real Voyage embedding
+// output (no VOYAGE_API_KEY in dev/test) and should be tuned from production
+// search logs once real query/document embedding distances are observable.
+const defaultMaxSemanticDistance = 0.75
+
 // maxSemanticDistance bounds the semantic candidate queries (see search.go)
 // to rows genuinely similar to the query embedding. Without it, "embedding IS
 // NOT NULL ORDER BY embedding <=> ? LIMIT pool" always returns `pool` rows
@@ -52,16 +65,22 @@ const (
 // a small group (fewer embedded rows than the pool floor), that means every
 // row in the group comes back, merely sorted by how (un)related it is,
 // letting fully irrelevant rows surface as "matches" whenever the keyword
-// query finds nothing to fuse against. Cosine distance ranges 0 (identical)
-// to 2 (opposite); 0.75 is a conservative starting cutoff meant to exclude
-// clearly-unrelated content while still admitting genuinely related matches
-// — it hasn't been validated against real Voyage embedding output (no
-// VOYAGE_API_KEY in dev/test) and should be tuned from production search
-// logs once real query/document embedding distances are observable. See
-// finishSemanticSearch's candidate-count log line, which exists so this
-// cutoff's real-world effect (how often it zeroes out the semantic side) is
-// observable without a code change.
-const maxSemanticDistance = 0.75
+// query finds nothing to fuse against.
+//
+// Overridable via SEMANTIC_SEARCH_MAX_DISTANCE (e.g. "0.8") so
+// defaultMaxSemanticDistance can be corrected from production search logs
+// (see finishSemanticSearch's candidate-count log line) without a code
+// change and redeploy. Read via os.Getenv per call, not cached, matching
+// embedding.SemanticSearchEnabled's pattern — cheap enough per-request, and
+// keeps it trivially overridable in tests via t.Setenv.
+func maxSemanticDistance() float64 {
+	if v := os.Getenv("SEMANTIC_SEARCH_MAX_DISTANCE"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return defaultMaxSemanticDistance
+}
 
 // semanticDistanceClause returns the "<column> <=> ? < ?" fragment each
 // resource's semantic candidate query in search.go uses to bound results to

--- a/internal/handlers/search_rank.go
+++ b/internal/handlers/search_rank.go
@@ -57,8 +57,23 @@ const (
 // clearly-unrelated content while still admitting genuinely related matches
 // — it hasn't been validated against real Voyage embedding output (no
 // VOYAGE_API_KEY in dev/test) and should be tuned from production search
-// logs once real query/document embedding distances are observable.
+// logs once real query/document embedding distances are observable. See
+// finishSemanticSearch's candidate-count log line, which exists so this
+// cutoff's real-world effect (how often it zeroes out the semantic side) is
+// observable without a code change.
 const maxSemanticDistance = 0.75
+
+// semanticDistanceClause returns the "<column> <=> ? < ?" fragment each
+// resource's semantic candidate query in search.go uses to bound results to
+// maxSemanticDistance. Centralized so the threshold/operator can't drift out
+// of sync across the animals/comments/updates queries, which are otherwise
+// identical in shape (see fuseResults' and finishSemanticSearch's doc
+// comments for why those are shared too). Callers still supply the query
+// vector and maxSemanticDistance as bind args, in that order, after this
+// fragment's own args.
+func semanticDistanceClause(embeddingColumn string) string {
+	return embeddingColumn + " <=> ? < ?"
+}
 
 // candidatePoolSize returns how many top matches to fetch from each of the
 // keyword and semantic queries before fusing. Ideally it covers the

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -328,6 +328,14 @@ func WithContext(ctx context.Context) *Logger {
 	return defaultLogger.WithContext(ctx)
 }
 
+// Enabled reports whether a message at the given level would actually be
+// emitted by the default logger, so a caller building an expensive field set
+// (e.g. a WithField chain, which allocates a new Logger and field map per
+// call) can skip that work entirely when the level is disabled.
+func Enabled(level Level) bool {
+	return level >= defaultLogger.level
+}
+
 // SetLevel sets the log level for the default logger
 func SetLevel(level Level) {
 	defaultLogger.level = level


### PR DESCRIPTION
## Summary
- Semantic search had no similarity threshold, so a query like "tennis ball" matched every animal in a group — the candidate pool query always returns `pool` rows regardless of relevance, and with fewer embedded rows than the pool floor (50), that's every row in the group. Added a `maxSemanticDistance` cosine-distance cutoff (0.75, a conservative starting point — not validated against real Voyage embeddings since no `VOYAGE_API_KEY` is available locally/in CI) applied to the animals/comments/updates semantic queries in `search.go`.
- Comment search results linked to the animal's page, not the comment itself. `GroupSearch` now links with `?comment=<id>`; `AnimalDetailPage` reads that param, auto-paginates through comment pages until it finds the target, then scrolls to and briefly highlights it.

## Test plan
- [x] `internal/handlers/search_postgres_test.go`: added `TestSearch_Postgres_ExcludesUnrelatedSemanticMatchesBeyondDistanceThreshold` — confirmed it fails without the fix (orthogonal/unrelated embedding surfaces as a match) and passes with it; full Postgres-gated suite (16 tests) passes
- [x] `frontend/src/pages/AnimalDetailPage.test.tsx`: added two tests for the deep-link/highlight/auto-paginate behavior — confirmed both fail without the fix and pass with it
- [x] `go build ./...`, `go vet ./...`, full non-Postgres handler test suite (one pre-existing unrelated failure on `TestCreateGroup/accepts_valid_GroupMe_bot_id`, reproduced identically on `main`)
- [x] `npx tsc --noEmit`, `npx eslint`, full frontend vitest suite for the touched files (21 tests)
- [ ] Manual click-through in a browser (not done this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)