### PR TITLE
Add observability instrumentation: Voyage spans, vector search span, sweep heartbeat, auth failure reasons, version marker, business counters

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,6 +71,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN if [ -f "package.json" ]; then \
 # CGO_ENABLED=0 with GOOS/GOARCH lets Go cross-compile natively to linux/amd64.
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS backend-builder
 
+# GIT_SHA identifies the build for the service.version OTel resource
+# attribute (see internal/version). Passed in via --build-arg from CI
+# (build-image.yml); defaults to "dev" for a manual `docker build` with no
+# build-arg, matching internal/version.GitSHA's own local-dev default.
+ARG GIT_SHA=dev
+
 # Install security updates and build dependencies
 RUN apk update && apk upgrade && \
     apk add --no-cache git ca-certificates tzdata && \
@@ -48,7 +54,7 @@ COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 # whole dependency tree (e.g. Azure SDK) every time.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "-static"' -o /app/api ./cmd/api
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -extldflags \"-static\" -X github.com/networkengineer-cloud/go-volunteer-media/internal/version.GitSHA=${GIT_SHA}" -o /app/api ./cmd/api
 
 # Final stage — use the pre-built base image so LibreOffice is not installed
 # on every build. Rebuild the base by running build-base-image.yml manually

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev: ## Run both backend and frontend (requires two terminals)
 
 build-backend: ## Build backend binary
 	@echo "Building backend..."
-	go build -ldflags="-X github.com/networkengineer-cloud/go-volunteer-media/internal/version.GitSHA=$(shell git rev-parse --short HEAD)" -o api ./cmd/api
+	go build -ldflags="-X github.com/networkengineer-cloud/go-volunteer-media/internal/version.GitSHA=$(shell git rev-parse HEAD 2>/dev/null || echo dev)" -o api ./cmd/api
 
 build-frontend: ## Build frontend for production
 	@echo "Building frontend..."

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev: ## Run both backend and frontend (requires two terminals)
 
 build-backend: ## Build backend binary
 	@echo "Building backend..."
-	go build -o api ./cmd/api
+	go build -ldflags="-X github.com/networkengineer-cloud/go-volunteer-media/internal/version.GitSHA=$(shell git rev-parse --short HEAD)" -o api ./cmd/api
 
 build-frontend: ## Build frontend for production
 	@echo "Building frontend..."

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/storage"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/version"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
@@ -65,7 +66,7 @@ func main() {
 	// reads, no network dial), so there's nothing for a deadline to bound —
 	// actual export happens later, asynchronously, in background batch
 	// processors.
-	telemetry.Init(context.Background(), serviceName, os.Getenv("ENV"))
+	telemetry.Init(context.Background(), serviceName, os.Getenv("ENV"), version.GitSHA)
 
 	shutdownTelemetry := func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/embedding/sweep.go
+++ b/internal/embedding/sweep.go
@@ -9,6 +9,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 )
@@ -40,6 +41,14 @@ const sweepStopTimeout = 10 * time.Second
 // sweepComments/sweepUpdates call's PersistEmbedding write against a closed
 // *sql.DB.
 func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Duration) (stop func()) {
+	meter := telemetry.Meter("internal/embedding")
+	heartbeat := telemetry.NewInstrument("embedding.sweep.heartbeat", func() (metric.Int64Counter, error) {
+		return meter.Int64Counter(
+			"embedding.sweep.heartbeat",
+			metric.WithDescription("Incremented once per reconciliation sweep tick, regardless of outcome — absence signals the sweep goroutine died"),
+		)
+	})
+
 	ticker := time.NewTicker(interval)
 	done := make(chan struct{})
 	finished := make(chan struct{})
@@ -49,6 +58,7 @@ func StartReconciliationSweep(db *gorm.DB, embedder Embedder, interval time.Dura
 		for {
 			select {
 			case <-ticker.C:
+				heartbeat.Add(context.Background(), 1)
 				if !Usable(embedder) {
 					continue
 				}

--- a/internal/embedding/sweep_test.go
+++ b/internal/embedding/sweep_test.go
@@ -1,0 +1,61 @@
+package embedding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func heartbeatTotal(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "embedding.sweep.heartbeat" {
+				continue
+			}
+			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
+				for _, dp := range sum.DataPoints {
+					total += dp.Value
+				}
+			}
+		}
+	}
+	return total
+}
+
+// TestStartReconciliationSweep_EmitsHeartbeatEveryTickEvenWhenUnusable proves
+// the heartbeat fires unconditionally — including on ticks where the sweep
+// itself does nothing because the embedder isn't usable. This is the case
+// that matters: the heartbeat exists to detect the scheduler goroutine dying
+// entirely, so it must not depend on a successful (or even attempted) sweep.
+func TestStartReconciliationSweep_EmitsHeartbeatEveryTickEvenWhenUnusable(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer otel.SetMeterProvider(prev)
+
+	interval := 5 * time.Millisecond
+	// nil db is safe here: Unconfigured makes Usable() false, so
+	// sweepAnimals/sweepComments/sweepUpdates (the only callers that touch
+	// db) are never invoked.
+	stop := StartReconciliationSweep(nil, &StubEmbedder{Unconfigured: true}, interval)
+	defer stop()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for heartbeatTotal(t, reader) < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected at least 2 heartbeat ticks within 500ms at a %s interval, got %d", interval, heartbeatTotal(t, reader))
+		}
+		time.Sleep(interval)
+	}
+}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -97,16 +98,25 @@ type voyageResponseItem struct {
 }
 
 type voyageResponse struct {
-	Data []voyageResponseItem `json:"data"`
+	Data  []voyageResponseItem `json:"data"`
+	Usage *struct {
+		TotalTokens int `json:"total_tokens"`
+	} `json:"usage"`
 }
 
-func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input interface{}, inputType string) ([]voyageResponseItem, error) {
+func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input interface{}, inputType string, batchSize int) ([]voyageResponseItem, error) {
 	if !v.IsConfigured() {
 		return nil, fmt.Errorf("Voyage embedder is not configured (VOYAGE_API_KEY not set)")
 	}
 
 	ctx, span := tracer.Start(ctx, spanName)
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("voyage.model", v.model),
+		attribute.String("voyage.input_type", inputType),
+		attribute.Int("voyage.batch_size", batchSize),
+		attribute.Int("voyage.dimension", Dimension),
+	)
 
 	reqBody := voyageRequest{
 		Input:           input,
@@ -145,6 +155,7 @@ func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input inter
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		span.SetAttributes(attribute.Int("voyage.http_status", resp.StatusCode))
 		// Truncated rather than included in full: an error response body is
 		// operator-facing diagnostic text, not something this app's own
 		// logs should let grow unbounded or risk echoing back arbitrarily
@@ -155,6 +166,9 @@ func (v *VoyageEmbedder) embed(ctx context.Context, spanName string, input inter
 	var voyageResp voyageResponse
 	if err := json.Unmarshal(body, &voyageResp); err != nil {
 		return nil, telemetry.Fail(span, fmt.Errorf("failed to unmarshal Voyage response: %w", err), "unmarshal failed")
+	}
+	if voyageResp.Usage != nil {
+		span.SetAttributes(attribute.Int("voyage.total_tokens", voyageResp.Usage.TotalTokens))
 	}
 
 	return voyageResp.Data, nil
@@ -186,7 +200,7 @@ func firstEmbedding(items []voyageResponseItem) ([]float32, error) {
 
 // EmbedDocument embeds a single piece of indexed text (input_type "document").
 func (v *VoyageEmbedder) EmbedDocument(ctx context.Context, text string) ([]float32, error) {
-	items, err := v.embed(ctx, "embedding.voyage.embed_document", text, "document")
+	items, err := v.embed(ctx, "embedding.voyage.embed_document", text, "document", 1)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +211,7 @@ func (v *VoyageEmbedder) EmbedDocument(ctx context.Context, text string) ([]floa
 // retrieval-tuned models perform better when query text is distinguished
 // from document text at embed time.
 func (v *VoyageEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
-	items, err := v.embed(ctx, "embedding.voyage.embed_query", text, "query")
+	items, err := v.embed(ctx, "embedding.voyage.embed_query", text, "query", 1)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +224,7 @@ func (v *VoyageEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([]
 	for i, t := range texts {
 		inputs[i] = t
 	}
-	items, err := v.embed(ctx, "embedding.voyage.embed_documents", inputs, "document")
+	items, err := v.embed(ctx, "embedding.voyage.embed_documents", inputs, "document", len(texts))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -380,7 +380,6 @@ func TestVoyageEmbedder_EmbedDocument_RecordsTotalTokensWhenPresent(t *testing.T
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	tp.ForceFlush(context.Background())
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {
 		t.Fatalf("expected 1 recorded span, got %d", len(spans))

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -268,9 +267,9 @@ func TestVoyageEmbedder_IsConfigured(t *testing.T) {
 func TestVoyageEmbedder_EmbedDocuments_RecordsSpanAttributes(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	defer otel.SetTracerProvider(prev)
+	origTracer := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = origTracer }()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := voyageTestResponse{Data: []voyageTestResponseItem{
@@ -315,9 +314,9 @@ func TestVoyageEmbedder_EmbedDocuments_RecordsSpanAttributes(t *testing.T) {
 func TestVoyageEmbedder_EmbedDocument_RecordsHTTPStatusOnFailure(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	defer otel.SetTracerProvider(prev)
+	origTracer := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = origTracer }()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
@@ -354,9 +353,9 @@ func TestVoyageEmbedder_EmbedDocument_RecordsHTTPStatusOnFailure(t *testing.T) {
 func TestVoyageEmbedder_EmbedDocument_RecordsTotalTokensWhenPresent(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	defer otel.SetTracerProvider(prev)
+	origTracer := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = origTracer }()
 
 	type responseWithUsage struct {
 		Data  []voyageTestResponseItem `json:"data"`

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -7,6 +7,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type voyageTestRequest struct {
@@ -257,5 +262,137 @@ func TestVoyageEmbedder_IsConfigured(t *testing.T) {
 	v.apiKey = "test-key"
 	if !v.IsConfigured() {
 		t.Fatal("expected IsConfigured to be true with an API key set")
+	}
+}
+
+func TestVoyageEmbedder_EmbedDocuments_RecordsSpanAttributes(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := voyageTestResponse{Data: []voyageTestResponseItem{
+			{Embedding: make([]float32, Dimension), Index: 0},
+			{Embedding: make([]float32, Dimension), Index: 1},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+	v.model = "voyage-4"
+
+	if _, err := v.EmbedDocuments(context.Background(), []string{"a", "b"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	got := map[string]interface{}{}
+	for _, a := range spans[0].Attributes {
+		got[string(a.Key)] = a.Value.AsInterface()
+	}
+	want := map[string]interface{}{
+		"voyage.model":      "voyage-4",
+		"voyage.input_type": "document",
+		"voyage.batch_size": int64(2),
+		"voyage.dimension":  int64(Dimension),
+	}
+	for k, wantV := range want {
+		if got[k] != wantV {
+			t.Errorf("attribute %s = %v, want %v", k, got[k], wantV)
+		}
+	}
+}
+
+func TestVoyageEmbedder_EmbedDocument_RecordsHTTPStatusOnFailure(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocument(context.Background(), "text"); err == nil {
+		t.Fatal("expected an error for a 429 response")
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	if spans[0].Status.Code != codes.Error {
+		t.Fatalf("expected span status Error, got %v", spans[0].Status)
+	}
+	var gotStatus int64 = -1
+	for _, a := range spans[0].Attributes {
+		if string(a.Key) == "voyage.http_status" {
+			gotStatus = a.Value.AsInt64()
+		}
+	}
+	if gotStatus != http.StatusTooManyRequests {
+		t.Fatalf("voyage.http_status = %d, want %d", gotStatus, http.StatusTooManyRequests)
+	}
+}
+
+func TestVoyageEmbedder_EmbedDocument_RecordsTotalTokensWhenPresent(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+
+	type responseWithUsage struct {
+		Data  []voyageTestResponseItem `json:"data"`
+		Usage struct {
+			TotalTokens int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := responseWithUsage{Data: []voyageTestResponseItem{{Embedding: make([]float32, Dimension), Index: 0}}}
+		resp.Usage.TotalTokens = 42
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	v := NewVoyageEmbedder()
+	v.apiKey = "test-key"
+	v.apiURL = server.URL
+
+	if _, err := v.EmbedDocument(context.Background(), "text"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	var gotTokens int64 = -1
+	for _, a := range spans[0].Attributes {
+		if string(a.Key) == "voyage.total_tokens" {
+			gotTokens = a.Value.AsInt64()
+		}
+	}
+	if gotTokens != 42 {
+		t.Fatalf("voyage.total_tokens = %d, want 42", gotTokens)
 	}
 }

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"go.opentelemetry.io/otel/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/metric"
 	"gorm.io/gorm"
 )
 

--- a/internal/handlers/animal_comment.go
+++ b/internal/handlers/animal_comment.go
@@ -8,9 +8,11 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
 	"gorm.io/gorm"
 )
 
@@ -293,6 +295,14 @@ func GetAnimalCommentPosition(db *gorm.DB) gin.HandlerFunc {
 
 // CreateAnimalComment creates a new comment on an animal
 func CreateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFunc {
+	meter := telemetry.Meter("internal/handlers/animal_comment")
+	commentsCreated := telemetry.NewInstrument("comments.created", func() (metric.Int64Counter, error) {
+		return meter.Int64Counter(
+			"comments.created",
+			metric.WithDescription("Comments successfully created"),
+		)
+	})
+
 	return func(c *gin.Context) {
 		// rawDB is captured before the shadow below so the detached
 		// goroutine spawned by embedCommentAsync gets the unscoped db, not
@@ -358,6 +368,7 @@ func CreateAnimalComment(db *gorm.DB, embedder embedding.Embedder) gin.HandlerFu
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create comment"})
 			return
 		}
+		commentsCreated.Add(c.Request.Context(), 1)
 
 		embedCommentAsync(rawDB, embedder, comment)
 

--- a/internal/handlers/animal_comment_test.go
+++ b/internal/handlers/animal_comment_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -551,5 +553,41 @@ func TestGetGroupLatestComments(t *testing.T) {
 				assert.Contains(t, w.Body.String(), tt.expectedError)
 			}
 		})
+	}
+}
+
+func TestCreateAnimalComment_IncrementsCommentsCreatedCounter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer otel.SetMeterProvider(prev)
+
+	db := setupAnimalCommentTestDB(t)
+	defer func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	}()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body, _ := json.Marshal(AnimalCommentRequest{Content: "Test comment"})
+	c.Request = httptest.NewRequest("POST", "/groups/1/animals/1/comments", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user_id", uint(1))
+	c.Set("is_admin", false)
+	c.Params = gin.Params{{Key: "id", Value: "1"}, {Key: "animalId", Value: "1"}}
+
+	handler := CreateAnimalComment(db, &embedding.StubEmbedder{})
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if total := metricSum(t, reader, "comments.created"); total != 1 {
+		t.Fatalf("comments.created = %d, want 1", total)
 	}
 }

--- a/internal/handlers/animal_comment_test.go
+++ b/internal/handlers/animal_comment_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"go.opentelemetry.io/otel"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"go.opentelemetry.io/otel/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/metric"
 	"gorm.io/gorm"
 )
 

--- a/internal/handlers/animal_crud.go
+++ b/internal/handlers/animal_crud.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/metric"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
 	"gorm.io/gorm"
 )
 
@@ -192,6 +194,14 @@ func GetAnimal(db *gorm.DB) gin.HandlerFunc {
 
 // CreateAnimal creates a new animal in a group
 func CreateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.Embedder) gin.HandlerFunc {
+	meter := telemetry.Meter("internal/handlers/animal_crud")
+	animalsCreated := telemetry.NewInstrument("animals.created", func() (metric.Int64Counter, error) {
+		return meter.Int64Counter(
+			"animals.created",
+			metric.WithDescription("Animals successfully created"),
+		)
+	})
+
 	return func(c *gin.Context) {
 		// rawDB is captured before the shadow below so the detached
 		// goroutine spawned by sendQuarantineNotificationEmail gets the
@@ -293,6 +303,7 @@ func CreateAnimal(db *gorm.DB, emailService *email.Service, embedder embedding.E
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create animal"})
 			return
 		}
+		animalsCreated.Add(c.Request.Context(), 1)
 
 		embedAnimalAsync(rawDB, embedder, animal)
 

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
-	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
 
 // animalListItem is the minimal shape of a GetAnimals response entry used across tests.

--- a/internal/handlers/animal_test.go
+++ b/internal/handlers/animal_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,6 +11,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/embedding"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 )
@@ -2629,5 +2633,57 @@ func TestUpdateAnimal_LeaveQuarantine_EarlyExit_CapsEndDateAtNow(t *testing.T) {
 	}
 	if incident.EndDate.Before(beforeRequest) || incident.EndDate.After(afterRequest) {
 		t.Errorf("Expected EndDate to be capped at now (between %v and %v), got %v (stored future end date was %v)", beforeRequest, afterRequest, *incident.EndDate, futureEndDate)
+	}
+}
+
+func metricSum(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
+				for _, dp := range sum.DataPoints {
+					total += dp.Value
+				}
+			}
+		}
+	}
+	return total
+}
+
+func TestCreateAnimal_IncrementsAnimalsCreatedCounter(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer otel.SetMeterProvider(prev)
+
+	db := setupAnimalTestDB(t)
+	user, group := createAnimalTestUser(t, db, "testuser", "test@example.com", false)
+
+	animalReq := AnimalRequest{Name: "Rex", Species: "Dog", Status: "available"}
+	jsonData, _ := json.Marshal(animalReq)
+
+	c, w := setupAnimalTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/groups/%d/animals", group.ID), bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := CreateAnimal(db, nil, &embedding.StubEmbedder{})
+	handler(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if total := metricSum(t, reader, "animals.created"); total != 1 {
+		t.Fatalf("animals.created = %d, want 1", total)
 	}
 }

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -10,6 +10,8 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gorm"
 )
 
@@ -108,6 +110,7 @@ func Login(db *gorm.DB) gin.HandlerFunc {
 		if err := db.Preload("Groups", activeGroupsPreload).Where("LOWER(username) = ?", strings.ToLower(req.Username)).First(&user).Error; err != nil {
 			// Audit log: failed login attempt (user not found)
 			logging.LogAuthFailure(ctx, req.Username, c.ClientIP(), "user_not_found")
+			telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "invalid_credentials"))
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 			return
 		}
@@ -185,6 +188,7 @@ func Login(db *gorm.DB) gin.HandlerFunc {
 
 			// Audit log: failed login attempt
 			logging.LogAuthFailure(ctx, req.Username, c.ClientIP(), "invalid_password")
+			telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "invalid_credentials"))
 
 			attemptsRemaining := MaxFailedLoginAttempts - user.FailedLoginAttempts
 			c.JSON(http.StatusUnauthorized, gin.H{

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gorm.io/gorm"
 )
 
@@ -591,5 +594,68 @@ func TestGetCurrentUserSoftDeletedGroups(t *testing.T) {
 				t.Errorf("Expected 'active-group', got '%s'", groupName)
 			}
 		}
+	}
+}
+
+func TestLogin_RecordsFailureReasonOnSpan(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		setupDB func(*gorm.DB)
+		payload map[string]interface{}
+	}{
+		{
+			name:    "user not found",
+			payload: map[string]interface{}{"username": "nobody", "password": "whatever123"},
+		},
+		{
+			name: "wrong password",
+			setupDB: func(db *gorm.DB) {
+				createTestUser(t, db, "testuser", "test@example.com", "password123", false)
+			},
+			payload: map[string]interface{}{"username": "testuser", "password": "wrongpassword"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			if tt.setupDB != nil {
+				tt.setupDB(db)
+			}
+
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+			ctx, span := tp.Tracer("test").Start(context.Background(), "test-request")
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			jsonBytes, _ := json.Marshal(tt.payload)
+			req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBuffer(jsonBytes))
+			req.Header.Set("Content-Type", "application/json")
+			c.Request = req.WithContext(ctx)
+
+			Login(db)(c)
+			span.End()
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+			}
+
+			spans := exporter.GetSpans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 recorded span, got %d", len(spans))
+			}
+			got := ""
+			for _, a := range spans[0].Attributes {
+				if string(a.Key) == "auth_failure_reason" {
+					got = a.Value.AsString()
+				}
+			}
+			if got != "invalid_credentials" {
+				t.Errorf("auth_failure_reason = %q, want %q", got, "invalid_credentials")
+			}
+		})
 	}
 }

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -20,6 +20,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var tracer = telemetry.Tracer("internal/handlers/search")
+
 // animalSearchResult is an animal match with its full-text/semantic
 // relevance rank (the Reciprocal Rank Fusion score once fused; see
 // fuseAnimalResults).
@@ -376,8 +378,19 @@ func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int
 // rather than kept as three copies that could drift out of sync — e.g. a
 // fix to the degrade-on-error behavior only needs to be made once.
 func finishSemanticSearch[T any](ctx context.Context, resourceName string, keywordRows []T, rebuildKeywordPage func() *gorm.DB, semanticQuery *gorm.DB, pool int, fuse func(keyword, semantic []T, offset, limit int) ([]T, int), keywordCount int64, offset, limit int, candidatesHistogram metric.Int64Histogram) ([]T, int64, error) {
+	_, span := tracer.Start(ctx, "search.vector_query")
+	span.SetAttributes(
+		attribute.String("search.resource", resourceName),
+		attribute.Float64("search.similarity_threshold", maxSemanticDistance()),
+		attribute.Int("search.embedding_dimension", embedding.Dimension),
+	)
+
 	var semanticRows []T
-	if err := semanticQuery.Limit(pool).Find(&semanticRows).Error; err != nil {
+	err := semanticQuery.Limit(pool).Find(&semanticRows).Error
+	if err != nil {
+		telemetry.Fail(span, err, "vector query failed")
+		span.End()
+
 		// Semantic search is a ranking enhancement, never a hard dependency
 		// (see Search's doc comment): degrade to keyword-only ranking
 		// instead of discarding the keyword results already in hand.
@@ -399,6 +412,9 @@ func finishSemanticSearch[T any](ctx context.Context, resourceName string, keywo
 		}
 		return page, keywordCount, nil
 	}
+
+	span.SetAttributes(attribute.Int("search.candidate_count", len(semanticRows)))
+	span.End()
 
 	// maxSemanticDistance (search_rank.go) hasn't been validated against real
 	// embedding output, so record how many candidates survive it per

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -381,7 +381,7 @@ func finishSemanticSearch[T any](ctx context.Context, resourceName string, keywo
 	_, span := tracer.Start(ctx, "search.vector_query")
 	span.SetAttributes(
 		attribute.String("search.resource", resourceName),
-		attribute.Float64("search.similarity_threshold", maxSemanticDistance()),
+		attribute.Float64("search.max_distance", maxSemanticDistance()),
 		attribute.Int("search.embedding_dimension", embedding.Dimension),
 	)
 

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -378,15 +378,22 @@ func fuseUpdateResults(keyword, semantic []updateSearchResult, offset, limit int
 // rather than kept as three copies that could drift out of sync — e.g. a
 // fix to the degrade-on-error behavior only needs to be made once.
 func finishSemanticSearch[T any](ctx context.Context, resourceName string, keywordRows []T, rebuildKeywordPage func() *gorm.DB, semanticQuery *gorm.DB, pool int, fuse func(keyword, semantic []T, offset, limit int) ([]T, int), keywordCount int64, offset, limit int, candidatesHistogram metric.Int64Histogram) ([]T, int64, error) {
-	_, span := tracer.Start(ctx, "search.vector_query")
+	spanCtx, span := tracer.Start(ctx, "search.vector_query")
 	span.SetAttributes(
 		attribute.String("search.resource", resourceName),
 		attribute.Float64("search.max_distance", maxSemanticDistance()),
 		attribute.Int("search.embedding_dimension", embedding.Dimension),
 	)
 
+	// WithContext(spanCtx), not the outer ctx: semanticQuery was built
+	// against the request context before this span existed, so without
+	// rebinding here the otelgorm plugin parents the actual gorm.Query span
+	// to the request span instead of to search.vector_query — defeating
+	// the point of this span, which is to make the vector query
+	// identifiable among the other (identically-named) gorm.Query spans a
+	// search request emits.
 	var semanticRows []T
-	err := semanticQuery.Limit(pool).Find(&semanticRows).Error
+	err := semanticQuery.WithContext(spanCtx).Limit(pool).Find(&semanticRows).Error
 	if err != nil {
 		telemetry.Fail(span, err, "vector query failed")
 		span.End()

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/assert"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -893,5 +895,56 @@ func TestSearch_Postgres_DeepPaginationCoversResultsBeyondDefaultPool(t *testing
 	animals, _ := body["animals"].([]interface{})
 	if len(animals) != 5 {
 		t.Fatalf("expected 5 animals on the last partial page (60 total, offset=55, limit=10), got %d: %v", len(animals), animals)
+	}
+}
+
+func TestSearch_Postgres_RecordsVectorQuerySpan(t *testing.T) {
+	t.Setenv("SEMANTIC_SEARCH_ENABLED", "true")
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	origTracer := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = origTracer }()
+
+	db := openSearchTestPostgres(t)
+	f := newSearchTestFixture(t, db)
+
+	animal := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Status: "available", Description: "resource guarding around food bowls"}
+	if err := f.tx.Create(&animal).Error; err != nil {
+		t.Fatalf("create animal: %v", err)
+	}
+	f.setAnimalEmbedding(t, animal.ID, vectorWithOneAt(0))
+
+	c, w := f.searchRequestWithParams(t, f.groupA.ID, url.Values{"q": {"resource guarding"}, "type": {"animals"}})
+	Search(f.tx, &fixedVectorEmbedder{vector: vectorWithOneAt(0)})(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var vectorSpans []tracetest.SpanStub
+	for _, s := range exporter.GetSpans() {
+		if s.Name == "search.vector_query" {
+			vectorSpans = append(vectorSpans, s)
+		}
+	}
+	if len(vectorSpans) != 1 {
+		t.Fatalf("expected 1 search.vector_query span, got %d", len(vectorSpans))
+	}
+
+	got := map[string]interface{}{}
+	for _, a := range vectorSpans[0].Attributes {
+		got[string(a.Key)] = a.Value.AsInterface()
+	}
+	if got["search.resource"] != "animals" {
+		t.Errorf("search.resource = %v, want %q", got["search.resource"], "animals")
+	}
+	if got["search.embedding_dimension"] != int64(embedding.Dimension) {
+		t.Errorf("search.embedding_dimension = %v, want %d", got["search.embedding_dimension"], embedding.Dimension)
+	}
+	if _, ok := got["search.candidate_count"]; !ok {
+		t.Error("expected search.candidate_count attribute to be set")
+	}
+	if _, ok := got["search.similarity_threshold"]; !ok {
+		t.Error("expected search.similarity_threshold attribute to be set")
 	}
 }

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -944,7 +944,7 @@ func TestSearch_Postgres_RecordsVectorQuerySpan(t *testing.T) {
 	if _, ok := got["search.candidate_count"]; !ok {
 		t.Error("expected search.candidate_count attribute to be set")
 	}
-	if _, ok := got["search.similarity_threshold"]; !ok {
-		t.Error("expected search.similarity_threshold attribute to be set")
+	if _, ok := got["search.max_distance"]; !ok {
+		t.Error("expected search.max_distance attribute to be set")
 	}
 }

--- a/internal/handlers/search_postgres_test.go
+++ b/internal/handlers/search_postgres_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gorm.io/driver/postgres"
@@ -908,6 +909,13 @@ func TestSearch_Postgres_RecordsVectorQuerySpan(t *testing.T) {
 	defer func() { tracer = origTracer }()
 
 	db := openSearchTestPostgres(t)
+	// Registered against tp (not the global provider) so the gorm.Query
+	// span this produces lands in the same exporter as search.vector_query
+	// above, letting the assertion below check they're actually nested
+	// rather than merely both existing.
+	if err := db.Use(otelgorm.NewPlugin(otelgorm.WithTracerProvider(tp))); err != nil {
+		t.Fatalf("register otelgorm plugin: %v", err)
+	}
 	f := newSearchTestFixture(t, db)
 
 	animal := models.Animal{GroupID: f.groupA.ID, Name: "Rex", Species: "Dog", Status: "available", Description: "resource guarding around food bowls"}
@@ -922,9 +930,13 @@ func TestSearch_Postgres_RecordsVectorQuerySpan(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var vectorSpans []tracetest.SpanStub
+	var gormQuerySpans []tracetest.SpanStub
 	for _, s := range exporter.GetSpans() {
-		if s.Name == "search.vector_query" {
+		switch s.Name {
+		case "search.vector_query":
 			vectorSpans = append(vectorSpans, s)
+		case "gorm.Query":
+			gormQuerySpans = append(gormQuerySpans, s)
 		}
 	}
 	if len(vectorSpans) != 1 {
@@ -946,5 +958,22 @@ func TestSearch_Postgres_RecordsVectorQuerySpan(t *testing.T) {
 	}
 	if _, ok := got["search.max_distance"]; !ok {
 		t.Error("expected search.max_distance attribute to be set")
+	}
+
+	// The whole point of search.vector_query is to make the semantic
+	// query's gorm.Query span identifiable among the several
+	// identically-named ones a search request emits — so it must actually
+	// be that span's parent, not merely a sibling that happens to overlap
+	// in time.
+	vectorSpanID := vectorSpans[0].SpanContext.SpanID()
+	childFound := false
+	for _, gs := range gormQuerySpans {
+		if gs.Parent.SpanID() == vectorSpanID {
+			childFound = true
+			break
+		}
+	}
+	if !childFound {
+		t.Error("expected a gorm.Query span parented to search.vector_query — the vector query's own span is not nested under it")
 	}
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -2,15 +2,19 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/auth"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gorm"
 )
 
@@ -71,6 +75,7 @@ func AuthRequired(db *gorm.DB) gin.HandlerFunc {
 				"endpoint": c.Request.URL.Path,
 				"method":   c.Request.Method,
 			}).Warn("Authorization header missing")
+			telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "missing_header"))
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header required"})
 			c.Abort()
 			return
@@ -85,6 +90,7 @@ func AuthRequired(db *gorm.DB) gin.HandlerFunc {
 				"endpoint": c.Request.URL.Path,
 				"method":   c.Request.Method,
 			}).Warn("Invalid authorization format")
+			telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "invalid_format"))
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid authorization format"})
 			c.Abort()
 			return
@@ -103,6 +109,7 @@ func AuthRequired(db *gorm.DB) gin.HandlerFunc {
 				}).Warn("Invalid or expired API token")
 
 				logging.LogUnauthorizedAccess(ctx, c.ClientIP(), c.Request.URL.Path, "invalid_api_token")
+				telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "invalid_api_token"))
 
 				c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired token"})
 				c.Abort()
@@ -128,6 +135,12 @@ func AuthRequired(db *gorm.DB) gin.HandlerFunc {
 
 			// Use audit logger for security event
 			logging.LogUnauthorizedAccess(ctx, c.ClientIP(), c.Request.URL.Path, "invalid_token")
+
+			reason := "token_invalid"
+			if errors.Is(err, jwt.ErrTokenExpired) {
+				reason = "token_expired"
+			}
+			telemetry.SetSpanAttributes(ctx, attribute.String("auth_failure_reason", reason))
 
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired token"})
 			c.Abort()

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +11,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/auth"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -1005,4 +1009,78 @@ func TestAuthRequired_APIToken(t *testing.T) {
 			t.Errorf("body = %s, want is_admin false (reflecting the demotion)", w.Body.String())
 		}
 	})
+}
+
+func TestAuthRequired_RecordsFailureReasonOnSpan(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		buildToken func(t *testing.T) string
+		wantReason string
+	}{
+		{name: "missing header", authHeader: "", wantReason: "missing_header"},
+		{name: "invalid format", authHeader: "Basic abc", wantReason: "invalid_format"},
+		{name: "invalid token", authHeader: "Bearer not-a-real-token", wantReason: "token_invalid"},
+		{
+			name: "expired token",
+			buildToken: func(t *testing.T) string {
+				claims := auth.Claims{
+					UserID: 1,
+					RegisteredClaims: jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+						IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+					},
+				}
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+				signed, err := token.SignedString([]byte("L5WTt6D+6R55YfKzwqPRAEX5bR0bkNo4i58jYKL0wsk="))
+				if err != nil {
+					t.Fatalf("failed to sign expired test token: %v", err)
+				}
+				return signed
+			},
+			wantReason: "token_expired",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+			ctx, span := tp.Tracer("test").Start(context.Background(), "test-request")
+
+			authHeader := tt.authHeader
+			if tt.buildToken != nil {
+				authHeader = "Bearer " + tt.buildToken(t)
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req := httptest.NewRequest("GET", "/protected", nil)
+			if authHeader != "" {
+				req.Header.Set("Authorization", authHeader)
+			}
+			c.Request = req.WithContext(ctx)
+
+			AuthRequired(newMiddlewareTestDB(t))(c)
+			span.End()
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", w.Code)
+			}
+
+			spans := exporter.GetSpans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 recorded span, got %d", len(spans))
+			}
+			got := ""
+			for _, a := range spans[0].Attributes {
+				if string(a.Key) == "auth_failure_reason" {
+					got = a.Value.AsString()
+				}
+			}
+			if got != tt.wantReason {
+				t.Errorf("auth_failure_reason = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/log/global"
 	lognoop "go.opentelemetry.io/otel/log/noop"
@@ -245,6 +246,14 @@ func RecordError(span trace.Span, err error, msg string) {
 func Fail(span trace.Span, err error, msg string) error {
 	RecordError(span, err, msg)
 	return err
+}
+
+// SetSpanAttributes sets attrs on the span active in ctx, if any. A no-op
+// when ctx carries no recording span — the single entry point handlers use
+// to annotate "the current request span" (e.g. why a 401 happened) without
+// each repeating the trace.SpanFromContext lookup themselves.
+func SetSpanAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
 }
 
 // Tracer returns a named tracer via the current global TracerProvider. A

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -77,7 +77,7 @@ func Enabled() bool {
 // traces/logs. Without that per-signal header, metrics silently degrade to
 // the generic one — no error here or in Terraform, just data landing in the
 // wrong dataset (or rejected) on the Axiom side.
-func Init(ctx context.Context, serviceName, environment string) {
+func Init(ctx context.Context, serviceName, environment, version string) {
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if endpoint == "" {
 		logging.Info("OTEL_EXPORTER_OTLP_ENDPOINT not set, telemetry disabled (using no-op providers)")
@@ -94,12 +94,7 @@ func Init(ctx context.Context, serviceName, environment string) {
 		logging.WithField("error", err.Error()).Warn("opentelemetry reported an internal error")
 	}))
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.DeploymentEnvironmentName(environment),
-		),
-	)
+	res, err := buildResource(ctx, serviceName, environment, version)
 	if err != nil {
 		logging.WithField("error", err.Error()).Warn("failed to build otel resource, falling back to no-op telemetry providers")
 		return
@@ -122,6 +117,20 @@ func Init(ctx context.Context, serviceName, environment string) {
 	}
 
 	logging.WithField("endpoint", endpoint).Info("OpenTelemetry initialized")
+}
+
+// buildResource constructs the OTel resource identifying this process —
+// service name, version (git SHA, or "dev" outside a versioned build), and
+// deployment environment. Split out from Init so it's unit-testable without
+// spinning up real exporters.
+func buildResource(ctx context.Context, serviceName, environment, version string) (*resource.Resource, error) {
+	return resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(version),
+			semconv.DeploymentEnvironmentName(environment),
+		),
+	)
 }
 
 // fallback tears down any providers Init already configured before a later

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // weakTestCertPEM is a throwaway self-signed cert (not a secret; borrowed
@@ -95,4 +98,34 @@ func TestInit_ExporterSetupError_FallsBackToNoOp(t *testing.T) {
 	if err := Shutdown(context.Background()); err != nil {
 		t.Fatalf("Shutdown returned error after failed Init: %v", err)
 	}
+}
+
+func TestSetSpanAttributes_SetsAttributesOnActiveSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	ctx, span := tp.Tracer("test").Start(context.Background(), "test-span")
+
+	SetSpanAttributes(ctx, attribute.String("auth_failure_reason", "token_expired"))
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	found := false
+	for _, a := range spans[0].Attributes {
+		if string(a.Key) == "auth_failure_reason" && a.Value.AsString() == "token_expired" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected auth_failure_reason=token_expired attribute, got %v", spans[0].Attributes)
+	}
+}
+
+func TestSetSpanAttributes_NoOpWithoutActiveSpan(t *testing.T) {
+	// Must not panic when ctx carries no span — the common case for a call
+	// site invoked outside any request (or in a test with no tracer wired
+	// up).
+	SetSpanAttributes(context.Background(), attribute.String("k", "v"))
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	semconv "go.opentelemetry.io/otel/semconv/v1.28.0"
 )
 
 // weakTestCertPEM is a throwaway self-signed cert (not a secret; borrowed
@@ -32,10 +33,26 @@ Lhnm4N/QDk5rek0=
 -----END CERTIFICATE-----
 `
 
+func TestBuildResource_IncludesServiceVersion(t *testing.T) {
+	res, err := buildResource(context.Background(), "test-service", "test", "abc1234")
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	found := false
+	for _, kv := range res.Attributes() {
+		if kv.Key == semconv.ServiceVersionKey && kv.Value.AsString() == "abc1234" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected service.version=abc1234 in resource attributes, got %v", res.Attributes())
+	}
+}
+
 func TestInit_NoEndpoint_IsNoOp(t *testing.T) {
 	os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 
-	Init(context.Background(), "test-service", "test")
+	Init(context.Background(), "test-service", "test", "test-version")
 
 	if err := Shutdown(context.Background()); err != nil {
 		t.Fatalf("Shutdown returned error after no-op Init: %v", err)
@@ -51,7 +68,7 @@ func TestInit_WithEndpoint_ConfiguresProviders(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", server.URL)
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 
-	Init(context.Background(), "test-service", "test")
+	Init(context.Background(), "test-service", "test", "test-version")
 
 	if err := Shutdown(context.Background()); err != nil {
 		t.Fatalf("Shutdown returned error: %v", err)
@@ -87,7 +104,7 @@ func TestInit_ExporterSetupError_FallsBackToNoOp(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", certPath)
 
-	Init(context.Background(), "test-service", "test")
+	Init(context.Background(), "test-service", "test", "test-version")
 
 	_, span := otel.Tracer("test").Start(context.Background(), "test-span")
 	defer span.End()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// GitSHA identifies the build this binary came from. Overridden at build
+// time via -ldflags "-X .../internal/version.GitSHA=<sha>" (see the
+// Makefile's build-backend target and the Dockerfile); left as "dev" for a
+// plain `go build`/`go run` with no ldflags, e.g. local development.
+var GitSHA = "dev"


### PR DESCRIPTION
## Summary

Closes six observability gaps found by reviewing production Axiom telemetry (traces in `myhaws-prd`, metrics in `myhaws-metrics`) for this service. Every change is additive telemetry only — no application behavior changes.

- **Voyage embedding span attributes** — `voyage.model`, `voyage.input_type`, `voyage.batch_size`, `voyage.dimension` on every span; `voyage.http_status` on failures; `voyage.total_tokens` when Voyage's response includes it.
- **Dedicated vector search span** — `search.vector_query` wraps the semantic similarity query with `search.resource`, `search.candidate_count`, `search.max_distance`, `search.embedding_dimension` (previously indistinguishable among 7 identically-named `gorm.Query` spans per search request).
- **Sweep heartbeat** — `embedding.sweep.heartbeat` counter fires unconditionally once per reconciliation-sweep tick, so an "absence of heartbeat" Axiom monitor can detect the scheduler goroutine dying silently.
- **Auth failure reason** — `attributes.auth_failure_reason` (`missing_header` / `invalid_format` / `invalid_api_token` / `token_expired` / `token_invalid` / `invalid_credentials`) on every 401, so a 401-spike monitor can distinguish credential-stuffing from routine session expiry.
- **Deployment version marker** — `internal/version.GitSHA`, threaded through to OTel's `service.version` resource attribute, wired via `-ldflags -X` in the Makefile, Dockerfile, and CI image build.
- **Business counters** — `animals.created` and `comments.created`, so a silent write-path bug wouldn't be invisible to infra-only dashboards.

Full design rationale and two corrections found while implementing (item 2's "7 queries" isn't an N+1 bug; item 1's error-marking already worked) are in `docs/superpowers/specs/2026-07-25-observability-gaps-design.md` and `docs/superpowers/plans/2026-07-25-observability-gaps.md` (both local-only, gitignored under `docs/superpowers/`, not part of this PR's diff).

## Test plan

- [x] `go build -tags dev ./...` succeeds
- [x] `go test -tags dev ./...` passes except one pre-existing, unrelated failure (`TestCreateGroup/accepts_valid_GroupMe_bot_id`), independently confirmed failing identically on `main` before this branch existed
- [x] Every task individually implemented via TDD, reviewed, and approved (10 tasks + one consolidated final-review fix wave for gofmt drift and a misleading attribute name, both fixed and re-verified)
- [x] `internal/handlers/search.go`'s new span independently verified against a real Postgres instance
- [x] Docker build's `-ldflags` git-SHA plumbing independently verified by extracting and inspecting the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)