### PR TITLE
Pass GIT_SHA build-arg in deploy-ghcr-az.sh

### DIFF
--- a/scripts/deploy-ghcr-az.sh
+++ b/scripts/deploy-ghcr-az.sh
@@ -160,6 +160,7 @@ if [[ "${SKIP_BUILD}" == false ]]; then
   echo "Building image ${FULL_IMAGE_TAG} for linux/amd64..."
   docker build --platform linux/amd64 \
     --cache-from "${REPO}:${IMAGE_TAG}" \
+    --build-arg GIT_SHA="${GIT_SHA}" \
     -t "${FULL_IMAGE_TAG}" \
     -t "${REPO}:${IMAGE_TAG}" \
     --label "revision=${REVISION_TAG}" \


### PR DESCRIPTION
## Summary

`deploy-ghcr-az.sh` already computes `GIT_SHA` for the revision tag and the `git-sha` image label, but never forwards it to `docker build`. That means the Dockerfile's `ARG GIT_SHA=dev` fallback always wins, so every real deploy through this script (dev and prod) reports `service.version=dev` in Axiom regardless of the commit actually shipped — confirmed by inspecting Axiom traces for a dev deploy that went out via this script.

Fixes it by passing `--build-arg GIT_SHA="${GIT_SHA}"` through to `docker build`.

## Test plan

- [x] Reviewed the diff — one-line addition, no other behavior change
- [ ] Next real deploy via `./scripts/deploy-ghcr-az.sh` should show a real git SHA (not `dev`) in Axiom's `service.version` resource attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)