### PR TITLE
Mirror Axiom API token into Key Vault

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -124,6 +124,15 @@ resource "azurerm_key_vault_secret" "jwt_secret" {
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }
 
+# Store Axiom API token in Key Vault
+resource "azurerm_key_vault_secret" "axiom_api_token" {
+  name         = "axiom-api-token"
+  value        = var.axiom_api_token
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+}
+
 # PostgreSQL Flexible Server with auto-pause capability
 resource "azurerm_postgresql_flexible_server" "main" {
   name                = "psql-${var.project_name}-${var.environment}"

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -121,6 +121,15 @@ resource "azurerm_key_vault_secret" "jwt_secret" {
   depends_on = [azurerm_role_assignment.terraform_kv_secrets_officer]
 }
 
+# Store Axiom API token in Key Vault
+resource "azurerm_key_vault_secret" "axiom_api_token" {
+  name         = "axiom-api-token"
+  value        = var.axiom_api_token
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_role_assignment.terraform_kv_secrets_officer]
+}
+
 # PostgreSQL Flexible Server
 resource "azurerm_postgresql_flexible_server" "main" {
   name                = "psql-${var.project_name}-${var.environment}"


### PR DESCRIPTION
## Summary
- Add `azurerm_key_vault_secret.axiom_api_token` in both dev and prod, mirroring `var.axiom_api_token` into Key Vault as `axiom-api-token`
- Brings Axiom's token in line with how `resend_api_key` and `jwt_secret` are already managed — previously it was the only secret var passed straight to the Container App without also being stored in Key Vault, which made it harder to find/rotate consistently

## Context
While debugging why the dev instance had stopped shipping telemetry to Axiom, found the container logs showing `401 Unauthorized: token invalid` for the OTLP exporter. That's a separate fix (rotating the token value itself, which is applied locally outside CI). This PR only addresses the storage-pattern inconsistency so the token can be rotated the same way as the other secrets going forward.

## Test plan
- [ ] `terraform validate` (pre-existing, unrelated `voyage_api_key` for_each errors aside)
- [ ] `terraform plan` against dev shows only the new `azurerm_key_vault_secret.axiom_api_token` resource being added
- [ ] `terraform plan` against prod shows the same
- [ ] After apply, confirm `axiom-api-token` secret appears in both Key Vaults