### PR TITLE
Fix GroupPage refetch storm and Clear Filters race

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -612,11 +612,11 @@ export const groupsApi = {
 
 // Animals API
 export const animalsApi = {
-  getAll: (groupId: number, status?: string, name?: string) => {
+  getAll: (groupId: number, status?: string, name?: string, options?: { signal?: AbortSignal }) => {
     const params: Record<string, unknown> = {};
     if (status !== undefined) params.status = status;
     if (name) params.name = name;
-    return api.get<Animal[]>('/groups/' + groupId + '/animals', { params });
+    return api.get<Animal[]>('/groups/' + groupId + '/animals', { params, signal: options?.signal });
   },
   getById: (groupId: number, id: number) =>
     api.get<Animal>('/groups/' + groupId + '/animals/' + id),

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import GroupPage from './GroupPage';
 import { groupsApi, animalsApi, authApi } from '../api/client';
@@ -130,5 +130,92 @@ describe('GroupPage', () => {
     // the stored field.
     expect(await screen.findByText(/Ends: Jul 15, 2026/)).toBeInTheDocument();
     expect(screen.queryByText(/Ends: Jul 6, 2026/)).not.toBeInTheDocument();
+  });
+
+  // Regression coverage for a refetch-storm bug: the name-search box used to
+  // be undebounced and feed a useCallback whose identity change re-ran an
+  // effect that also (redundantly) fetched email preferences, group data,
+  // and the full groups list on every keystroke - plus a second, separate
+  // effect meant only to react to filter changes duplicated the animals
+  // fetch itself. Fixed by debouncing the search value and splitting the
+  // once-per-visit fetches (preferences/group data/groups list, keyed only
+  // on the group id) from the one place that triggers loadAnimals.
+  describe('debounced search and one-time-per-visit data loading', () => {
+    const DEBOUNCE_MS = 400; // must match GroupPage.tsx's NAME_SEARCH_DEBOUNCE_MS
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Flushes pending microtasks (mocked-promise resolution and the
+    // resulting state updates/effects) without relying on real wall-clock
+    // time - findByText/waitFor poll via real setTimeout internally, which
+    // never advances under fake timers, so this is the fake-timers
+    // replacement for "wait for the initial load to settle".
+    const flushInitialLoad = async () => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    };
+
+    it('does not refetch email preferences, group data, or the groups list while typing in the name-search box', async () => {
+      renderGroupPage();
+      await flushInitialLoad();
+      expect(screen.getByText('Rex')).toBeInTheDocument();
+
+      // Each of these fires exactly once on initial mount - confirming that
+      // up front makes the "still 1" assertions below meaningful (not just
+      // "never called").
+      expect(authApi.getEmailPreferences).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getById).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getMembership).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getAll).toHaveBeenCalledTimes(1);
+
+      const input = screen.getByLabelText('Search animals by name');
+      fireEvent.change(input, { target: { value: 'r' } });
+      fireEvent.change(input, { target: { value: 're' } });
+      fireEvent.change(input, { target: { value: 'rex' } });
+
+      // Let the debounce settle (which does reload the animals list - see
+      // the next test) and confirm none of the other three endpoints fire
+      // again, since none of them depend on the search value anymore.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      });
+
+      expect(authApi.getEmailPreferences).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getById).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getMembership).toHaveBeenCalledTimes(1);
+      expect(groupsApi.getAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads the animals list exactly once, with the final value, after typing settles', async () => {
+      renderGroupPage();
+      await flushInitialLoad();
+      expect(screen.getByText('Rex')).toBeInTheDocument();
+      vi.mocked(animalsApi.getAll).mockClear();
+
+      const input = screen.getByLabelText('Search animals by name');
+      fireEvent.change(input, { target: { value: 'r' } });
+      fireEvent.change(input, { target: { value: 're' } });
+      fireEvent.change(input, { target: { value: 'rex' } });
+
+      // Not settled yet - none of the keystrokes above should have queued
+      // an animals fetch on their own.
+      expect(animalsApi.getAll).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      });
+
+      // Exactly once - not twice (the old double-effect bug) - and with the
+      // final debounced value, not an intermediate keystroke.
+      expect(animalsApi.getAll).toHaveBeenCalledTimes(1);
+      expect(animalsApi.getAll).toHaveBeenLastCalledWith(1, '', 'rex');
+    });
   });
 });

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import GroupPage from './GroupPage';
 import { groupsApi, animalsApi, authApi } from '../api/client';
 import type { Animal, Group, GroupMembership } from '../api/client';
+import { CanceledError } from 'axios';
 import type { AxiosResponse } from 'axios';
 import { AuthProvider } from '../contexts/AuthContext';
 import { ToastProvider } from '../contexts/ToastContext';
@@ -215,7 +216,114 @@ describe('GroupPage', () => {
       // Exactly once - not twice (the old double-effect bug) - and with the
       // final debounced value, not an intermediate keystroke.
       expect(animalsApi.getAll).toHaveBeenCalledTimes(1);
-      expect(animalsApi.getAll).toHaveBeenLastCalledWith(1, '', 'rex');
+      expect(animalsApi.getAll).toHaveBeenLastCalledWith(1, '', 'rex', { signal: expect.any(AbortSignal) });
+    });
+  });
+
+  // Regression coverage for two further bugs found reviewing the fix above:
+  // (1) "Clear Filters" reset statusFilter and nameSearch together, but
+  // loadAnimals depended on the *debounced* search value, which took up to
+  // NAME_SEARCH_DEBOUNCE_MS to catch up - producing one fetch combining the
+  // new (empty) status with the old (stale) search term, before a second,
+  // corrected fetch landed ~400ms later. (2) loadAnimals had no request
+  // cancellation, unlike GroupSearch.tsx's AbortController pattern, so a
+  // superseded request could resolve after a newer one and overwrite it
+  // with stale data.
+  describe('Clear Filters and request cancellation', () => {
+    const DEBOUNCE_MS = 400; // must match GroupPage.tsx's NAME_SEARCH_DEBOUNCE_MS
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const flush = async () => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    };
+
+    it('produces exactly one fetch with the cleared params when Clear Filters is clicked, not a stale-then-corrected pair', async () => {
+      renderGroupPage();
+      await flush();
+      expect(screen.getByText('Rex')).toBeInTheDocument();
+
+      // Empty results so the "Clear Filters" button (only rendered in the
+      // empty-results state) actually appears once filters are applied.
+      vi.mocked(animalsApi.getAll).mockResolvedValue({ data: [] } as unknown as AxiosResponse<Animal[]>);
+
+      fireEvent.change(screen.getByLabelText('Search animals by name'), { target: { value: 'rex' } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      });
+      fireEvent.change(screen.getByLabelText('Filter animals by status'), { target: { value: 'available' } });
+      await flush();
+
+      const clearButton = screen.getByRole('button', { name: 'Clear Filters' });
+      vi.mocked(animalsApi.getAll).mockClear();
+
+      fireEvent.click(clearButton);
+
+      // Immediately correct - a single fetch with both filters cleared
+      // together, not a stale-search-term fetch followed by a correction.
+      expect(animalsApi.getAll).toHaveBeenCalledTimes(1);
+      expect(animalsApi.getAll).toHaveBeenLastCalledWith(1, '', '', { signal: expect.any(AbortSignal) });
+
+      // Wait out the full debounce window to confirm nothing extra fires
+      // once it would have caught up - proving the second, corrected fetch
+      // the bug produced is actually gone, not just that the first fetch
+      // happens to look right.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      });
+      expect(animalsApi.getAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let a superseded (aborted) request overwrite fresher results', async () => {
+      let capturedFirstSignal: AbortSignal | undefined;
+      let resolveFirst: (value: AxiosResponse<Animal[]>) => void = () => {};
+      const fido: Animal = { ...quarantinedAnimal, id: 2, name: 'Fido', status: 'available' };
+
+      // First call (the initial mount's loadAnimals): stays pending until
+      // resolveFirst is invoked, but rejects immediately - the way a real
+      // aborted axios request would - if its signal fires first.
+      vi.mocked(animalsApi.getAll)
+        .mockImplementationOnce((_groupId, _status, _name, options) => {
+          capturedFirstSignal = options?.signal;
+          return new Promise<AxiosResponse<Animal[]>>((resolve, reject) => {
+            resolveFirst = resolve;
+            options?.signal?.addEventListener('abort', () => reject(new CanceledError()));
+          });
+        })
+        // Second call (triggered by the status-filter change below):
+        // resolves normally with different data.
+        .mockResolvedValueOnce({ data: [fido] } as AxiosResponse<Animal[]>);
+
+      renderGroupPage();
+      await flush();
+      expect(capturedFirstSignal).toBeDefined();
+      expect(capturedFirstSignal?.aborted).toBe(false);
+
+      // Fires the second loadAnimals call before the first has resolved -
+      // this must abort the first.
+      fireEvent.change(screen.getByLabelText('Filter animals by status'), { target: { value: 'available' } });
+      await flush();
+
+      expect(capturedFirstSignal?.aborted).toBe(true);
+      expect(screen.getByText('Fido')).toBeInTheDocument();
+
+      // The first (now-aborted) request resolving late must not overwrite
+      // the fresher data already rendered.
+      await act(async () => {
+        resolveFirst({ data: [quarantinedAnimal] } as AxiosResponse<Animal[]>);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(screen.getByText('Fido')).toBeInTheDocument();
+      expect(screen.queryByText('Rex')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
+import axios from 'axios';
 import { groupsApi, animalsApi, authApi, updatesApi, groupDocumentsApi } from '../api/client';
 import ConfirmDialog from '../components/ConfirmDialog';
 import type { Group, Animal, GroupMembership, ActivityItem, GroupMember, UserSkillTag, GroupDocument } from '../api/client';
@@ -48,6 +49,13 @@ const GroupPage: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [nameSearch, setNameSearch] = useState<string>('');
   const debouncedNameSearch = useDebounce(nameSearch, NAME_SEARCH_DEBOUNCE_MS);
+  // Mirrors debouncedNameSearch for normal typing, but "Clear Filters"
+  // (see handleClearAnimalFilters) also sets this directly - bypassing the
+  // debounce - so a statusFilter reset can't combine with a stale,
+  // not-yet-caught-up search term in the same loadAnimals call. Kept in
+  // sync with debouncedNameSearch by the effect further down, near
+  // loadAnimals.
+  const [effectiveNameSearch, setEffectiveNameSearch] = useState(debouncedNameSearch);
   const [showAnnouncementForm, setShowAnnouncementForm] = useState(false);
   const [showProtocolForm, setShowProtocolForm] = useState(false);
   const [showLengthOfStay, setShowLengthOfStay] = useState(false);
@@ -141,18 +149,46 @@ const GroupPage: React.FC = () => {
     }
   };
 
-  // Load animals with filters. Depends on debouncedNameSearch, not the raw
+  // Load animals with filters. Depends on effectiveNameSearch (normally
+  // just debouncedNameSearch, see the sync effect below), not the raw
   // nameSearch, so this (and anything that depends on it) doesn't get a new
   // identity - and doesn't refetch - on every keystroke in the name-search
   // box.
+  //
+  // Cancels any request already in flight before starting a new one -
+  // matching GroupSearch.tsx's AbortController pattern - so a group switch
+  // or rapid filter change can't let a slower, older response land after a
+  // newer one and overwrite it with stale animals.
+  const animalsAbortControllerRef = useRef<AbortController | null>(null);
   const loadAnimals = useCallback(async (groupId: number) => {
+    animalsAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    animalsAbortControllerRef.current = controller;
+
     try {
-      const animalsRes = await animalsApi.getAll(groupId, statusFilter, debouncedNameSearch);
+      const animalsRes = await animalsApi.getAll(groupId, statusFilter, effectiveNameSearch, { signal: controller.signal });
       setAnimals(animalsRes.data);
     } catch (error) {
+      if (axios.isCancel(error)) return;
       console.error('Failed to load animals:', error);
     }
-  }, [statusFilter, debouncedNameSearch]);
+  }, [statusFilter, effectiveNameSearch]);
+
+  // Cancel any in-flight animals request on unmount so it can't set state
+  // on an unmounted component.
+  useEffect(() => {
+    return () => {
+      animalsAbortControllerRef.current?.abort();
+    };
+  }, []);
+
+  // Keeps effectiveNameSearch in sync with the debounced search value for
+  // normal typing. handleClearAnimalFilters additionally sets
+  // effectiveNameSearch directly, bypassing this, for the one case where
+  // waiting for the debounce to catch up would be wrong (see its comment).
+  useEffect(() => {
+    setEffectiveNameSearch(debouncedNameSearch);
+  }, [debouncedNameSearch]);
 
   // Update view mode when URL search params change
   useEffect(() => {
@@ -196,6 +232,18 @@ const GroupPage: React.FC = () => {
       loadAnimals(Number(id));
     }
   }, [id, loadAnimals]);
+
+  // Clears both animal filters together. Also sets effectiveNameSearch
+  // directly (not just nameSearch), bypassing the debounce - otherwise
+  // statusFilter would clear immediately while effectiveNameSearch kept
+  // its stale pre-clear value for up to NAME_SEARCH_DEBOUNCE_MS, so
+  // loadAnimals would fire once with the wrong combination (new status +
+  // old search term) before self-correcting.
+  const handleClearAnimalFilters = () => {
+    setStatusFilter('');
+    setNameSearch('');
+    setEffectiveNameSearch('');
+  };
 
   const handleGroupSwitch = async (newGroupId: number) => {
     if (newGroupId !== Number(id)) {
@@ -989,10 +1037,7 @@ const GroupPage: React.FC = () => {
                   (statusFilter || nameSearch)
                     ? {
                         label: 'Clear Filters',
-                        onClick: () => {
-                          setStatusFilter('');
-                          setNameSearch('');
-                        },
+                        onClick: handleClearAnimalFilters,
                       }
                     : (membership?.is_group_admin || membership?.is_site_admin)
                       ? {

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -5,6 +5,7 @@ import ConfirmDialog from '../components/ConfirmDialog';
 import type { Group, Animal, GroupMembership, ActivityItem, GroupMember, UserSkillTag, GroupDocument } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
+import { useDebounce } from '../hooks/useDebounce';
 import SessionCommentDisplay from '../components/SessionCommentDisplay';
 import AnnouncementForm from '../components/AnnouncementForm';
 import EmptyState from '../components/EmptyState';
@@ -21,6 +22,10 @@ import './GroupPage.css';
 
 type ViewMode = 'activity' | 'animals' | 'protocols' | 'members' | 'documents';
 type FilterType = 'all' | 'comments' | 'announcements';
+
+// Matches GroupSearch.tsx's debounce delay for the same kind of free-text
+// filter input.
+const NAME_SEARCH_DEBOUNCE_MS = 400;
 
 const GroupPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -42,6 +47,7 @@ const GroupPage: React.FC = () => {
   const [filterType, setFilterType] = useState<FilterType>('all');
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [nameSearch, setNameSearch] = useState<string>('');
+  const debouncedNameSearch = useDebounce(nameSearch, NAME_SEARCH_DEBOUNCE_MS);
   const [showAnnouncementForm, setShowAnnouncementForm] = useState(false);
   const [showProtocolForm, setShowProtocolForm] = useState(false);
   const [showLengthOfStay, setShowLengthOfStay] = useState(false);
@@ -135,15 +141,18 @@ const GroupPage: React.FC = () => {
     }
   };
 
-  // Load animals with filters
+  // Load animals with filters. Depends on debouncedNameSearch, not the raw
+  // nameSearch, so this (and anything that depends on it) doesn't get a new
+  // identity - and doesn't refetch - on every keystroke in the name-search
+  // box.
   const loadAnimals = useCallback(async (groupId: number) => {
     try {
-      const animalsRes = await animalsApi.getAll(groupId, statusFilter, nameSearch);
+      const animalsRes = await animalsApi.getAll(groupId, statusFilter, debouncedNameSearch);
       setAnimals(animalsRes.data);
     } catch (error) {
       console.error('Failed to load animals:', error);
     }
-  }, [statusFilter, nameSearch]);
+  }, [statusFilter, debouncedNameSearch]);
 
   // Update view mode when URL search params change
   useEffect(() => {
@@ -157,6 +166,10 @@ const GroupPage: React.FC = () => {
     }
   }, [searchParams, membership]);
 
+  // Once-per-page-visit data: email preferences, group details/membership,
+  // and the full groups list (for the switcher). Deliberately depends only
+  // on `id` - not on loadAnimals - so retyping in the name-search box or
+  // changing the status filter can't re-trigger these unrelated fetches.
   useEffect(() => {
     const loadPreferences = async () => {
       try {
@@ -166,20 +179,19 @@ const GroupPage: React.FC = () => {
         console.error('Failed to load preferences:', error);
       }
     };
-    
+
     loadPreferences();
-    
+
     if (id) {
       loadGroupData(Number(id));
-      // Load animals immediately to show count in tab
-      loadAnimals(Number(id));
     }
     // Load all groups for the switcher
     loadAllGroups();
-  }, [id, loadAnimals]);
+  }, [id]);
 
+  // The one place that triggers loadAnimals: on mount/group switch, and
+  // whenever the status or (debounced) name filter actually changes.
   useEffect(() => {
-    // Reload animals when filters change
     if (id) {
       loadAnimals(Number(id));
     }


### PR DESCRIPTION
## Summary

- The animals-tab name-search box was undebounced and fed `loadAnimals`, a `useCallback` with deps `[statusFilter, nameSearch]`. Every keystroke gave `loadAnimals` a new identity, which re-triggered an unrelated effect that also refetched email preferences, group details/membership, and the full groups list on every character typed — plus a second effect that fired `loadAnimals` itself again on the same trigger, so it ran twice per keystroke on top of that.
- Fixed by debouncing `nameSearch` (400ms, via the existing `useDebounce` hook, same convention as `GroupSearch.tsx`) and splitting the single overloaded effect into two: one depends only on `id` and loads email-preferences/group-data/groups-list exactly once per page visit; the other is the sole trigger for `loadAnimals`, responding to `id`/`statusFilter`/`debouncedNameSearch`.
- A follow-up review pass caught two more issues in the same area:
  1. **Clear Filters stale-fetch**: the handler reset `statusFilter` and `nameSearch` together, but `loadAnimals` depended on the *debounced* search value, which lagged behind by up to the debounce window — so Clear Filters fired one fetch with the still-stale search term before a corrected fetch landed ~400ms later. Fixed via a new `effectiveNameSearch` value that normally mirrors the debounced value but that `handleClearAnimalFilters` can set directly, bypassing the debounce for that one transition so both filters land in the same `loadAnimals` call.
  2. **No request cancellation**: `loadAnimals` had no `AbortController`, unlike `GroupSearch.tsx`'s existing pattern — a superseded request (group switch, or a status-filter change while a debounced search was settling) could resolve after a newer one and overwrite it with stale data. `animalsApi.getAll` now accepts an optional `{ signal }`, threaded through exactly like `searchApi.search` already does; `loadAnimals` aborts any in-flight request before starting a new one (and on unmount), silently ignoring the resulting cancellation via `axios.isCancel()`.

## Why

Every keystroke in the animal name search was firing 6+ unrelated network requests (email preferences, group details, groups list, doubled animals fetches), and Clear Filters could briefly show wrong results due to the stale-debounce race — both traced to the same overloaded effect/dependency design in `GroupPage.tsx`.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full backend suite green (only the pre-existing, unrelated `TestCreateGroup/accepts_valid_GroupMe_bot_id` failure remains, confirmed identical on unmodified `main`)
- [x] `npx vitest run` — all 373 frontend unit tests pass (25/25 files), including the new `GroupPage.test.tsx` coverage for debounce/split-effects, the Clear Filters race, and request cancellation
- [x] Verified each fix has real teeth: reverting the Clear Filters fix alone reproduced the exact bug (stale search term); reverting the cancellation logic alone left the cancellation test's captured signal undefined and failed the "every fetch carries a signal" assertions; reverting `GroupPage.tsx` entirely reproduced the double-fetch-per-keystroke bug (6 calls for a 3-keystroke sequence)
- [x] Verified live in a browser against a real backend: typed into the name search box and watched the network panel (no extra email-preferences/groups requests per keystroke, one settled animals request per debounced value); reproduced the Clear Filters empty-state scenario and confirmed exactly one correct request fires with no stale param and no delayed second request

🤖 Generated with [Claude Code](https://claude.com/claude-code)