### PR TITLE
Ignore container image drift in Terraform for dev and prod

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -521,6 +521,11 @@ resource "azurerm_container_app" "main" {
   }
 
   tags = azurerm_resource_group.main.tags
+
+  lifecycle {
+    # Deploys happen via scripts/deploy-ghcr-az.sh (az containerapp update), not Terraform.
+    ignore_changes = [template[0].container[0].image]
+  }
 }
 
 # Custom Domain Configuration (only if custom domain is provided)

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -505,6 +505,11 @@ resource "azurerm_container_app" "main" {
   }
 
   tags = azurerm_resource_group.main.tags
+
+  lifecycle {
+    # Deploys happen via scripts/deploy-ghcr-az.sh (az containerapp update), not Terraform.
+    ignore_changes = [template[0].container[0].image]
+  }
 }
 
 # Custom Domain Configuration (only if custom domain is provided)


### PR DESCRIPTION
## Summary
- Container App deploys ship via `scripts/deploy-ghcr-az.sh` (`az containerapp update`), not Terraform, so the running image is SHA-tagged (e.g. `20260727-fe53914`) while the `container_image` input variable stays pinned to `:develop`/whatever default is configured.
- Without a guard, `terraform plan`/`apply` wants to revert the live Container App back to that variable's image tag, undoing the SHA-pinning done in #254.
- Added `lifecycle { ignore_changes = [template[0].container[0].image] }` to `azurerm_container_app.main` in both `terraform/environments/dev/main.tf` and `terraform/environments/prod/main.tf` so Terraform stops fighting the CI-managed image tag.

## Test plan
- [x] `terraform validate` passes in both `terraform/environments/dev` and `terraform/environments/prod` (pre-existing unrelated deprecation warnings only)
- [ ] `terraform plan` on dev/prod no longer proposes reverting the container image