### PR TITLE
Switch OpenTelemetry export from Axiom to Grafana Cloud OTLP

### DIFF
--- a/.github/workflows/terraform-deploy-dev.yml
+++ b/.github/workflows/terraform-deploy-dev.yml
@@ -142,6 +142,9 @@ jobs:
           TF_VAR_container_image: ${{ secrets.DEV_CONTAINER_IMAGE }}
           TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
           TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
+          TF_VAR_grafana_otlp_endpoint: ${{ secrets.DEV_GRAFANA_OTLP_ENDPOINT }}
+          TF_VAR_grafana_instance_id: ${{ secrets.DEV_GRAFANA_INSTANCE_ID }}
+          TF_VAR_grafana_api_token: ${{ secrets.DEV_GRAFANA_API_TOKEN }}
         continue-on-error: true
       
       - name: Create Plan Summary
@@ -197,6 +200,9 @@ jobs:
           TF_VAR_container_image: ${{ secrets.DEV_CONTAINER_IMAGE }}
           TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
           TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
+          TF_VAR_grafana_otlp_endpoint: ${{ secrets.DEV_GRAFANA_OTLP_ENDPOINT }}
+          TF_VAR_grafana_instance_id: ${{ secrets.DEV_GRAFANA_INSTANCE_ID }}
+          TF_VAR_grafana_api_token: ${{ secrets.DEV_GRAFANA_API_TOKEN }}
 
       - name: Get Outputs
         id: outputs
@@ -273,6 +279,9 @@ jobs:
           TF_VAR_container_image: ${{ secrets.DEV_CONTAINER_IMAGE }}
           TF_VAR_axiom_api_token: ${{ secrets.DEV_AXIOM_API_TOKEN }}
           TF_VAR_axiom_dataset: ${{ secrets.DEV_AXIOM_DATASET }}
+          TF_VAR_grafana_otlp_endpoint: ${{ secrets.DEV_GRAFANA_OTLP_ENDPOINT }}
+          TF_VAR_grafana_instance_id: ${{ secrets.DEV_GRAFANA_INSTANCE_ID }}
+          TF_VAR_grafana_api_token: ${{ secrets.DEV_GRAFANA_API_TOKEN }}
 
       - name: Create Destroy Summary
         run: |

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -127,6 +127,9 @@ jobs:
           TF_VAR_container_image: ${{ secrets.CONTAINER_IMAGE }}
           TF_VAR_axiom_api_token: ${{ secrets.AXIOM_API_TOKEN }}
           TF_VAR_axiom_dataset: ${{ secrets.AXIOM_DATASET }}
+          TF_VAR_grafana_otlp_endpoint: ${{ secrets.GRAFANA_OTLP_ENDPOINT }}
+          TF_VAR_grafana_instance_id: ${{ secrets.GRAFANA_INSTANCE_ID }}
+          TF_VAR_grafana_api_token: ${{ secrets.GRAFANA_API_TOKEN }}
         continue-on-error: true
       
       - name: Comment PR with Plan
@@ -196,6 +199,9 @@ jobs:
           TF_VAR_container_image: ${{ secrets.CONTAINER_IMAGE }}
           TF_VAR_axiom_api_token: ${{ secrets.AXIOM_API_TOKEN }}
           TF_VAR_axiom_dataset: ${{ secrets.AXIOM_DATASET }}
+          TF_VAR_grafana_otlp_endpoint: ${{ secrets.GRAFANA_OTLP_ENDPOINT }}
+          TF_VAR_grafana_instance_id: ${{ secrets.GRAFANA_INSTANCE_ID }}
+          TF_VAR_grafana_api_token: ${{ secrets.GRAFANA_API_TOKEN }}
 
       - name: Get Outputs
         id: outputs

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -133,6 +133,15 @@ resource "azurerm_key_vault_secret" "axiom_api_token" {
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }
 
+# Store Grafana Cloud API token in Key Vault
+resource "azurerm_key_vault_secret" "grafana_api_token" {
+  name         = "grafana-api-token"
+  value        = var.grafana_api_token
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+}
+
 # PostgreSQL Flexible Server with auto-pause capability
 resource "azurerm_postgresql_flexible_server" "main" {
   name                = "psql-${var.project_name}-${var.environment}"
@@ -421,30 +430,18 @@ resource "azurerm_container_app" "main" {
         value = join(",", var.allowed_origins)
       }
 
-      # Monitoring — OpenTelemetry exported to Axiom
+      # Monitoring — OpenTelemetry exported to Grafana Cloud. Grafana's OTLP
+      # gateway takes a single Basic-auth header for all three signals - no
+      # per-signal dataset routing like Axiom needed, so there's no
+      # metrics-specific header/env var pair here anymore.
       env {
         name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-        value = var.axiom_endpoint
+        value = var.grafana_otlp_endpoint
       }
 
       env {
         name        = "OTEL_EXPORTER_OTLP_HEADERS"
         secret_name = "otel-exporter-otlp-headers"
-      }
-
-      # Axiom requires metrics on their own dataset (type "Metrics", not
-      # "Events") with a dedicated x-axiom-metrics-dataset header — the
-      # generic OTEL_EXPORTER_OTLP_HEADERS above only routes traces/logs
-      # correctly. Per OTel's env var precedence, otlpmetrichttp falls back
-      # to OTEL_EXPORTER_OTLP_HEADERS when this is unset, so metrics export
-      # stays misconfigured (not disabled) until axiom_metrics_dataset is
-      # set — same as before this env var existed, not a regression.
-      dynamic "env" {
-        for_each = var.axiom_metrics_dataset != "" ? [1] : []
-        content {
-          name        = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
-          secret_name = "otel-exporter-otlp-metrics-headers"
-        }
       }
 
       env {
@@ -502,15 +499,7 @@ resource "azurerm_container_app" "main" {
 
   secret {
     name  = "otel-exporter-otlp-headers"
-    value = "Authorization=Bearer ${var.axiom_api_token},X-Axiom-Dataset=${var.axiom_dataset}"
-  }
-
-  dynamic "secret" {
-    for_each = var.axiom_metrics_dataset != "" ? [var.axiom_metrics_dataset] : []
-    content {
-      name  = "otel-exporter-otlp-metrics-headers"
-      value = "Authorization=Bearer ${var.axiom_api_token},x-axiom-metrics-dataset=${secret.value}"
-    }
+    value = "Authorization=Basic ${base64encode("${var.grafana_instance_id}:${var.grafana_api_token}")}"
   }
 
   # Note: No registry configuration needed - GHCR image is public

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -29,7 +29,16 @@ resend_from_email = "dev@volunteermedia.app"
 # Security
 jwt_secret = "generate-with-openssl-rand-base64-32"  # Separate from prod!
 
-# Observability (Axiom via OpenTelemetry)
+# Observability (Grafana Cloud via OpenTelemetry)
+grafana_otlp_endpoint = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp"  # Grafana Cloud stack's OTLP gateway URL
+grafana_instance_id   = "123456"  # Grafana Cloud stack/instance ID
+grafana_api_token     = "glc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # Grafana Cloud API token (metrics/logs/traces write scope)
+
+# Observability (Axiom via OpenTelemetry) — axiom_api_token has no default,
+# so it's still required to `terraform apply` (it's mirrored into Key Vault
+# regardless), even though it's no longer wired into OTEL_EXPORTER_OTLP_*
+# below (see main.tf). Any placeholder value works if you don't have a real
+# Axiom token anymore.
 axiom_api_token = "xaat-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # Get from Axiom Settings > API tokens
 axiom_dataset   = "go-volunteer-media-dev"
 

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -235,6 +235,28 @@ variable "axiom_metrics_dataset" {
   default     = ""
 }
 
+# Grafana Cloud / OpenTelemetry Configuration
+#
+# The axiom_* variables above are no longer read by the OTLP wiring in
+# main.tf (see the otel-exporter-otlp-headers secret and
+# OTEL_EXPORTER_OTLP_ENDPOINT env var) - left in place rather than deleted,
+# in case Axiom is wanted again as a fallback or point of comparison.
+variable "grafana_otlp_endpoint" {
+  type        = string
+  description = "Grafana Cloud OTLP gateway endpoint for OpenTelemetry export (traces, metrics, logs) - e.g. https://otlp-gateway-prod-us-central-0.grafana.net/otlp. Per-stack/region, unlike Axiom's single shared ingest host, so there's no sensible default."
+}
+
+variable "grafana_instance_id" {
+  type        = string
+  description = "Grafana Cloud stack/instance ID - the username half of the OTLP gateway's HTTP Basic Auth credential"
+}
+
+variable "grafana_api_token" {
+  type        = string
+  description = "Grafana Cloud API token (needs metrics/logs/traces write scope) - the password half of the OTLP gateway's HTTP Basic Auth credential"
+  sensitive   = true
+}
+
 # Monitoring Configuration
 variable "log_retention_days" {
   type        = number

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -130,6 +130,15 @@ resource "azurerm_key_vault_secret" "axiom_api_token" {
   depends_on = [azurerm_role_assignment.terraform_kv_secrets_officer]
 }
 
+# Store Grafana Cloud API token in Key Vault
+resource "azurerm_key_vault_secret" "grafana_api_token" {
+  name         = "grafana-api-token"
+  value        = var.grafana_api_token
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_role_assignment.terraform_kv_secrets_officer]
+}
+
 # PostgreSQL Flexible Server
 resource "azurerm_postgresql_flexible_server" "main" {
   name                = "psql-${var.project_name}-${var.environment}"
@@ -408,30 +417,18 @@ resource "azurerm_container_app" "main" {
         value = azurerm_storage_container.uploads.name
       }
 
-      # Monitoring — OpenTelemetry exported to Axiom
+      # Monitoring — OpenTelemetry exported to Grafana Cloud. Grafana's OTLP
+      # gateway takes a single Basic-auth header for all three signals - no
+      # per-signal dataset routing like Axiom needed, so there's no
+      # metrics-specific header/env var pair here anymore.
       env {
         name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-        value = var.axiom_endpoint
+        value = var.grafana_otlp_endpoint
       }
 
       env {
         name        = "OTEL_EXPORTER_OTLP_HEADERS"
         secret_name = "otel-exporter-otlp-headers"
-      }
-
-      # Axiom requires metrics on their own dataset (type "Metrics", not
-      # "Events") with a dedicated x-axiom-metrics-dataset header — the
-      # generic OTEL_EXPORTER_OTLP_HEADERS above only routes traces/logs
-      # correctly. Per OTel's env var precedence, otlpmetrichttp falls back
-      # to OTEL_EXPORTER_OTLP_HEADERS when this is unset, so metrics export
-      # stays misconfigured (not disabled) until axiom_metrics_dataset is
-      # set — same as before this env var existed, not a regression.
-      dynamic "env" {
-        for_each = var.axiom_metrics_dataset != "" ? [1] : []
-        content {
-          name        = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
-          secret_name = "otel-exporter-otlp-metrics-headers"
-        }
       }
 
       env {
@@ -484,17 +481,9 @@ resource "azurerm_container_app" "main" {
     value = azurerm_storage_account.main.primary_access_key
   }
 
-  dynamic "secret" {
-    for_each = var.axiom_metrics_dataset != "" ? [var.axiom_metrics_dataset] : []
-    content {
-      name  = "otel-exporter-otlp-metrics-headers"
-      value = "Authorization=Bearer ${var.axiom_api_token},x-axiom-metrics-dataset=${secret.value}"
-    }
-  }
-
   secret {
     name  = "otel-exporter-otlp-headers"
-    value = "Authorization=Bearer ${var.axiom_api_token},X-Axiom-Dataset=${var.axiom_dataset}"
+    value = "Authorization=Basic ${base64encode("${var.grafana_instance_id}:${var.grafana_api_token}")}"
   }
 
   # Note: No registry configuration needed - GHCR image is public

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -64,7 +64,17 @@ allowed_origins = [
 # cloudflare_zone_id          = "your-cloudflare-zone-id"
 # cloudflare_api_token        = "cf_api_token_with_dns_edit"
 
-# Observability (Axiom via OpenTelemetry)
+# Observability (Grafana Cloud via OpenTelemetry)
+# Get your instance ID and API token from: https://grafana.com/orgs/<your-org>/stacks (Details > OTLP)
+grafana_otlp_endpoint = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp"
+grafana_instance_id   = "123456"
+grafana_api_token     = "glc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Observability (Axiom via OpenTelemetry) — axiom_api_token has no default,
+# so it's still required to `terraform apply` (it's mirrored into Key Vault
+# regardless), even though it's no longer wired into OTEL_EXPORTER_OTLP_*
+# below (see main.tf). Any placeholder value works if you don't have a real
+# Axiom token anymore.
 # Get your API token from: https://app.axiom.co (Settings > API tokens)
 axiom_api_token = "xaat-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 axiom_dataset   = "go-volunteer-media-prod"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -239,6 +239,28 @@ variable "axiom_metrics_dataset" {
   default     = ""
 }
 
+# Grafana Cloud / OpenTelemetry Configuration
+#
+# The axiom_* variables above are no longer read by the OTLP wiring in
+# main.tf (see the otel-exporter-otlp-headers secret and
+# OTEL_EXPORTER_OTLP_ENDPOINT env var) - left in place rather than deleted,
+# in case Axiom is wanted again as a fallback or point of comparison.
+variable "grafana_otlp_endpoint" {
+  type        = string
+  description = "Grafana Cloud OTLP gateway endpoint for OpenTelemetry export (traces, metrics, logs) - e.g. https://otlp-gateway-prod-us-central-0.grafana.net/otlp. Per-stack/region, unlike Axiom's single shared ingest host, so there's no sensible default."
+}
+
+variable "grafana_instance_id" {
+  type        = string
+  description = "Grafana Cloud stack/instance ID - the username half of the OTLP gateway's HTTP Basic Auth credential"
+}
+
+variable "grafana_api_token" {
+  type        = string
+  description = "Grafana Cloud API token (needs metrics/logs/traces write scope) - the password half of the OTLP gateway's HTTP Basic Auth credential"
+  sensitive   = true
+}
+
 # Monitoring Configuration
 variable "log_retention_days" {
   type        = number


### PR DESCRIPTION
## Summary

Moves OTLP export (traces, metrics, logs) from Axiom to Grafana Cloud in both `dev` and `prod`. The app's OTel SDK setup (`internal/telemetry/telemetry.go`) is standard OTLP/HTTP and needed no changes — Axiom's header shape (`Authorization: Bearer <token>` + `X-Axiom-Dataset`) and its per-signal metrics-dataset routing were hardcoded into the Terraform string interpolation, not just backed by variable values, so switching backends required editing that Terraform logic directly.

Identical changes in `terraform/environments/{dev,prod}`:

- **New variables**: `grafana_otlp_endpoint`, `grafana_instance_id`, `grafana_api_token` (sensitive), mirroring the `axiom_*` declaration pattern. `grafana_otlp_endpoint` has no default (unlike `axiom_endpoint`) since Grafana Cloud's OTLP gateway URL is per-stack/region.
- **New Key Vault mirror**: `azurerm_key_vault_secret.grafana_api_token`, mirroring the existing `axiom_api_token` mirror, for rotation consistency.
- **`OTEL_EXPORTER_OTLP_ENDPOINT`** now reads `var.grafana_otlp_endpoint` instead of `var.axiom_endpoint`.
- **`otel-exporter-otlp-headers` secret** rebuilt for Grafana's HTTP Basic Auth shape: `"Authorization=Basic ${base64encode("${instance_id}:${token}")}"`, replacing Axiom's Bearer+dataset-header string.
- **Removed** the `OTEL_EXPORTER_OTLP_METRICS_HEADERS` env/secret `dynamic` blocks entirely — Grafana Cloud's OTLP gateway accepts all three signals through one endpoint/header pair, with no per-signal dataset routing to work around.
- **CI**: added `TF_VAR_grafana_otlp_endpoint`/`grafana_instance_id`/`grafana_api_token` mappings alongside every existing `axiom_*` mapping in `terraform-deploy.yml` (plan, apply) and `terraform-deploy-dev.yml` (plan, apply, destroy).
- **`terraform.tfvars.example`** updated in both environments with Grafana placeholders.

The `axiom_*` variables and the Axiom Key Vault mirror are left in place, not deleted — kept in case Axiom is wanted again as a fallback or comparison. Note: `axiom_api_token` has no default and is still consumed by `azurerm_key_vault_secret.axiom_api_token`, so it remains a required variable to `terraform apply` even though it's no longer part of the OTLP wiring — any placeholder value works. `axiom_dataset`/`axiom_endpoint`/`axiom_metrics_dataset` are now genuinely unused. Worth a follow-up decision on deleting the Axiom scaffolding entirely once Grafana Cloud is confirmed working.

## Manual follow-up required (not done here)

The following GitHub Actions secrets don't exist yet and must be added before this can deploy:
- **prod**: `GRAFANA_OTLP_ENDPOINT`, `GRAFANA_INSTANCE_ID`, `GRAFANA_API_TOKEN`
- **dev**: `DEV_GRAFANA_OTLP_ENDPOINT`, `DEV_GRAFANA_INSTANCE_ID`, `DEV_GRAFANA_API_TOKEN`

(Terry has already provisioned the Grafana Cloud stack itself — these are just the values to wire in as secrets.)

Also flagging, found while verifying this branch (pre-existing, unrelated to this change, applies to unmodified `main` too):
- CI's pinned Terraform CLI (`TERRAFORM_VERSION: '1.5.7'` in both workflow files, unchanged since each file was first created — Oct 2025 prod, Dec 2025 dev) can't even `terraform init` current `main` — a cross-variable `validation` block added in December 2025 (`variables.tf`, `cloudflare_zone_id`) requires Terraform ≥1.9. Confirmed clean under 1.14.9 (the version actually used to deploy this locally) — CI's pin should probably be bumped to match.
- Both `terraform-deploy.yml` and `terraform-deploy-dev.yml` have zero successful runs in this repo's history — the 4 historical runs (all from Nov 2025) failed on a GitHub Actions billing block before ever reaching a Terraform step. Actual deployments have evidently happened via manual/local `terraform apply`, not through this CI pipeline.

## Test plan

- [x] `terraform fmt -check` — clean on all 4 changed `.tf` files
- [x] `terraform validate` (via `init -backend=false`, no real HCP Terraform credentials available) — clean `Success!` in both environments under Terraform 1.14.9 (matching what's actually run locally to deploy this), only pre-existing deprecation warnings, no errors. (An initial pass with Terraform 1.9.8 spuriously failed on an unrelated `voyage_api_key` `dynamic`-block `for_each` type-check that 1.14.9 doesn't reproduce — a version-testing artifact on my end, not a real issue; see PR discussion.)
- [x] `actionlint` on both workflow files — identical finding set before/after (same warnings, shifted line numbers only)
- [ ] Not run: `terraform plan`/`apply` (no real Azure/HCP Terraform credentials available in this environment) — needs a real run once the Grafana secrets above are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
