### PR TITLE
Add Renovate config

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Versioned date tag — referenced in Dockerfile FROM; update manually
-            # after each monthly base rebuild (or configure Renovate to do it).
+            # Versioned date tag — referenced in Dockerfile FROM; Renovate
+            # (see renovate.json) opens a PR bumping it after each rebuild.
             type=raw,value={{date 'YYYY.MM'}}
             # Convenience alias — not used in Dockerfile FROM
             type=raw,value=latest
@@ -82,4 +82,4 @@ jobs:
           echo "${IMAGE_TAGS}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Update the FROM tag in Dockerfile to the new date tag and open a PR." >> $GITHUB_STEP_SUMMARY
+          echo "Renovate will open a PR bumping the Dockerfile FROM tag to this date tag." >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Final stage — use the pre-built base image so LibreOffice is not installed
 # on every build. Rebuild the base by running build-base-image.yml manually
 # or by editing Dockerfile.base (it also rebuilds monthly for security patches).
-# Tag format: YYYY.MM — update this after each monthly base rebuild
-# (see build-base-image.yml; configure Renovate to automate the bump).
+# Tag format: YYYY.MM — Renovate (see renovate.json) opens a PR bumping this
+# after each monthly rebuild in build-base-image.yml.
 FROM ghcr.io/networkengineer-cloud/go-volunteer-media-base:2026.06
 
 # Copy binary from backend builder

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Group Go module bumps into one PR and keep go.sum in sync",
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies",
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "description": "Group non-major frontend bumps into one PR",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "frontend dependencies (non-major)"
+    },
+    {
+      "description": "Group GitHub Actions version bumps into one PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "go-volunteer-media-base is our own image (Dockerfile.base / build-base-image.yml), tagged YYYY.MM and rebuilt monthly — track it so the Dockerfile FROM bump gets proposed automatically instead of manually",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["ghcr.io/networkengineer-cloud/go-volunteer-media-base"],
+      "versioning": "loose",
+      "groupName": "internal base image"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- No `renovate.json` existed anywhere in the repo — Renovate was only referenced as a someday-TODO in a `build-base-image.yml` comment ("update manually... or configure Renovate to do it").
- Adds `renovate.json` extending `config:recommended`, with grouping rules per ecosystem (Go, npm, GitHub Actions) to keep PR volume down, plus a rule that tracks `ghcr.io/networkengineer-cloud/go-volunteer-media-base`'s `YYYY.MM` tags so the Dockerfile's `FROM` bump is proposed automatically after each monthly rebuild instead of manually.
- Updated the stale comments in `Dockerfile` and `build-base-image.yml` that referenced the manual/someday-Renovate process, now that it's actually configured.

## Note

This PR only adds the config file — it does **not** install the Renovate GitHub App on the org/repo. That's a separate step (via the GitHub App marketplace or your Renovate/Mend account) that needs an org admin, and Renovate won't actually start opening PRs until it's done.

## Test plan

- [x] `renovate.json` validated as well-formed JSON
- [ ] Once the Renovate App is installed, confirm it opens onboarding/dependency-dashboard PR and picks up gomod/npm/github-actions/dockerfile/terraform as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)