### PR TITLE
ci: automate PR validation and dev deploy/teardown

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,13 +1,14 @@
 name: Build Container Image
 
 on:
-  push:
-    branches:
-      - main
-      - develop
+  pull_request:
     paths:
       - 'Dockerfile'
-      - '.github/workflows/build-image.yml'
+      - 'Dockerfile.base'
+      - 'go.mod'
+      - 'go.sum'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
   workflow_dispatch:
     inputs:
       environment:
@@ -32,82 +33,62 @@ jobs:
   build:
     name: Build and Push Image
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # For develop branch: latest-dev and commit SHA
-            type=raw,value=latest-dev,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=sha,prefix=dev-,enable=${{ github.ref == 'refs/heads/develop' }}
-            # For main branch: latest and semver tags
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=prod-,enable=${{ github.ref == 'refs/heads/main' }}
-            # For PRs: pr-number
+            type=raw,value=sha-${{ github.event.pull_request.head.sha }},enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr,prefix=pr-
-      
+            type=raw,value=manual-${{ github.run_id }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
       - name: Build and push image
         id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
-      
+
       - name: Generate artifact attestation
-        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
-      
-      - name: Create deployment summary
-        if: github.event_name != 'pull_request'
+
+      - name: Create build summary
         run: |
           echo "## Container Image Built 📦" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
-            echo "Update the \`DEV_CONTAINER_IMAGE\` secret in GitHub:" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-dev" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Update the \`CONTAINER_IMAGE\` secret in GitHub:" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          fi

--- a/.github/workflows/deploy-dev-auto.yml
+++ b/.github/workflows/deploy-dev-auto.yml
@@ -6,9 +6,9 @@ on:
     types: [completed]
 
 permissions:
-  id-token: write
   contents: read
   actions: read
+  id-token: write
 
 env:
   TERRAFORM_VERSION: '1.5.7'
@@ -17,10 +17,12 @@ env:
   TF_WORKSPACE: 'volunteer-app-dev'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  APP_NAME: ca-volunteer-media-dev
+  RESOURCE_GROUP: rg-volunteer-media-dev
 
 jobs:
   deploy:
-    name: Terraform Apply (Dev)
+    name: Deploy Dev
     runs-on: ubuntu-latest
     environment: development
     if: github.event.workflow_run.conclusion == 'success'
@@ -57,33 +59,32 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
       - name: Terraform Apply
-        id: apply
         run: terraform apply -auto-approve
         working-directory: ${{ env.WORKING_DIRECTORY }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_DEV }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_USE_OIDC: true
-          TF_VAR_resend_api_key: ${{ secrets.DEV_RESEND_API_KEY }}
-          TF_VAR_jwt_secret: ${{ secrets.DEV_JWT_SECRET }}
-          TF_VAR_container_image: ${{ steps.image.outputs.ref }}
-          TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
-          TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
 
-      - name: Get Outputs
-        id: outputs
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_DEV }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy image to Container App
         run: |
-          echo "container_app_url=$(terraform output -raw container_app_url)" >> $GITHUB_OUTPUT
-        working-directory: ${{ env.WORKING_DIRECTORY }}
-        continue-on-error: true
+          set -euo pipefail
+          MONTH_DAY=$(date +%m%d)
+          GIT_SHORT=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-6)
+          REVISION_SUFFIX="${MONTH_DAY}${GIT_SHORT}"
+          az containerapp update \
+            --name "${{ env.APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --image "${{ steps.image.outputs.ref }}" \
+            --revision-suffix "$REVISION_SUFFIX"
 
       - name: Create Deployment Summary
-        if: steps.outputs.outcome == 'success'
         run: |
           echo "## Dev Auto-Deploy Successful ✅" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ steps.image.outputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**URL:** ${{ steps.outputs.outputs.container_app_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "_Will be torn down by the nightly destroy workflow._" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-dev-auto.yml
+++ b/.github/workflows/deploy-dev-auto.yml
@@ -1,0 +1,89 @@
+name: Deploy Dev (Auto)
+
+on:
+  workflow_run:
+    workflows: ["Promote Image"]
+    types: [completed]
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+env:
+  TERRAFORM_VERSION: '1.5.7'
+  WORKING_DIRECTORY: './terraform/environments/dev'
+  TF_CLOUD_ORGANIZATION: 'Networkengineer'
+  TF_WORKSPACE: 'volunteer-app-dev'
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  deploy:
+    name: Terraform Apply (Dev)
+    runs-on: ubuntu-latest
+    environment: development
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download image digest
+        uses: actions/download-artifact@v4
+        with:
+          name: image-digest
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read image digest
+        id: image
+        run: |
+          set -euo pipefail
+          DIGEST=$(cat image-digest.txt)
+          test -n "$DIGEST"
+          echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply -auto-approve
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_DEV }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_USE_OIDC: true
+          TF_VAR_resend_api_key: ${{ secrets.DEV_RESEND_API_KEY }}
+          TF_VAR_jwt_secret: ${{ secrets.DEV_JWT_SECRET }}
+          TF_VAR_container_image: ${{ steps.image.outputs.ref }}
+          TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
+          TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
+
+      - name: Get Outputs
+        id: outputs
+        run: |
+          echo "container_app_url=$(terraform output -raw container_app_url)" >> $GITHUB_OUTPUT
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        continue-on-error: true
+
+      - name: Create Deployment Summary
+        if: steps.outputs.outcome == 'success'
+        run: |
+          echo "## Dev Auto-Deploy Successful ✅" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ steps.image.outputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** ${{ steps.outputs.outputs.container_app_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_Will be torn down by the nightly destroy workflow._" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/destroy-dev-nightly.yml
+++ b/.github/workflows/destroy-dev-nightly.yml
@@ -1,0 +1,56 @@
+name: Destroy Dev (Nightly)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TERRAFORM_VERSION: '1.5.7'
+  WORKING_DIRECTORY: './terraform/environments/dev'
+  TF_CLOUD_ORGANIZATION: 'Networkengineer'
+  TF_WORKSPACE: 'volunteer-app-dev'
+
+jobs:
+  destroy:
+    name: Terraform Destroy (Dev)
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_DEV }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_USE_OIDC: true
+          TF_VAR_resend_api_key: ${{ secrets.DEV_RESEND_API_KEY }}
+          TF_VAR_jwt_secret: ${{ secrets.DEV_JWT_SECRET }}
+          TF_VAR_container_image: ${{ secrets.DEV_CONTAINER_IMAGE }}
+          TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
+          TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
+
+      - name: Create Destroy Summary
+        run: |
+          echo "## Dev Environment Destroyed (Nightly) 🗑️" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Ran at $(date -u +%Y-%m-%dT%H:%M:%SZ). Next merge will redeploy automatically." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/destroy-dev-nightly.yml
+++ b/.github/workflows/destroy-dev-nightly.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -38,16 +37,6 @@ jobs:
       - name: Terraform Destroy
         run: terraform destroy -auto-approve
         working-directory: ${{ env.WORKING_DIRECTORY }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_DEV }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_USE_OIDC: true
-          TF_VAR_resend_api_key: ${{ secrets.DEV_RESEND_API_KEY }}
-          TF_VAR_jwt_secret: ${{ secrets.DEV_JWT_SECRET }}
-          TF_VAR_container_image: ${{ secrets.DEV_CONTAINER_IMAGE }}
-          TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
-          TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
 
       - name: Create Destroy Summary
         run: |

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -1,0 +1,109 @@
+name: Promote Image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  promote:
+    name: Promote or Build Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find PR associated with this merge
+        id: findpr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0] // empty')
+          if [ -n "$PR_JSON" ]; then
+            HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote existing PR image (no rebuild)
+        id: promote
+        if: steps.findpr.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          SOURCE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.findpr.outputs.head_sha }}"
+          docker buildx imagetools create \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-${{ github.sha }}" \
+            "$SOURCE"
+          DIGEST=$(docker buildx imagetools inspect "$SOURCE" --format '{{json .}}' | jq -r '.manifest.digest')
+          test -n "$DIGEST" && test "$DIGEST" != "null"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Fallback build (no associated PR found)
+        id: fallback
+        if: steps.findpr.outputs.found == 'false'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-${{ github.sha }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Resolve final digest
+        id: final
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.findpr.outputs.found }}" == "true" ]; then
+            echo "digest=${{ steps.promote.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "digest=${{ steps.fallback.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write digest artifact
+        run: echo "${{ steps.final.outputs.digest }}" > image-digest.txt
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-digest
+          path: image-digest.txt
+          retention-days: 7
+
+      - name: Create promotion summary
+        run: |
+          echo "## Image Promoted 📦" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Method:** ${{ steps.findpr.outputs.found == 'true' && 'Retagged existing PR build' || 'Fallback rebuild (no associated PR found)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${{ steps.final.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -79,7 +79,7 @@ jobs:
   backend-lint:
     name: Backend Lint
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run go vet
       run: go vet -tags dev ./...
@@ -176,12 +176,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
-    
+        go-version: '1.25'
+
     - name: Start backend API
       env:
         DB_HOST: localhost
@@ -261,7 +261,7 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run govulncheck
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test Suite
 
 on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,16 @@ jobs:
       with:
         go-version: '1.25'
 
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Start backend API
       env:
         DB_HOST: localhost
@@ -202,12 +212,12 @@ jobs:
         echo $! > backend.pid
         
         # Wait for backend to be ready
-        for i in {1..30}; do
+        for i in {1..60}; do
           if curl -f http://localhost:8080/api/health 2>/dev/null; then
             echo "Backend is ready!"
             break
           fi
-          echo "Waiting for backend... ($i/30)"
+          echo "Waiting for backend... ($i/60)"
           sleep 2
         done
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Run Go tests
       env:
         JWT_SECRET: ${{ secrets.TEST_JWT_SECRET || 'L5WTt6D+6R55YfKzwqPRAEX5bR0bkNo4i58jYKL0wsk=' }}
-      run: go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
+      run: go test -tags dev ./... -v -race -coverprofile=coverage.out -covermode=atomic
 
     - name: Generate coverage report
       run: go tool cover -html=coverage.out -o coverage.html
@@ -90,13 +90,13 @@ jobs:
         go-version: '1.24'
 
     - name: Run go vet
-      run: go vet ./...
+      run: go vet -tags dev ./...
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
         version: latest
-        args: --timeout=5m
+        args: --timeout=5m --build-tags=dev
 
   frontend-lint:
     name: Frontend Lint
@@ -198,7 +198,7 @@ jobs:
         SMTP_FROM_EMAIL: test@example.com
         SMTP_FROM_NAME: Test
       run: |
-        go run cmd/api/main.go &
+        go run -tags dev cmd/api/main.go &
         echo $! > backend.pid
         
         # Wait for backend to be ready

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       run: go vet -tags dev ./...
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         args: --timeout=5m --build-tags=dev


### PR DESCRIPTION
## Summary
- test.yml now runs automatically on PRs and pushes to main
- build-image.yml builds+pushes a candidate image on PR (validates Dockerfile/base-image bumps)
- New promote-image.yml retags the validated image on merge (no rebuild)
- New deploy-dev-auto.yml deploys the promoted image to the shared dev environment
- New destroy-dev-nightly.yml tears dev down every night at 03:00 UTC

## Test plan
- [ ] Confirm this PR's own checks (Backend Tests, Backend Lint, Frontend Lint, Frontend Build) run and pass
- [ ] Confirm build-image.yml does NOT trigger (no Dockerfile/go.mod/package.json changes in this PR)
- [ ] After merge: confirm promote-image.yml and deploy-dev-auto.yml run successfully
- [ ] After merge: manually trigger destroy-dev-nightly.yml once to confirm teardown works

Note: AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, DEV_AXIOM_API_TOKEN, DEV_AXIOM_DATASET secrets are missing from the repo — deploy-dev-auto.yml and destroy-dev-nightly.yml will fail at terraform apply/destroy until these are set.

🤖 Generated with subagent-driven-development