### PR TITLE
Fix activity feed date-range filter timezone bug

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -566,15 +566,16 @@ export const groupsApi = {
     const params = limit ? { limit } : {};
     return api.get<CommentWithAnimal[]>('/groups/' + id + '/latest-comments', { params });
   },
-  getActivityFeed: (id: number, options?: { 
-    limit?: number; 
-    offset?: number; 
+  getActivityFeed: (id: number, options?: {
+    limit?: number;
+    offset?: number;
     type?: 'all' | 'comments' | 'announcements';
     animal?: number;
     tags?: string;
     rating?: string;
     from?: string;
     to?: string;
+    signal?: AbortSignal;
   }) => {
     const params: Record<string, unknown> = {};
     if (options?.limit) params.limit = options.limit;
@@ -585,7 +586,7 @@ export const groupsApi = {
     if (options?.rating) params.rating = options.rating;
     if (options?.from) params.from = options.from;
     if (options?.to) params.to = options.to;
-    return api.get<ActivityFeedResponse>('/groups/' + id + '/activity-feed', { params });
+    return api.get<ActivityFeedResponse>('/groups/' + id + '/activity-feed', { params, signal: options?.signal });
   },
   create: (name: string, description: string, image_url?: string, hero_image_url?: string, has_protocols?: boolean, groupme_bot_id?: string, groupme_enabled?: boolean) =>
     api.post<Group>('/admin/groups', { name, description, image_url, hero_image_url, has_protocols, groupme_bot_id, groupme_enabled }),

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -395,4 +395,82 @@ describe('GroupPage', () => {
       expect(lastCall?.[1]?.to).toBeUndefined();
     });
   });
+
+  // Regression coverage for a request-cancellation gap found while verifying
+  // the timezone fix above: loadActivityFeed had no AbortController, unlike
+  // GroupSearch.tsx's/loadAnimals' pattern - so a superseded request (e.g.
+  // changing the type filter while an earlier load was still in flight)
+  // could resolve after a newer one and overwrite it with stale activity
+  // items.
+  describe('activity feed request cancellation', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockUseSearchParams.mockReturnValue([new URLSearchParams('view=activity'), vi.fn()]);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const flush = async () => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    };
+
+    it('does not let a superseded (aborted) request overwrite fresher activity items', async () => {
+      let capturedFirstSignal: AbortSignal | undefined;
+      let resolveFirst: (value: AxiosResponse) => void = () => {};
+      const staleResponse = {
+        data: {
+          items: [{ id: 1, type: 'comment', content: 'stale comment', created_at: '2026-01-01T00:00:00Z' }],
+          total: 1, limit: 20, offset: 0, hasMore: false, summary: {},
+        },
+      } as unknown as AxiosResponse;
+      const freshResponse = {
+        data: {
+          items: [{ id: 2, type: 'comment', content: 'fresh comment', created_at: '2026-01-02T00:00:00Z' }],
+          total: 1, limit: 20, offset: 0, hasMore: false, summary: {},
+        },
+      } as unknown as AxiosResponse;
+
+      // First call (the initial mount's loadActivityFeed): stays pending
+      // until resolveFirst is invoked, but rejects immediately - the way a
+      // real aborted axios request would - if its signal fires first.
+      vi.mocked(groupsApi.getActivityFeed)
+        .mockImplementationOnce((_groupId, options) => {
+          capturedFirstSignal = options?.signal;
+          return new Promise<AxiosResponse>((resolve, reject) => {
+            resolveFirst = resolve;
+            options?.signal?.addEventListener('abort', () => reject(new CanceledError()));
+          });
+        })
+        // Second call (triggered by the type-filter change below): resolves
+        // normally with different data.
+        .mockResolvedValueOnce(freshResponse);
+
+      renderGroupPage();
+      await flush();
+      expect(capturedFirstSignal).toBeDefined();
+      expect(capturedFirstSignal?.aborted).toBe(false);
+
+      // Fires the second loadActivityFeed call before the first has
+      // resolved - this must abort the first.
+      fireEvent.change(screen.getByLabelText('Filter activity by type'), { target: { value: 'comments' } });
+      await flush();
+
+      expect(capturedFirstSignal?.aborted).toBe(true);
+      expect(screen.getByText('fresh comment')).toBeInTheDocument();
+
+      // The first (now-aborted) request resolving late must not overwrite
+      // the fresher data already rendered.
+      await act(async () => {
+        resolveFirst(staleResponse);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(screen.getByText('fresh comment')).toBeInTheDocument();
+      expect(screen.queryByText('stale comment')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import GroupPage from './GroupPage';
 import { groupsApi, animalsApi, authApi } from '../api/client';
@@ -11,8 +11,9 @@ import { ToastProvider } from '../contexts/ToastContext';
 
 // Mock the API client. GroupPage's 'animals' view only needs group/membership/animal
 // data plus the site-wide group switcher list and the length-of-stay preference; the
-// activity/members/documents view APIs are intentionally left unmocked since this test
-// never navigates to those tabs.
+// members/documents view APIs are intentionally left unmocked since this test never
+// navigates to those tabs. getActivityFeed is mocked too, for the 'activity' view
+// tests further below.
 vi.mock('../api/client', () => ({
   authApi: {
     getCurrentUser: vi.fn(),
@@ -22,21 +23,25 @@ vi.mock('../api/client', () => ({
     getById: vi.fn(),
     getMembership: vi.fn(),
     getAll: vi.fn(),
+    getActivityFeed: vi.fn(),
   },
   animalsApi: {
     getAll: vi.fn(),
   },
 }));
 
-// Mock useParams/useSearchParams so the page loads group id=1 directly into the
-// 'animals' view (its default view is 'activity', which pulls in a much larger set
-// of APIs this test doesn't care about).
+// useSearchParams is routed through a controllable mock (mockUseSearchParams -
+// the "mock" prefix is required for vitest to allow referencing it from inside
+// this hoisted factory) so most tests can load group id=1 directly into the
+// 'animals' view, while the 'activity' view tests further below can switch it
+// to 'view=activity' without needing a real navigation.
+const mockUseSearchParams = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
     useParams: () => ({ id: '1' }),
-    useSearchParams: () => [new URLSearchParams('view=animals'), vi.fn()],
+    useSearchParams: () => mockUseSearchParams(),
   };
 });
 
@@ -108,6 +113,10 @@ describe('GroupPage', () => {
     vi.mocked(animalsApi.getAll).mockResolvedValue({
       data: [quarantinedAnimal],
     } as AxiosResponse<Animal[]>);
+
+    // Default view for most tests below; the 'activity' view tests further
+    // down override this in their own beforeEach.
+    mockUseSearchParams.mockReturnValue([new URLSearchParams('view=animals'), vi.fn()]);
   });
 
   const renderGroupPage = () => {
@@ -324,6 +333,66 @@ describe('GroupPage', () => {
 
       expect(screen.getByText('Fido')).toBeInTheDocument();
       expect(screen.queryByText('Rex')).not.toBeInTheDocument();
+    });
+  });
+
+  // Regression coverage for a timezone bug found reviewing the activity-feed
+  // date-range filter: the backend interprets a bare YYYY-MM-DD as UTC
+  // midnight, but every real user is in some other timezone - so sending the
+  // date-picker's raw value produced a day boundary off by the user's UTC
+  // offset (see localDayStartISO/localDayEndISO in dateUtils.ts). Fixed by
+  // converting each bound to a full UTC-instant ISO timestamp, computed from
+  // the *local* start/end of that calendar day, before it ever leaves the
+  // browser.
+  describe('activity feed date-range filter (timezone-aware)', () => {
+    beforeEach(() => {
+      // Deliberately non-UTC (standard time, no DST edge) - if GroupPage ever
+      // regressed to sending the bare date-picker value, or swapped which
+      // helper backs which field, this is what would catch it: the whole
+      // point of this test is that "from"/"to" must NOT equal the bare
+      // '2024-01-15'/'2024-01-20' the user typed.
+      vi.stubEnv('TZ', 'America/Chicago');
+      mockUseSearchParams.mockReturnValue([new URLSearchParams('view=activity'), vi.fn()]);
+      vi.mocked(groupsApi.getActivityFeed).mockResolvedValue({
+        data: { items: [], total: 0, limit: 20, offset: 0, hasMore: false, summary: {} },
+      } as unknown as AxiosResponse);
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('sends full local-day-boundary UTC instants for from/to, not the bare date-picker value', async () => {
+      renderGroupPage();
+      await screen.findByLabelText('Filter from date');
+
+      fireEvent.change(screen.getByLabelText('Filter from date'), { target: { value: '2024-01-15' } });
+      fireEvent.change(screen.getByLabelText('Filter to date'), { target: { value: '2024-01-20' } });
+
+      await waitFor(() => {
+        expect(groupsApi.getActivityFeed).toHaveBeenLastCalledWith(1, expect.objectContaining({
+          // Local midnight of 2024-01-15 in America/Chicago (UTC-6, standard
+          // time) is 2024-01-15T06:00:00.000Z.
+          from: '2024-01-15T06:00:00.000Z',
+          // Local end-of-day (23:59:59.999) of 2024-01-20 in America/Chicago
+          // is 2024-01-21T05:59:59.999Z - one day later in UTC, and NOT the
+          // bare '2024-01-20' a UTC-anchored interpretation would produce.
+          to: '2024-01-21T05:59:59.999Z',
+        }));
+      });
+    });
+
+    it('omits from/to entirely when the date filters are empty, unlike the tags/rating/animal filters', async () => {
+      renderGroupPage();
+      await screen.findByLabelText('Filter from date');
+
+      await waitFor(() => {
+        expect(groupsApi.getActivityFeed).toHaveBeenCalled();
+      });
+
+      const lastCall = vi.mocked(groupsApi.getActivityFeed).mock.calls.at(-1);
+      expect(lastCall?.[1]?.from).toBeUndefined();
+      expect(lastCall?.[1]?.to).toBeUndefined();
     });
   });
 });

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -278,8 +278,19 @@ const GroupPage: React.FC = () => {
     }
   };
 
-  // Load activity feed with filters (integrated from ActivityFeedPage)
+  // Load activity feed with filters (integrated from ActivityFeedPage).
+  //
+  // Cancels any request already in flight before starting a new one -
+  // matching GroupSearch.tsx's/loadAnimals' AbortController pattern - so a
+  // rapid filter change (e.g. from/to picked in quick succession) can't let
+  // a slower, older response land after a newer one and overwrite it with
+  // stale activity items.
+  const activityAbortControllerRef = useRef<AbortController | null>(null);
   const loadActivityFeed = async (groupId: number, reset = false) => {
+    activityAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    activityAbortControllerRef.current = controller;
+
     if (reset) {
       setActivityLoading(true);
       setActivities([]);
@@ -303,6 +314,7 @@ const GroupPage: React.FC = () => {
         // localDayStartISO/localDayEndISO in dateUtils.ts).
         from: filterDateFrom ? localDayStartISO(filterDateFrom) : undefined,
         to: filterDateTo ? localDayEndISO(filterDateTo) : undefined,
+        signal: controller.signal,
       });
 
       if (reset) {
@@ -310,20 +322,34 @@ const GroupPage: React.FC = () => {
       } else {
         setActivities([...activities, ...response.data.items]);
       }
-      
+
       setActivityTotal(response.data.total);
       setActivityHasMore(response.data.hasMore);
       setActivityError('');
     } catch (err: any) {
+      if (axios.isCancel(err)) return;
       console.error('Failed to load activity feed:', err);
       const errorMessage = err.response?.data?.error || 'Failed to load activity feed. Please try again.';
       setActivityError(errorMessage);
       toast.showError(errorMessage);
     } finally {
-      setActivityLoading(false);
-      setActivityLoadingMore(false);
+      // A superseded (now-aborted) request's `finally` must not flip the
+      // loading flags back off after a newer request already set them -
+      // only the request that's still current should clear them.
+      if (activityAbortControllerRef.current === controller) {
+        setActivityLoading(false);
+        setActivityLoadingMore(false);
+      }
     }
   };
+
+  // Cancel any in-flight activity-feed request on unmount so it can't set
+  // state on an unmounted component.
+  useEffect(() => {
+    return () => {
+      activityAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   const handleLoadMoreActivity = () => {
     if (id) {

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -15,7 +15,7 @@ import ErrorState from '../components/ErrorState';
 import GroupSearch from '../components/GroupSearch';
 import Modal from '../components/Modal';
 import ScriptsList from '../components/ScriptsList';
-import { calculateAge, formatAge, formatQuarantineEndDate } from '../utils/dateUtils';
+import { calculateAge, formatAge, formatQuarantineEndDate, localDayStartISO, localDayEndISO } from '../utils/dateUtils';
 import { formatAnimalStatus } from '../utils/animalUtils';
 import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { formatDisplayName } from '../utils/formatName';
@@ -296,8 +296,13 @@ const GroupPage: React.FC = () => {
         animal: filterAnimal ? Number(filterAnimal) : undefined,
         tags: filterTags.length > 0 ? filterTags.join(',') : undefined,
         rating: filterRating || undefined,
-        from: filterDateFrom || undefined,
-        to: filterDateTo || undefined,
+        // Sent as full local-day-boundary instants, not the bare YYYY-MM-DD
+        // the date inputs hold - the backend compares against precise
+        // created_at timestamps, and this browser is the only place that
+        // actually knows the volunteer's current local timezone (see
+        // localDayStartISO/localDayEndISO in dateUtils.ts).
+        from: filterDateFrom ? localDayStartISO(filterDateFrom) : undefined,
+        to: filterDateTo ? localDayEndISO(filterDateTo) : undefined,
       });
 
       if (reset) {

--- a/frontend/src/utils/dateUtils.test.ts
+++ b/frontend/src/utils/dateUtils.test.ts
@@ -11,6 +11,8 @@ import {
   computeEstimatedBirthDate,
   formatCalendarDate,
   formatQuarantineEndDate,
+  localDayStartISO,
+  localDayEndISO,
 } from './dateUtils';
 
 describe('dateUtils', () => {
@@ -195,6 +197,66 @@ describe('dateUtils', () => {
 
     it('returns "-" when neither date is present', () => {
       expect(formatQuarantineEndDate({})).toBe('-');
+    });
+  });
+
+  describe('localDayStartISO / localDayEndISO', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('returns non-bare-date input unchanged', () => {
+      expect(localDayStartISO('')).toBe('');
+      expect(localDayEndISO('')).toBe('');
+      expect(localDayStartISO('not-a-date')).toBe('not-a-date');
+      expect(localDayStartISO('2024-01-15T10:00:00Z')).toBe('2024-01-15T10:00:00Z');
+      expect(localDayEndISO('2024-01-15T10:00:00Z')).toBe('2024-01-15T10:00:00Z');
+    });
+
+    describe('in America/Chicago (UTC-6 in January, standard time)', () => {
+      beforeEach(() => {
+        vi.stubEnv('TZ', 'America/Chicago');
+      });
+
+      it('resolves start-of-day to the correct UTC instant', () => {
+        expect(localDayStartISO('2024-01-15')).toBe('2024-01-15T06:00:00.000Z');
+      });
+
+      it('resolves end-of-day to the correct UTC instant', () => {
+        expect(localDayEndISO('2024-01-15')).toBe('2024-01-16T05:59:59.999Z');
+      });
+    });
+
+    describe('in Asia/Kolkata (UTC+5:30, no DST)', () => {
+      beforeEach(() => {
+        vi.stubEnv('TZ', 'Asia/Kolkata');
+      });
+
+      it('resolves start-of-day to the correct UTC instant', () => {
+        expect(localDayStartISO('2024-01-15')).toBe('2024-01-14T18:30:00.000Z');
+      });
+
+      it('resolves end-of-day to the correct UTC instant', () => {
+        expect(localDayEndISO('2024-01-15')).toBe('2024-01-15T18:29:59.999Z');
+      });
+    });
+
+    describe('in UTC', () => {
+      beforeEach(() => {
+        vi.stubEnv('TZ', 'UTC');
+      });
+
+      it('start/end of day match the bare UTC boundary exactly', () => {
+        expect(localDayStartISO('2024-01-15')).toBe('2024-01-15T00:00:00.000Z');
+        expect(localDayEndISO('2024-01-15')).toBe('2024-01-15T23:59:59.999Z');
+      });
+    });
+
+    it('end-of-day is exactly 1ms before the next day\'s start-of-day, regardless of zone', () => {
+      vi.stubEnv('TZ', 'America/Chicago');
+      const end = new Date(localDayEndISO('2024-03-05')).getTime();
+      const nextDayStart = new Date(localDayStartISO('2024-03-06')).getTime();
+      expect(nextDayStart - end).toBe(1);
     });
   });
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -45,6 +45,41 @@ function parseDateOnly(dateString?: string): Date | null {
   return isNaN(date.getTime()) ? null : date;
 }
 
+// Shared by localDayStartISO/localDayEndISO: anchors a bare YYYY-MM-DD string
+// to a specific time-of-day using the same trick as parseDateOnly (appending
+// a zone-less time makes the browser parse it as *local* time, not UTC), then
+// converts that local instant to its UTC ISO representation. This is the
+// piece parseDateOnly doesn't need but a date-range filter does: the backend
+// compares against precise created_at instants, so a day boundary has to be
+// resolved to a real instant somewhere, and the browser is the only place
+// that actually knows the user's current local timezone - resolving it here
+// means the backend never has to guess. A value that isn't a bare
+// YYYY-MM-DD (e.g. already a full timestamp, or empty) is returned
+// unchanged, since it either already names a precise instant or isn't a
+// valid date-only value to begin with.
+function localDayBoundaryISO(dateString: string, timeOfDay: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) return dateString;
+  const date = new Date(`${dateString}T${timeOfDay}`);
+  if (isNaN(date.getTime())) return dateString;
+  return date.toISOString();
+}
+
+// Converts a bare YYYY-MM-DD string (e.g. from an <input type="date">) into
+// the UTC instant marking the start of that calendar date in the browser's
+// local timezone - what an activity-feed "from" filter should mean for
+// whoever is actually picking the date, regardless of what timezone the
+// backend runs in.
+export function localDayStartISO(dateString: string): string {
+  return localDayBoundaryISO(dateString, '00:00:00.000');
+}
+
+// Same as localDayStartISO, but for the end of the calendar date (23:59:59.999
+// local) - so a "to" filter includes the entire selected day, not just its
+// first instant.
+export function localDayEndISO(dateString: string): string {
+  return localDayBoundaryISO(dateString, '23:59:59.999');
+}
+
 // Shared computation for calculateQuarantineEndDate / calculateQuarantineEndDateISO:
 // 10 days after the start date, shifted forward if it falls on a weekend.
 function addQuarantineDays(startDateString?: string): Date | null {


### PR DESCRIPTION
## Summary

Follow-up to #270's date-range fix. That PR made the backend correctly *parse* the `YYYY-MM-DD` strings the date-picker sends, but a review of that fix (`internal/handlers/activity_feed.go`) found the day boundary was still anchored to **UTC midnight** — a real, systematic bug for every non-UTC volunteer, off by their UTC offset (several hours for most US users). This PR fixes that, plus a related request-cancellation gap found while verifying the fix live.

### Commit 1 — timezone fix (Option A: resolved in the browser, not the backend)

Investigated first: no timezone concept exists anywhere in this app (no `User`/`Group`/`SiteSetting` timezone field). But the codebase already has an established, deliberate convention for this exact problem — `dateUtils.ts`'s `parseDateOnly` and `AnimalForm.tsx`'s `bqExitDefaultEndDate` both anchor bare dates to *local* time (via a zone-less `T00:00:00` suffix) specifically to avoid UTC-shift bugs, rather than trusting `toISOString()`. The browser is the only place that actually knows a volunteer's current local timezone, so that's where the day boundary has to be resolved.

Added `localDayStartISO`/`localDayEndISO` to `dateUtils.ts`, following that same local-getter pattern: a bare `YYYY-MM-DD` is anchored to local `00:00:00.000` (start) or `23:59:59.999` (end) before being converted to its UTC instant via `toISOString()`. Wired `GroupPage.tsx`'s activity-feed request builder to send these instead of the raw date-picker strings. **No backend changes** — RFC3339 was already its primary, fully-supported parse branch.

**DST correctness**: each boundary is computed *independently* via its own `new Date()` call on a local-time string, rather than start-of-day plus a fixed 24h offset — which is what makes it automatically correct across DST transitions. Verified directly: on the 2024-03-10 US spring-forward day (a 23-hour day), `localDayStartISO` → `2024-03-10T06:00:00.000Z`, `localDayEndISO` → `2024-03-11T04:59:59.999Z` (span = 23h − 1ms, correct). On the 2024-11-03 fall-back day (25-hour day), the span comes out to 25h − 1ms, also correct. A naive fixed-offset implementation would be off by a full hour on these two days per year; this one isn't.

Tests: 7 new cases in `dateUtils.test.ts` (using `vi.stubEnv('TZ', ...)`, verified to actually affect `Date`'s local-time behavior mid-test-run) proving both helpers resolve to the mathematically correct UTC instant in America/Chicago, Asia/Kolkata, and UTC, plus a boundary check that end-of-day is exactly 1ms before the next day's start. 2 new cases in `GroupPage.test.tsx` proving the outgoing request carries the converted instant (not the bare date) and that empty filters send nothing. Confirmed both `GroupPage` tests fail against the pre-fix code before restoring it.

### Commit 2 — request cancellation for `loadActivityFeed`

Verifying the timezone fix live surfaced a separate, pre-existing gap: `loadActivityFeed` had no `AbortController`, unlike `GroupSearch.tsx`'s pattern and `loadAnimals` (#269). Firing `from`/`to` changes in quick succession let an earlier, broader in-flight request occasionally resolve after a newer, narrower one and briefly clobber it in the UI.

Fixed following the existing pattern exactly: `groupsApi.getActivityFeed` (`client.ts`) now accepts an optional `signal`, threaded to axios like `animalsApi.getAll` already does. `loadActivityFeed` aborts any in-flight request via a ref-held `AbortController` before starting a new one, swallows cancellation via `axios.isCancel()`, and cancels on unmount. Its `finally` block only clears the loading flags when the completing request is still current (a guard `loadAnimals` doesn't need, since it has no dedicated loading flags of its own to protect).

Added a regression test mirroring the existing `loadAnimals` cancellation test. Confirmed it fails against the pre-fix code (reverted, reran — `capturedFirstSignal` stayed undefined) before restoring the fix.

## Test plan

- [x] `go build ./...` — backend untouched by this frontend-only branch
- [x] `npx vitest run` — 383 frontend tests pass (up from 373 on main)
- [x] `npx tsc -b` / `npx eslint` — only the same pre-existing, unrelated errors remain (confirmed identical on unmodified `main`)
- [x] TDD throughout: each new test confirmed to fail against the corresponding pre-fix code, then pass after the fix
- [x] Verified live in an actual browser, on this host's genuine `America/Chicago` timezone (not simulated): driving the real `<input type="date">` elements produced `from=2026-07-24T05:00:00.000Z&to=2026-07-30T04:59:59.999Z` — the exact correct local-midnight/local-end-of-day UTC instants for CDT — and the rendered feed correctly excluded/included items across the boundary
- [x] Verified the cancellation fix live: fired `from`, then `to`, then immediately a different `to` with no waiting — the exact scenario that previously let a stale response clobber a fresher one. Only the final, correctly-computed request ever completed and rendered; no stale intermediate state appeared
- [x] Independent code review pass completed (self-reviewed via a separate critical pass): DST boundary math re-verified by hand for both the spring-forward and fall-back transition dates; confirmed the cancellation guard doesn't introduce a new race

🤖 Generated with [Claude Code](https://claude.com/claude-code)