### PR TITLE
Make voyage-api-key Container App secret conditional in prod

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -365,9 +365,12 @@ resource "azurerm_container_app" "main" {
       }
 
       # Semantic Search (Voyage AI embeddings)
-      env {
-        name        = "VOYAGE_API_KEY"
-        secret_name = "voyage-api-key"
+      dynamic "env" {
+        for_each = var.voyage_api_key != "" ? [1] : []
+        content {
+          name        = "VOYAGE_API_KEY"
+          secret_name = "voyage-api-key"
+        }
       }
 
       env {
@@ -454,9 +457,12 @@ resource "azurerm_container_app" "main" {
     value = var.resend_api_key
   }
 
-  secret {
-    name  = "voyage-api-key"
-    value = var.voyage_api_key
+  dynamic "secret" {
+    for_each = var.voyage_api_key != "" ? [var.voyage_api_key] : []
+    content {
+      name  = "voyage-api-key"
+      value = secret.value
+    }
   }
 
   secret {


### PR DESCRIPTION
## Summary
- Ports the fix from #248 (which only updated `dev/main.tf`) to `terraform/environments/prod/main.tf`
- `voyage-api-key` `secret`/`env` blocks are now `dynamic`, only created when `var.voyage_api_key != ""`
- Prevents `ContainerAppSecretInvalid` on prod apply if the Voyage API key is unset (it defaults to `""`)

## Test plan
- [x] `terraform fmt -check` / `terraform validate` pass in `terraform/environments/prod`
- [ ] `terraform plan` reviewed against real prod tfvars before merge/apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)