### PR TITLE
Add per-group weekly volunteer shift scheduling

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -446,6 +446,11 @@ func main() {
 			group.POST("/members/:userId/promote", handlers.PromoteMemberToGroupAdmin(db))
 			group.POST("/members/:userId/demote", handlers.DemoteMemberFromGroupAdmin(db))
 
+			group.GET("/schedule/me", handlers.GetMySchedule(db))
+			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
+			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))
+			group.PUT("/schedule/:userId", handlers.UpdateMemberSchedule(db))
+
 			// Content moderation - group admin or site admin can view deleted content
 			group.GET("/deleted-comments", handlers.GetDeletedComments(db))
 			group.GET("/deleted-images", handlers.GetDeletedImages(db))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -446,6 +446,7 @@ func main() {
 			group.POST("/members/:userId/promote", handlers.PromoteMemberToGroupAdmin(db))
 			group.POST("/members/:userId/demote", handlers.DemoteMemberFromGroupAdmin(db))
 
+			group.PATCH("/scheduling", handlers.UpdateGroupScheduling(db))
 			group.GET("/schedule/me", handlers.GetMySchedule(db))
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -611,6 +611,26 @@ export const groupsApi = {
   },
 };
 
+// Weekly volunteer shift schedule (per group). day_of_week is 0=Sunday..6=Saturday;
+// hour is the slot's start hour, 8..17 (8am-6pm in 1-hour increments).
+export interface ScheduleSlot {
+  day_of_week: number;
+  hour: number;
+}
+
+export interface ScheduleResponse {
+  slots: ScheduleSlot[];
+}
+
+export const scheduleApi = {
+  getMine: (groupId: number) => api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`),
+  updateMine: (groupId: number, slots: ScheduleSlot[]) =>
+    api.put<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { slots }),
+  getForMember: (groupId: number, userId: number) => api.get<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`),
+  updateForMember: (groupId: number, userId: number, slots: ScheduleSlot[]) =>
+    api.put<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { slots }),
+};
+
 // Animals API
 export const animalsApi = {
   getAll: (groupId: number, status?: string, name?: string, options?: { signal?: AbortSignal }) => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -626,10 +626,12 @@ export interface ScheduleResponse {
 }
 
 export const scheduleApi = {
-  getMine: (groupId: number) => api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`),
+  getMine: (groupId: number, options?: { signal?: AbortSignal }) =>
+    api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { signal: options?.signal }),
   updateMine: (groupId: number, slots: ScheduleSlot[]) =>
     api.put<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { slots }),
-  getForMember: (groupId: number, userId: number) => api.get<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`),
+  getForMember: (groupId: number, userId: number, options?: { signal?: AbortSignal }) =>
+    api.get<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { signal: options?.signal }),
   updateForMember: (groupId: number, userId: number, slots: ScheduleSlot[]) =>
     api.put<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { slots }),
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -162,6 +162,7 @@ export interface Group {
   image_url: string;
   hero_image_url: string;
   has_protocols: boolean;
+  scheduling_enabled: boolean;
   groupme_bot_id?: string; // Only present in admin responses; hidden from regular group members
   groupme_enabled: boolean;
 }
@@ -562,6 +563,8 @@ export const groupsApi = {
   getAll: () => api.get<Group[]>('/groups'),
   getById: (id: number) => api.get<Group>('/groups/' + id),
   getMembership: (id: number) => api.get<GroupMembership>('/groups/' + id + '/membership'),
+  updateScheduling: (id: number, enabled: boolean) =>
+    api.patch<{ scheduling_enabled: boolean }>(`/groups/${id}/scheduling`, { enabled }),
   getLatestComments: (id: number, limit?: number) => {
     const params = limit ? { limit } : {};
     return api.get<CommentWithAnimal[]>('/groups/' + id + '/latest-comments', { params });

--- a/frontend/src/pages/BulkEditAnimalsPage.test.tsx
+++ b/frontend/src/pages/BulkEditAnimalsPage.test.tsx
@@ -40,6 +40,7 @@ const mockGroup: Group = {
   image_url: '',
   hero_image_url: '',
   has_protocols: false,
+  scheduling_enabled: false,
   groupme_enabled: false,
 };
 

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../api/client', () => ({
     getMembership: vi.fn(),
     getAll: vi.fn(),
     getActivityFeed: vi.fn(),
+    updateScheduling: vi.fn(),
   },
   animalsApi: {
     getAll: vi.fn(),
@@ -472,6 +473,48 @@ describe('GroupPage', () => {
 
       expect(screen.getByText('fresh comment')).toBeInTheDocument();
       expect(screen.queryByText('stale comment')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('scheduling toggle', () => {
+    it('does not show the Schedule tab when scheduling is disabled for the group', async () => {
+      renderGroupPage();
+      await screen.findByRole('tab', { name: /animals/i });
+      expect(screen.queryByRole('tab', { name: /schedule/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the Schedule tab to a member when scheduling is enabled for the group', async () => {
+      vi.mocked(groupsApi.getById).mockResolvedValue({
+        data: { ...mockGroup, scheduling_enabled: true },
+      } as AxiosResponse<Group>);
+
+      renderGroupPage();
+      expect(await screen.findByRole('tab', { name: /schedule/i })).toBeInTheDocument();
+    });
+
+    it('does not show the scheduling toggle button to a regular member', async () => {
+      renderGroupPage();
+      await screen.findByRole('tab', { name: /animals/i });
+      expect(screen.queryByRole('button', { name: /enable scheduling|disable scheduling/i })).not.toBeInTheDocument();
+    });
+
+    it('a group admin can enable scheduling, which then reveals the Schedule tab', async () => {
+      vi.mocked(groupsApi.getMembership).mockResolvedValue({
+        data: { ...mockMembership, is_group_admin: true },
+      } as AxiosResponse<GroupMembership>);
+      vi.mocked(groupsApi.updateScheduling).mockResolvedValue({
+        data: { scheduling_enabled: true },
+      } as AxiosResponse<{ scheduling_enabled: boolean }>);
+
+      renderGroupPage();
+      const enableButton = await screen.findByRole('button', { name: /enable scheduling/i });
+      expect(screen.queryByRole('tab', { name: /schedule/i })).not.toBeInTheDocument();
+
+      fireEvent.click(enableButton);
+
+      await waitFor(() => expect(groupsApi.updateScheduling).toHaveBeenCalledWith(1, true));
+      expect(await screen.findByRole('tab', { name: /schedule/i })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /disable scheduling/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -52,6 +52,7 @@ const mockGroup: Group = {
   image_url: '',
   hero_image_url: '',
   has_protocols: false,
+  scheduling_enabled: false,
   groupme_enabled: false,
 };
 

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -665,7 +665,7 @@ const GroupPage: React.FC = () => {
               <span>Documents</span>
             </button>
           )}
-          {(membership?.is_member || membership?.is_site_admin) && (
+          {group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && (
             <button
               role="tab"
               aria-selected={viewMode === 'schedule'}
@@ -1582,7 +1582,7 @@ const GroupPage: React.FC = () => {
         </div>
       )}
 
-      {viewMode === 'schedule' && (membership?.is_member || membership?.is_site_admin) && id && (
+      {viewMode === 'schedule' && group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && id && (
         <div
           role="tabpanel"
           id="schedule-panel"

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -59,6 +59,7 @@ const GroupPage: React.FC = () => {
   const [effectiveNameSearch, setEffectiveNameSearch] = useState(debouncedNameSearch);
   const [showAnnouncementForm, setShowAnnouncementForm] = useState(false);
   const [showProtocolForm, setShowProtocolForm] = useState(false);
+  const [togglingScheduling, setTogglingScheduling] = useState(false);
   const [showLengthOfStay, setShowLengthOfStay] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<{ show: boolean; updateId: number | null; title: string }>({
     show: false, updateId: null, title: '',
@@ -276,6 +277,24 @@ const GroupPage: React.FC = () => {
       toast.showSuccess('Announcement deleted');
     } catch {
       toast.showError('Failed to delete announcement');
+    }
+  };
+
+  const handleToggleScheduling = async () => {
+    if (!id || !group) return;
+    const nextEnabled = !group.scheduling_enabled;
+    setTogglingScheduling(true);
+    try {
+      const res = await groupsApi.updateScheduling(Number(id), nextEnabled);
+      setGroup((prev) => (prev ? { ...prev, scheduling_enabled: res.data.scheduling_enabled } : prev));
+      toast.showSuccess(res.data.scheduling_enabled ? 'Scheduling enabled for this group' : 'Scheduling disabled for this group');
+      if (!res.data.scheduling_enabled && viewMode === 'schedule') {
+        setViewMode('activity');
+      }
+    } catch {
+      toast.showError('Failed to update scheduling setting');
+    } finally {
+      setTogglingScheduling(false);
     }
   };
 
@@ -742,6 +761,20 @@ const GroupPage: React.FC = () => {
               <span>Upload Script</span>
             </button>
           )}
+          <button
+            type="button"
+            className="group-admin-link"
+            onClick={handleToggleScheduling}
+            disabled={togglingScheduling}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+              <line x1="16" y1="2" x2="16" y2="6" />
+              <line x1="8" y1="2" x2="8" y2="6" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
+            <span>{group.scheduling_enabled ? 'Disable Scheduling' : 'Enable Scheduling'}</span>
+          </button>
         </div>
       )}
 

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -19,9 +19,10 @@ import { calculateAge, formatAge, formatQuarantineEndDate, localDayStartISO, loc
 import { formatAnimalStatus } from '../utils/animalUtils';
 import QuarantineApprovalBadge from '../components/QuarantineApprovalBadge';
 import { formatDisplayName } from '../utils/formatName';
+import ScheduleTab from './group/ScheduleTab';
 import './GroupPage.css';
 
-type ViewMode = 'activity' | 'animals' | 'protocols' | 'members' | 'documents';
+type ViewMode = 'activity' | 'animals' | 'protocols' | 'members' | 'documents' | 'schedule';
 type FilterType = 'all' | 'comments' | 'announcements';
 
 // Matches GroupSearch.tsx's debounce delay for the same kind of free-text
@@ -195,9 +196,9 @@ const GroupPage: React.FC = () => {
     const viewParam = searchParams.get('view') as ViewMode;
     if (viewParam && (viewParam === 'activity' || viewParam === 'animals' || viewParam === 'protocols' || viewParam === 'documents')) {
       setViewMode(viewParam);
-    } else if (viewParam === 'members' && (membership?.is_member || membership?.is_site_admin)) {
+    } else if ((viewParam === 'members' || viewParam === 'schedule') && (membership?.is_member || membership?.is_site_admin)) {
       setViewMode(viewParam);
-    } else if (viewParam === 'members' && !membership?.is_member && !membership?.is_site_admin) {
+    } else if ((viewParam === 'members' || viewParam === 'schedule') && !membership?.is_member && !membership?.is_site_admin) {
       setViewMode('activity');
     }
   }, [searchParams, membership]);
@@ -662,6 +663,24 @@ const GroupPage: React.FC = () => {
                 <polyline points="10 9 9 9 8 9" />
               </svg>
               <span>Documents</span>
+            </button>
+          )}
+          {(membership?.is_member || membership?.is_site_admin) && (
+            <button
+              role="tab"
+              aria-selected={viewMode === 'schedule'}
+              aria-controls="schedule-panel"
+              id="schedule-tab"
+              className={`group-tab ${viewMode === 'schedule' ? 'group-tab--active' : ''}`}
+              onClick={() => setViewMode('schedule')}
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              <span>Schedule</span>
             </button>
           )}
         </div>
@@ -1560,6 +1579,20 @@ const GroupPage: React.FC = () => {
               </div>
             )}
           </div>
+        </div>
+      )}
+
+      {viewMode === 'schedule' && (membership?.is_member || membership?.is_site_admin) && id && (
+        <div
+          role="tabpanel"
+          id="schedule-panel"
+          aria-labelledby="schedule-tab"
+          className="group-content"
+        >
+          <ScheduleTab
+            groupId={Number(id)}
+            canManageMembers={!!(membership?.is_group_admin || membership?.is_site_admin)}
+          />
         </div>
       )}
 

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -1,0 +1,78 @@
+.schedule-tab {
+  padding: 1rem 0;
+}
+
+.schedule-tab__picker {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.schedule-tab__picker select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--neutral-300);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: 90px repeat(7, 1fr);
+  gap: 2px;
+  overflow-x: auto;
+}
+
+.schedule-grid__row {
+  display: contents;
+}
+
+.schedule-grid__cell {
+  padding: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.schedule-grid__cell--header {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.schedule-grid__cell--corner {
+  background: transparent;
+}
+
+.schedule-grid__slot {
+  height: 32px;
+  border: 1px solid var(--neutral-200);
+  border-radius: 4px;
+  background: var(--surface);
+  cursor: pointer;
+  padding: 0;
+}
+
+.schedule-grid__slot:hover {
+  border-color: var(--brand);
+}
+
+.schedule-grid__slot:focus {
+  outline: 2px solid var(--brand);
+  outline-offset: 1px;
+}
+
+.schedule-grid__slot--active {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+
+.schedule-tab__save {
+  margin-top: 1rem;
+}
+
+[data-theme='dark'] .schedule-grid__slot {
+  border-color: var(--neutral-300);
+}

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ScheduleTab from './ScheduleTab';
 import { scheduleApi, groupsApi } from '../../api/client';
+import { CanceledError } from 'axios';
 import type { AxiosResponse } from 'axios';
 import type { ScheduleResponse, GroupMember } from '../../api/client';
 import { ToastProvider } from '../../contexts/ToastContext';
@@ -40,7 +41,7 @@ describe('ScheduleTab', () => {
 
     renderScheduleTab(false);
 
-    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalledWith(1, expect.objectContaining({ signal: expect.any(AbortSignal) })));
     const slot = await screen.findByRole('cell', { name: 'Tue 9:00 AM' });
     expect(slot).toHaveAttribute('aria-pressed', 'true');
   });
@@ -79,8 +80,63 @@ describe('ScheduleTab', () => {
 
     fireEvent.change(screen.getByLabelText(/viewing schedule for/i), { target: { value: '42' } });
 
-    await waitFor(() => expect(scheduleApi.getForMember).toHaveBeenCalledWith(1, 42));
+    await waitFor(() => expect(scheduleApi.getForMember).toHaveBeenCalledWith(1, 42, expect.objectContaining({ signal: expect.any(AbortSignal) })));
     const slot = await screen.findByRole('cell', { name: 'Fri 4:00 PM' });
     expect(slot).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not let a superseded (aborted) request overwrite a newer group\'s data', async () => {
+    // Simulates GroupPage's group-switcher changing the groupId prop while
+    // the previous group's schedule is still loading (the volunteer picker
+    // itself unmounts during loading - see the `loading` early-return above
+    // - so this prop-driven race is the realistic path, not picker clicks).
+    let resolveFirst!: (value: AxiosResponse<ScheduleResponse>) => void;
+    let capturedFirstSignal: AbortSignal | undefined;
+    const staleResponse = { data: { slots: [{ day_of_week: 0, hour: 8 }] } } as unknown as AxiosResponse<ScheduleResponse>;
+    const freshResponse = { data: { slots: [{ day_of_week: 6, hour: 17 }] } } as unknown as AxiosResponse<ScheduleResponse>;
+
+    // First group's own-schedule fetch: stays pending until resolveFirst is
+    // invoked, but rejects immediately - the way a real aborted axios
+    // request would - if its signal fires first.
+    vi.mocked(scheduleApi.getMine)
+      .mockImplementationOnce((_groupId, options) => {
+        capturedFirstSignal = options?.signal;
+        return new Promise<AxiosResponse<ScheduleResponse>>((resolve, reject) => {
+          resolveFirst = resolve;
+          options?.signal?.addEventListener('abort', () => reject(new CanceledError()));
+        });
+      })
+      // Second group's fetch (after the prop changes): resolves immediately
+      // with different data.
+      .mockResolvedValueOnce(freshResponse);
+
+    const { rerender } = render(
+      <ToastProvider>
+        <ScheduleTab groupId={1} canManageMembers={false} />
+      </ToastProvider>
+    );
+
+    await waitFor(() => expect(capturedFirstSignal).toBeDefined());
+    expect(capturedFirstSignal?.aborted).toBe(false);
+
+    // Switching to a new group before the first request resolves must abort it.
+    rerender(
+      <ToastProvider>
+        <ScheduleTab groupId={2} canManageMembers={false} />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(capturedFirstSignal?.aborted).toBe(true));
+
+    const freshSlot = await screen.findByRole('cell', { name: 'Sat 5:00 PM' });
+    expect(freshSlot).toHaveAttribute('aria-pressed', 'true');
+
+    // The first (now-aborted) request resolving late must not overwrite the
+    // fresher data already rendered.
+    await act(async () => {
+      resolveFirst(staleResponse);
+    });
+
+    expect(screen.getByRole('cell', { name: 'Sat 5:00 PM' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('cell', { name: 'Sun 8:00 AM' })).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ScheduleTab from './ScheduleTab';
+import { scheduleApi, groupsApi } from '../../api/client';
+import type { AxiosResponse } from 'axios';
+import type { ScheduleResponse, GroupMember } from '../../api/client';
+import { ToastProvider } from '../../contexts/ToastContext';
+
+vi.mock('../../api/client', () => ({
+  scheduleApi: {
+    getMine: vi.fn(),
+    updateMine: vi.fn(),
+    getForMember: vi.fn(),
+    updateForMember: vi.fn(),
+  },
+  groupsApi: {
+    getMembers: vi.fn(),
+  },
+}));
+
+function renderScheduleTab(canManageMembers: boolean) {
+  return render(
+    <ToastProvider>
+      <ScheduleTab groupId={1} canManageMembers={canManageMembers} />
+    </ToastProvider>
+  );
+}
+
+describe('ScheduleTab', () => {
+  beforeEach(() => {
+    vi.mocked(scheduleApi.getMine).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleResponse>);
+    vi.mocked(scheduleApi.updateMine).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleResponse>);
+    vi.mocked(groupsApi.getMembers).mockResolvedValue({ data: [] } as unknown as AxiosResponse<GroupMember[]>);
+  });
+
+  it('loads and displays the caller\'s own schedule by default', async () => {
+    vi.mocked(scheduleApi.getMine).mockResolvedValue({
+      data: { slots: [{ day_of_week: 2, hour: 9 }] },
+    } as unknown as AxiosResponse<ScheduleResponse>);
+
+    renderScheduleTab(false);
+
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalledWith(1));
+    const slot = await screen.findByRole('cell', { name: 'Tue 9:00 AM' });
+    expect(slot).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggling a cell and saving calls updateMine with the new slot set', async () => {
+    renderScheduleTab(false);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+
+    const slot = await screen.findByRole('cell', { name: 'Wed 10:00 AM' });
+    fireEvent.click(slot);
+    expect(slot).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: /save schedule/i }));
+
+    await waitFor(() => {
+      expect(scheduleApi.updateMine).toHaveBeenCalledWith(1, [{ day_of_week: 3, hour: 10 }]);
+    });
+  });
+
+  it('does not show the volunteer picker for a non-admin member', async () => {
+    renderScheduleTab(false);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+    expect(screen.queryByLabelText(/viewing schedule for/i)).not.toBeInTheDocument();
+  });
+
+  it('a group admin can pick another member and load their schedule', async () => {
+    vi.mocked(groupsApi.getMembers).mockResolvedValue({
+      data: [{ user_id: 42, username: 'vol2', is_group_admin: false, is_site_admin: false, email: '', skill_tags: [] }],
+    } as unknown as AxiosResponse<GroupMember[]>);
+    vi.mocked(scheduleApi.getForMember).mockResolvedValue({
+      data: { slots: [{ day_of_week: 5, hour: 16 }] },
+    } as unknown as AxiosResponse<ScheduleResponse>);
+
+    renderScheduleTab(true);
+    await waitFor(() => expect(groupsApi.getMembers).toHaveBeenCalledWith(1));
+
+    fireEvent.change(screen.getByLabelText(/viewing schedule for/i), { target: { value: '42' } });
+
+    await waitFor(() => expect(scheduleApi.getForMember).toHaveBeenCalledWith(1, 42));
+    const slot = await screen.findByRole('cell', { name: 'Fri 4:00 PM' });
+    expect(slot).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { scheduleApi, groupsApi } from '../../api/client';
+import type { GroupMember } from '../../api/client';
+import { useToast } from '../../hooks/useToast';
+import SkeletonLoader from '../../components/SkeletonLoader';
+import ErrorState from '../../components/ErrorState';
+import './ScheduleTab.css';
+
+export interface ScheduleTabProps {
+  groupId: number;
+  canManageMembers: boolean;
+}
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
+
+function slotKey(dayOfWeek: number, hour: number): string {
+  return `${dayOfWeek}-${hour}`;
+}
+
+function formatHourLabel(hour: number): string {
+  const period = hour < 12 ? 'AM' : 'PM';
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${displayHour}:00 ${period}`;
+}
+
+const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) => {
+  const toast = useToast();
+  const [members, setMembers] = useState<GroupMember[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const [selectedSlots, setSelectedSlots] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const loadSchedule = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    const request = selectedUserId === null
+      ? scheduleApi.getMine(groupId)
+      : scheduleApi.getForMember(groupId, selectedUserId);
+    request
+      .then(res => {
+        setSelectedSlots(new Set(res.data.slots.map(s => slotKey(s.day_of_week, s.hour))));
+      })
+      .catch(() => setError('Unable to load schedule.'))
+      .finally(() => setLoading(false));
+  }, [groupId, selectedUserId]);
+
+  useEffect(() => {
+    loadSchedule();
+  }, [loadSchedule]);
+
+  useEffect(() => {
+    if (!canManageMembers) return;
+    groupsApi.getMembers(groupId)
+      .then(res => setMembers(res.data))
+      .catch(() => { /* picker just won't populate; own-schedule view still works */ });
+  }, [groupId, canManageMembers]);
+
+  const toggleSlot = (dayOfWeek: number, hour: number) => {
+    setSelectedSlots(prev => {
+      const next = new Set(prev);
+      const key = slotKey(dayOfWeek, hour);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    const slots = Array.from(selectedSlots).map(key => {
+      const [dayOfWeek, hour] = key.split('-').map(Number);
+      return { day_of_week: dayOfWeek, hour };
+    });
+    setSaving(true);
+    const request = selectedUserId === null
+      ? scheduleApi.updateMine(groupId, slots)
+      : scheduleApi.updateForMember(groupId, selectedUserId, slots);
+    request
+      .then(() => toast.showSuccess('Schedule saved.'))
+      .catch(() => toast.showError('Failed to save schedule.'))
+      .finally(() => setSaving(false));
+  };
+
+  if (loading) {
+    return <SkeletonLoader variant="card" count={1} />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={loadSchedule} />;
+  }
+
+  return (
+    <div className="schedule-tab">
+      {canManageMembers && (
+        <div className="schedule-tab__picker">
+          <label htmlFor="schedule-member-select">Viewing schedule for</label>
+          <select
+            id="schedule-member-select"
+            value={selectedUserId ?? ''}
+            onChange={e => setSelectedUserId(e.target.value === '' ? null : Number(e.target.value))}
+          >
+            <option value="">My Schedule</option>
+            {members.map(m => (
+              <option key={m.user_id} value={m.user_id}>
+                {[m.first_name, m.last_name].filter(Boolean).join(' ') || m.username}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="schedule-grid" role="table" aria-label="Weekly shift schedule">
+        <div className="schedule-grid__row schedule-grid__row--header" role="row">
+          <div className="schedule-grid__cell schedule-grid__cell--corner" role="columnheader" />
+          {DAYS.map(day => (
+            <div key={day} className="schedule-grid__cell schedule-grid__cell--header" role="columnheader">
+              {day}
+            </div>
+          ))}
+        </div>
+        {HOURS.map(hour => (
+          <div key={hour} className="schedule-grid__row" role="row">
+            <div className="schedule-grid__cell schedule-grid__cell--header" role="rowheader">
+              {formatHourLabel(hour)}
+            </div>
+            {DAYS.map((_, dayOfWeek) => {
+              const key = slotKey(dayOfWeek, hour);
+              const active = selectedSlots.has(key);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  role="cell"
+                  className={`schedule-grid__slot ${active ? 'schedule-grid__slot--active' : ''}`}
+                  aria-pressed={active}
+                  aria-label={`${DAYS[dayOfWeek]} ${formatHourLabel(hour)}`}
+                  onClick={() => toggleSlot(dayOfWeek, hour)}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      <button type="button" className="btn-primary schedule-tab__save" onClick={handleSave} disabled={saving}>
+        {saving ? 'Saving…' : 'Save Schedule'}
+      </button>
+    </div>
+  );
+};
+
+export default ScheduleTab;

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
 import { scheduleApi, groupsApi } from '../../api/client';
 import type { GroupMember } from '../../api/client';
 import { useToast } from '../../hooks/useToast';
@@ -33,23 +34,51 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) 
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
+  // Cancels any in-flight request before starting a new one - matching
+  // GroupPage.tsx's loadAnimals/loadActivityFeed AbortController pattern -
+  // so switching the volunteer picker (or a group/prop change) in quick
+  // succession can't let a slower, older response land after a newer one
+  // and overwrite it with the wrong volunteer's schedule.
+  const loadAbortControllerRef = useRef<AbortController | null>(null);
   const loadSchedule = useCallback(() => {
+    loadAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    loadAbortControllerRef.current = controller;
+
     setLoading(true);
     setError(null);
     const request = selectedUserId === null
-      ? scheduleApi.getMine(groupId)
-      : scheduleApi.getForMember(groupId, selectedUserId);
+      ? scheduleApi.getMine(groupId, { signal: controller.signal })
+      : scheduleApi.getForMember(groupId, selectedUserId, { signal: controller.signal });
     request
       .then(res => {
         setSelectedSlots(new Set(res.data.slots.map(s => slotKey(s.day_of_week, s.hour))));
       })
-      .catch(() => setError('Unable to load schedule.'))
-      .finally(() => setLoading(false));
+      .catch(err => {
+        if (axios.isCancel(err)) return;
+        setError('Unable to load schedule.');
+      })
+      .finally(() => {
+        // A superseded (now-aborted) request's `finally` must not flip
+        // loading back off after a newer request already set it - only the
+        // request that's still current should clear it.
+        if (loadAbortControllerRef.current === controller) {
+          setLoading(false);
+        }
+      });
   }, [groupId, selectedUserId]);
 
   useEffect(() => {
     loadSchedule();
   }, [loadSchedule]);
+
+  // Cancel any in-flight schedule request on unmount so it can't set state
+  // on an unmounted component.
+  useEffect(() => {
+    return () => {
+      loadAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (!canManageMembers) return;

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -202,6 +202,7 @@ func RunMigrations(db *gorm.DB) error {
 		&models.AnimalBQIncident{},
 		&models.GroupDocument{},
 		&models.APIToken{},
+		&models.ShiftSlot{},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)

--- a/internal/handlers/group.go
+++ b/internal/handlers/group.go
@@ -339,6 +339,19 @@ func AddUserToGroup(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
+// removeUserFromGroupAndSchedule removes the group membership association
+// and deletes any ShiftSlot rows the user has for that group, in a single
+// transaction - otherwise a stale schedule would silently reappear if they
+// rejoin the group later.
+func removeUserFromGroupAndSchedule(db *gorm.DB, user *models.User, group *models.Group) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(user).Association("Groups").Delete(group); err != nil {
+			return err
+		}
+		return tx.Where("user_id = ? AND group_id = ?", user.ID, group.ID).Delete(&models.ShiftSlot{}).Error
+	})
+}
+
 // RemoveUserFromGroup removes a user from a group (admin only)
 func RemoveUserFromGroup(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -366,7 +379,7 @@ func RemoveUserFromGroup(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		if err := db.Model(&user).Association("Groups").Delete(&group); err != nil {
+		if err := removeUserFromGroupAndSchedule(db, &user, &group); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove user from group"})
 			return
 		}
@@ -836,16 +849,7 @@ func RemoveMemberFromGroup(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		// Remove user from group, along with any shift schedule they set for
-		// it - otherwise the old schedule would silently reappear if they
-		// rejoin the group later.
-		err = db.Transaction(func(tx *gorm.DB) error {
-			if err := tx.Model(&targetUser).Association("Groups").Delete(&group); err != nil {
-				return err
-			}
-			return tx.Where("user_id = ? AND group_id = ?", targetUserID, groupID).Delete(&models.ShiftSlot{}).Error
-		})
-		if err != nil {
+		if err := removeUserFromGroupAndSchedule(db, &targetUser, &group); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove user from group"})
 			return
 		}

--- a/internal/handlers/group.go
+++ b/internal/handlers/group.go
@@ -836,8 +836,16 @@ func RemoveMemberFromGroup(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		// Remove user from group
-		if err := db.Model(&targetUser).Association("Groups").Delete(&group); err != nil {
+		// Remove user from group, along with any shift schedule they set for
+		// it - otherwise the old schedule would silently reappear if they
+		// rejoin the group later.
+		err = db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(&targetUser).Association("Groups").Delete(&group); err != nil {
+				return err
+			}
+			return tx.Where("user_id = ? AND group_id = ?", targetUserID, groupID).Delete(&models.ShiftSlot{}).Error
+		})
+		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove user from group"})
 			return
 		}

--- a/internal/handlers/group_test.go
+++ b/internal/handlers/group_test.go
@@ -29,7 +29,7 @@ func setupGroupTestDB(t *testing.T) *gorm.DB {
 	}
 
 	// Run migrations
-	err = db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{})
+	err = db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}, &models.ShiftSlot{})
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)
 	}
@@ -814,6 +814,27 @@ func TestRemoveUserFromGroup(t *testing.T) {
 						t.Error("User was not removed from group")
 						break
 					}
+				}
+			},
+		},
+		{
+			name: "shift slots for the group are deleted along with membership",
+			setupFunc: func(db *gorm.DB) (uint, uint) {
+				user := createGroupTestUser(t, db, "regularuser", "user@example.com", false)
+				group := createTestGroup(t, db, "Test Group", "Description")
+				db.Model(&user).Association("Groups").Append(group)
+				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
+				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 3, Hour: 10})
+				return user.ID, group.ID
+			},
+			expectedStatus: http.StatusOK,
+			checkFunc: func(t *testing.T, db *gorm.DB, userID, groupID uint) {
+				var remaining []models.ShiftSlot
+				if err := db.Where("user_id = ? AND group_id = ?", userID, groupID).Find(&remaining).Error; err != nil {
+					t.Fatalf("Failed to query remaining shift slots: %v", err)
+				}
+				if len(remaining) != 0 {
+					t.Errorf("Expected all ShiftSlot rows for the removed user to be deleted, found %d", len(remaining))
 				}
 			},
 		},

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -1,0 +1,1 @@
+package handlers

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -158,3 +158,97 @@ func UpdateMySchedule(db *gorm.DB) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
 	}
 }
+
+// GetMemberSchedule returns a specific group member's weekly shift slots.
+// Requires group admin or site admin access. Returns 404 if the target user
+// is not a member of the group.
+func GetMemberSchedule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		targetUserID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+			return
+		}
+
+		var membership models.UserGroup
+		if err := db.Where("user_id = ? AND group_id = ?", targetUserID, groupIDParam).First(&membership).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "User is not a member of this group"})
+			return
+		}
+
+		var slots []models.ShiftSlot
+		if err := db.Where("user_id = ? AND group_id = ?", targetUserID, groupIDParam).
+			Order("day_of_week, hour").Find(&slots).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch schedule"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
+	}
+}
+
+// UpdateMemberSchedule replaces a specific group member's weekly shift
+// slots. Requires group admin or site admin access. Returns 404 if the
+// target user is not a member of the group.
+func UpdateMemberSchedule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		targetUserID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+			return
+		}
+
+		var membership models.UserGroup
+		if err := db.Where("user_id = ? AND group_id = ?", targetUserID, groupIDParam).First(&membership).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "User is not a member of this group"})
+			return
+		}
+
+		groupIDUint, err := strconv.ParseUint(groupIDParam, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+			return
+		}
+
+		var req updateScheduleRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			return
+		}
+
+		if err := validateScheduleSlots(req.Slots); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		slots, err := replaceGroupScheduleForUser(db, uint(targetUserID), uint(groupIDUint), req.Slots)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update schedule"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
+	}
+}

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -29,6 +29,24 @@ type scheduleSlotResponse struct {
 	Hour      int `json:"hour"`
 }
 
+// requireSchedulingEnabled loads the group's SchedulingEnabled flag and
+// writes a 404 response if the feature is off, mirroring the HasProtocols
+// gate in protocol.go/script.go. Returns false if the response was already
+// written (either because scheduling is disabled or the group lookup
+// failed) — callers should return immediately in that case.
+func requireSchedulingEnabled(c *gin.Context, db *gorm.DB, groupID string) bool {
+	var group models.Group
+	if err := db.Select("scheduling_enabled").First(&group, groupID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+		return false
+	}
+	if !group.SchedulingEnabled {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Scheduling is not enabled for this group"})
+		return false
+	}
+	return true
+}
+
 func toScheduleSlotResponses(slots []models.ShiftSlot) []scheduleSlotResponse {
 	out := make([]scheduleSlotResponse, 0, len(slots))
 	for _, s := range slots {
@@ -94,6 +112,10 @@ func GetMySchedule(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
 		userIDUint, ok := middleware.GetUserID(c)
 		if !ok {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
@@ -123,6 +145,10 @@ func UpdateMySchedule(db *gorm.DB) gin.HandlerFunc {
 
 		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
 			return
 		}
 
@@ -159,6 +185,47 @@ func UpdateMySchedule(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
+// updateSchedulingRequest is the body of PATCH .../scheduling.
+type updateSchedulingRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// UpdateGroupScheduling turns the shift-scheduling feature on or off for a
+// group. Requires group admin or site admin access.
+func UpdateGroupScheduling(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		var req updateSchedulingRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			return
+		}
+
+		var group models.Group
+		if err := db.First(&group, groupIDParam).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+			return
+		}
+
+		if err := db.Model(&group).Update("scheduling_enabled", req.Enabled).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update group"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"scheduling_enabled": req.Enabled})
+	}
+}
+
 // GetMemberSchedule returns a specific group member's weekly shift slots.
 // Requires group admin or site admin access. Returns 404 if the target user
 // is not a member of the group.
@@ -172,6 +239,10 @@ func GetMemberSchedule(db *gorm.DB) gin.HandlerFunc {
 
 		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
 			return
 		}
 
@@ -211,6 +282,10 @@ func UpdateMemberSchedule(db *gorm.DB) gin.HandlerFunc {
 
 		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
 			return
 		}
 

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -1,1 +1,160 @@
 package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
+)
+
+// scheduleSlotInput is one 1-hour slot in an incoming schedule-update request.
+type scheduleSlotInput struct {
+	DayOfWeek int `json:"day_of_week"`
+	Hour      int `json:"hour"`
+}
+
+// updateScheduleRequest is the body of PUT .../schedule/me and .../schedule/:userId.
+// The full slot set replaces whatever was previously stored.
+type updateScheduleRequest struct {
+	Slots []scheduleSlotInput `json:"slots"`
+}
+
+// scheduleSlotResponse is one 1-hour slot in a schedule GET/PUT response.
+type scheduleSlotResponse struct {
+	DayOfWeek int `json:"day_of_week"`
+	Hour      int `json:"hour"`
+}
+
+func toScheduleSlotResponses(slots []models.ShiftSlot) []scheduleSlotResponse {
+	out := make([]scheduleSlotResponse, 0, len(slots))
+	for _, s := range slots {
+		out = append(out, scheduleSlotResponse{DayOfWeek: s.DayOfWeek, Hour: s.Hour})
+	}
+	return out
+}
+
+// validateScheduleSlots checks each slot's day/hour range (day_of_week 0-6,
+// hour 8-17) and rejects duplicate (day_of_week, hour) pairs within the
+// payload.
+func validateScheduleSlots(slots []scheduleSlotInput) error {
+	seen := make(map[[2]int]bool, len(slots))
+	for _, s := range slots {
+		if s.DayOfWeek < 0 || s.DayOfWeek > 6 {
+			return fmt.Errorf("day_of_week must be between 0 and 6, got %d", s.DayOfWeek)
+		}
+		if s.Hour < 8 || s.Hour > 17 {
+			return fmt.Errorf("hour must be between 8 and 17, got %d", s.Hour)
+		}
+		key := [2]int{s.DayOfWeek, s.Hour}
+		if seen[key] {
+			return fmt.Errorf("duplicate slot for day_of_week %d, hour %d", s.DayOfWeek, s.Hour)
+		}
+		seen[key] = true
+	}
+	return nil
+}
+
+// replaceGroupScheduleForUser deletes all existing ShiftSlot rows for the
+// given (userID, groupID) pair and inserts the provided slots in a single
+// transaction, so a schedule update is all-or-nothing.
+func replaceGroupScheduleForUser(db *gorm.DB, userID, groupID uint, slots []scheduleSlotInput) ([]models.ShiftSlot, error) {
+	var result []models.ShiftSlot
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ? AND group_id = ?", userID, groupID).Delete(&models.ShiftSlot{}).Error; err != nil {
+			return err
+		}
+		for _, s := range slots {
+			slot := models.ShiftSlot{UserID: userID, GroupID: groupID, DayOfWeek: s.DayOfWeek, Hour: s.Hour}
+			if err := tx.Create(&slot).Error; err != nil {
+				return err
+			}
+			result = append(result, slot)
+		}
+		return nil
+	})
+	return result, err
+}
+
+// GetMySchedule returns the caller's weekly shift slots for the given group.
+// Requires group membership (or site admin).
+func GetMySchedule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		userIDUint, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		var slots []models.ShiftSlot
+		if err := db.Where("user_id = ? AND group_id = ?", userIDUint, groupIDParam).
+			Order("day_of_week, hour").Find(&slots).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch schedule"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
+	}
+}
+
+// UpdateMySchedule replaces the caller's weekly shift slots for the given
+// group. Requires group membership (or site admin).
+func UpdateMySchedule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+
+		userIDUint, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		groupIDUint, err := strconv.ParseUint(groupIDParam, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+			return
+		}
+
+		var req updateScheduleRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			return
+		}
+
+		if err := validateScheduleSlots(req.Slots); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		slots, err := replaceGroupScheduleForUser(db, userIDUint, uint(groupIDUint), req.Slots)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update schedule"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
+	}
+}

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -185,9 +185,11 @@ func UpdateMySchedule(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
-// updateSchedulingRequest is the body of PATCH .../scheduling.
+// updateSchedulingRequest is the body of PATCH .../scheduling. Enabled is a
+// pointer so an omitted field is rejected rather than silently defaulting
+// to false (Go's zero value for bool) and disabling the feature.
 type updateSchedulingRequest struct {
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 // UpdateGroupScheduling turns the shift-scheduling feature on or off for a
@@ -211,18 +213,23 @@ func UpdateGroupScheduling(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		if req.Enabled == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "enabled is required"})
+			return
+		}
+
 		var group models.Group
 		if err := db.First(&group, groupIDParam).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
 			return
 		}
 
-		if err := db.Model(&group).Update("scheduling_enabled", req.Enabled).Error; err != nil {
+		if err := db.Model(&group).Update("scheduling_enabled", *req.Enabled).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update group"})
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"scheduling_enabled": req.Enabled})
+		c.JSON(http.StatusOK, gin.H{"scheduling_enabled": *req.Enabled})
 	}
 }
 

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+)
+
+// TestShiftSlotUniqueConstraint verifies the model's composite unique index
+// rejects a duplicate (user_id, group_id, day_of_week, hour) row, and that a
+// distinct slot (different hour) for the same user/group succeeds.
+func TestShiftSlotUniqueConstraint(t *testing.T) {
+	db := SetupTestDB(t)
+	user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+	group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+
+	first := models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9}
+	if err := db.Create(&first).Error; err != nil {
+		t.Fatalf("expected first slot to be created, got error: %v", err)
+	}
+
+	duplicate := models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9}
+	if err := db.Create(&duplicate).Error; err == nil {
+		t.Fatal("expected duplicate (user_id, group_id, day_of_week, hour) to be rejected, got no error")
+	}
+
+	distinctHour := models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10}
+	if err := db.Create(&distinctHour).Error; err != nil {
+		t.Fatalf("expected a slot with a different hour to be created, got error: %v", err)
+	}
+}

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -1,9 +1,17 @@
 package handlers
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
 )
 
 // TestShiftSlotUniqueConstraint verifies the model's composite unique index
@@ -27,5 +35,217 @@ func TestShiftSlotUniqueConstraint(t *testing.T) {
 	distinctHour := models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10}
 	if err := db.Create(&distinctHour).Error; err != nil {
 		t.Fatalf("expected a slot with a different hour to be created, got error: %v", err)
+	}
+}
+
+func TestGetMySchedule(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*gorm.DB) (*models.User, *models.Group)
+		isAdmin        bool
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			name: "member with no slots yet gets an empty list",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				return user, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusOK,
+			expectedCount:  0,
+		},
+		{
+			name: "member sees their own slots for this group only",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				otherGroup := CreateTestGroup(t, db, "Cats", "Cat volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				AddUserToGroupWithAdmin(t, db, user.ID, otherGroup.ID, false)
+				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
+				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: otherGroup.ID, DayOfWeek: 3, Hour: 10})
+				return user, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusOK,
+			expectedCount:  1,
+		},
+		{
+			name: "non-member is denied",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				return user, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name: "site admin (non-member) is allowed",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				return admin, group
+			},
+			isAdmin:        true,
+			expectedStatus: http.StatusOK,
+			expectedCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			user, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(user.ID, tt.isAdmin)
+			c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+			c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID), nil)
+
+			handler := GetMySchedule(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedStatus == http.StatusOK {
+				var resp struct {
+					Slots []scheduleSlotResponse `json:"slots"`
+				}
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if len(resp.Slots) != tt.expectedCount {
+					t.Errorf("expected %d slots, got %d", tt.expectedCount, len(resp.Slots))
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateMySchedule(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*gorm.DB) (*models.User, *models.Group)
+		isAdmin        bool
+		body           string
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name: "member can set their own schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":2,"hour":9},{"day_of_week":2,"hour":10}]}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "replace-all semantics: a second update replaces the first set",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 0, Hour: 8})
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":5,"hour":16}]}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "invalid day_of_week is rejected",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":7,"hour":9}]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "day_of_week",
+		},
+		{
+			name: "invalid hour is rejected",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":2,"hour":18}]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "hour",
+		},
+		{
+			name: "duplicate slot in payload is rejected",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":2,"hour":9},{"day_of_week":2,"hour":9}]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "duplicate",
+		},
+		{
+			name: "non-member is denied",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				return user, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[]}`,
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			user, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(user.ID, tt.isAdmin)
+			c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID), bytes.NewBufferString(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			handler := UpdateMySchedule(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedError != "" && !strings.Contains(w.Body.String(), tt.expectedError) {
+				t.Errorf("expected error containing %q, got %q", tt.expectedError, w.Body.String())
+			}
+			if tt.name == "replace-all semantics: a second update replaces the first set" {
+				var count int64
+				db.Model(&models.ShiftSlot{}).Where("user_id = ? AND group_id = ?", user.ID, group.ID).Count(&count)
+				if count != 1 {
+					t.Errorf("expected exactly 1 slot after replace, got %d", count)
+				}
+				var slot models.ShiftSlot
+				if err := db.Where("user_id = ? AND group_id = ?", user.ID, group.ID).First(&slot).Error; err != nil {
+					t.Fatalf("failed to load remaining slot: %v", err)
+				}
+				if slot.DayOfWeek != 5 || slot.Hour != 16 {
+					t.Errorf("expected remaining slot to be day 5 hour 16, got day %d hour %d", slot.DayOfWeek, slot.Hour)
+				}
+			}
+		})
 	}
 }

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -14,6 +14,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// createSchedulingEnabledGroup creates a test group with the scheduling
+// feature turned on, since SchedulingEnabled defaults to false and most
+// schedule-endpoint tests are exercising auth/validation behavior, not the
+// feature-gate itself.
+func createSchedulingEnabledGroup(t *testing.T, db *gorm.DB, name, description string) *models.Group {
+	group := CreateTestGroup(t, db, name, description)
+	if err := db.Model(group).Update("scheduling_enabled", true).Error; err != nil {
+		t.Fatalf("failed to enable scheduling for test group: %v", err)
+	}
+	return group
+}
+
 // TestShiftSlotUniqueConstraint verifies the model's composite unique index
 // rejects a duplicate (user_id, group_id, day_of_week, hour) row, and that a
 // distinct slot (different hour) for the same user/group succeeds.
@@ -50,7 +62,7 @@ func TestGetMySchedule(t *testing.T) {
 			name: "member with no slots yet gets an empty list",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				return user, group
 			},
@@ -62,8 +74,8 @@ func TestGetMySchedule(t *testing.T) {
 			name: "member sees their own slots for this group only",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
-				otherGroup := CreateTestGroup(t, db, "Cats", "Cat volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				otherGroup := createSchedulingEnabledGroup(t, db, "Cats", "Cat volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				AddUserToGroupWithAdmin(t, db, user.ID, otherGroup.ID, false)
 				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
@@ -78,7 +90,7 @@ func TestGetMySchedule(t *testing.T) {
 			name: "non-member is denied",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				return user, group
 			},
 			isAdmin:        false,
@@ -88,7 +100,7 @@ func TestGetMySchedule(t *testing.T) {
 			name: "site admin (non-member) is allowed",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				return admin, group
 			},
 			isAdmin:        true,
@@ -140,7 +152,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "member can set their own schedule",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				return user, group
 			},
@@ -152,7 +164,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "replace-all semantics: a second update replaces the first set",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 0, Hour: 8})
 				return user, group
@@ -165,7 +177,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "invalid day_of_week is rejected",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				return user, group
 			},
@@ -178,7 +190,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "invalid hour is rejected",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				return user, group
 			},
@@ -191,7 +203,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "duplicate slot in payload is rejected",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
 				return user, group
 			},
@@ -204,7 +216,7 @@ func TestUpdateMySchedule(t *testing.T) {
 			name: "non-member is denied",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				return user, group
 			},
 			isAdmin:        false,
@@ -263,7 +275,7 @@ func TestGetMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				db.Create(&models.ShiftSlot{UserID: member.ID, GroupID: group.ID, DayOfWeek: 1, Hour: 8})
@@ -278,7 +290,7 @@ func TestGetMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				siteAdmin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				return siteAdmin, member, group
 			},
@@ -291,7 +303,7 @@ func TestGetMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				return regular, member, group
@@ -304,7 +316,7 @@ func TestGetMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
 				nonMember := CreateTestUser(t, db, "outsider", "outsider@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
 				return groupAdmin, nonMember, group
 			},
@@ -360,7 +372,7 @@ func TestUpdateMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				return groupAdmin, member, group
@@ -374,7 +386,7 @@ func TestUpdateMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				return regular, member, group
@@ -389,7 +401,7 @@ func TestUpdateMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
 				nonMember := CreateTestUser(t, db, "outsider", "outsider@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
 				return groupAdmin, nonMember, group
 			},
@@ -402,7 +414,7 @@ func TestUpdateMemberSchedule(t *testing.T) {
 			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
 				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
 				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
-				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
 				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
 				return groupAdmin, member, group
@@ -435,6 +447,209 @@ func TestUpdateMemberSchedule(t *testing.T) {
 			}
 			if tt.expectedError != "" && !strings.Contains(w.Body.String(), tt.expectedError) {
 				t.Errorf("expected error containing %q, got %q", tt.expectedError, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestScheduleRequiresSchedulingEnabled verifies all four schedule endpoints
+// return 404 for a group where SchedulingEnabled is false (the default),
+// even for a site admin — this is a feature gate, not an authorization gate.
+func TestScheduleRequiresSchedulingEnabled(t *testing.T) {
+	t.Run("GetMySchedule returns 404 when scheduling is disabled for the group", func(t *testing.T) {
+		db := SetupTestDB(t)
+		user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+		AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+		c, w := setupGroupTestContext(user.ID, false)
+		c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+		c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID), nil)
+
+		GetMySchedule(db)(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "Scheduling") {
+			t.Errorf("expected error message to mention scheduling, got %q", w.Body.String())
+		}
+	})
+
+	t.Run("UpdateMySchedule returns 404 when scheduling is disabled for the group", func(t *testing.T) {
+		db := SetupTestDB(t)
+		user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+		AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+		c, w := setupGroupTestContext(user.ID, false)
+		c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+		c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID), bytes.NewBufferString(`{"slots":[]}`))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		UpdateMySchedule(db)(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("GetMemberSchedule returns 404 when scheduling is disabled for the group", func(t *testing.T) {
+		db := SetupTestDB(t)
+		groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+		member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+		AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+		AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+
+		c, w := setupGroupTestContext(groupAdmin.ID, false)
+		c.Params = gin.Params{
+			{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+			{Key: "userId", Value: fmt.Sprintf("%d", member.ID)},
+		}
+		c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, member.ID), nil)
+
+		GetMemberSchedule(db)(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("UpdateMemberSchedule returns 404 when scheduling is disabled for the group", func(t *testing.T) {
+		db := SetupTestDB(t)
+		groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+		member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+		AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+		AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+
+		c, w := setupGroupTestContext(groupAdmin.ID, false)
+		c.Params = gin.Params{
+			{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+			{Key: "userId", Value: fmt.Sprintf("%d", member.ID)},
+		}
+		c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, member.ID), bytes.NewBufferString(`{"slots":[]}`))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		UpdateMemberSchedule(db)(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("site admin still gets 404 when scheduling is disabled (feature gate applies to everyone)", func(t *testing.T) {
+		db := SetupTestDB(t)
+		siteAdmin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+
+		c, w := setupGroupTestContext(siteAdmin.ID, true)
+		c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+		c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID), nil)
+
+		GetMySchedule(db)(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestUpdateGroupScheduling(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupFunc       func(*gorm.DB) (*models.User, *models.Group)
+		isAdmin         bool
+		body            string
+		expectedStatus  int
+		expectedEnabled bool
+	}{
+		{
+			name: "group admin can enable scheduling",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, group
+			},
+			isAdmin:         false,
+			body:            `{"enabled":true}`,
+			expectedStatus:  http.StatusOK,
+			expectedEnabled: true,
+		},
+		{
+			name: "group admin can disable scheduling",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, group
+			},
+			isAdmin:         false,
+			body:            `{"enabled":false}`,
+			expectedStatus:  http.StatusOK,
+			expectedEnabled: false,
+		},
+		{
+			name: "site admin can enable scheduling for a group they're not a member of",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				siteAdmin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				return siteAdmin, group
+			},
+			isAdmin:         true,
+			body:            `{"enabled":true}`,
+			expectedStatus:  http.StatusOK,
+			expectedEnabled: true,
+		},
+		{
+			name: "regular member cannot toggle scheduling",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
+				return regular, group
+			},
+			isAdmin:        false,
+			body:           `{"enabled":true}`,
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			user, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(user.ID, tt.isAdmin)
+			c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+			c.Request = httptest.NewRequest("PATCH", fmt.Sprintf("/api/groups/%d/scheduling", group.ID), bytes.NewBufferString(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			handler := UpdateGroupScheduling(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedStatus == http.StatusOK {
+				var resp struct {
+					SchedulingEnabled bool `json:"scheduling_enabled"`
+				}
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if resp.SchedulingEnabled != tt.expectedEnabled {
+					t.Errorf("expected scheduling_enabled=%v, got %v", tt.expectedEnabled, resp.SchedulingEnabled)
+				}
+				var reloaded models.Group
+				if err := db.First(&reloaded, group.ID).Error; err != nil {
+					t.Fatalf("failed to reload group: %v", err)
+				}
+				if reloaded.SchedulingEnabled != tt.expectedEnabled {
+					t.Errorf("expected persisted scheduling_enabled=%v, got %v", tt.expectedEnabled, reloaded.SchedulingEnabled)
+				}
 			}
 		})
 	}

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -564,6 +564,7 @@ func TestUpdateGroupScheduling(t *testing.T) {
 		body            string
 		expectedStatus  int
 		expectedEnabled bool
+		expectedError   string
 	}{
 		{
 			name: "group admin can enable scheduling",
@@ -615,6 +616,19 @@ func TestUpdateGroupScheduling(t *testing.T) {
 			body:           `{"enabled":true}`,
 			expectedStatus: http.StatusForbidden,
 		},
+		{
+			name: "omitted enabled field is rejected rather than silently disabling",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, group
+			},
+			isAdmin:        false,
+			body:           `{}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "enabled",
+		},
 	}
 
 	for _, tt := range tests {
@@ -633,6 +647,9 @@ func TestUpdateGroupScheduling(t *testing.T) {
 			if w.Code != tt.expectedStatus {
 				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
 			}
+			if tt.expectedError != "" && !strings.Contains(w.Body.String(), tt.expectedError) {
+				t.Errorf("expected error containing %q, got %q", tt.expectedError, w.Body.String())
+			}
 			if tt.expectedStatus == http.StatusOK {
 				var resp struct {
 					SchedulingEnabled bool `json:"scheduling_enabled"`
@@ -649,6 +666,15 @@ func TestUpdateGroupScheduling(t *testing.T) {
 				}
 				if reloaded.SchedulingEnabled != tt.expectedEnabled {
 					t.Errorf("expected persisted scheduling_enabled=%v, got %v", tt.expectedEnabled, reloaded.SchedulingEnabled)
+				}
+			}
+			if tt.name == "omitted enabled field is rejected rather than silently disabling" {
+				var reloaded models.Group
+				if err := db.First(&reloaded, group.ID).Error; err != nil {
+					t.Fatalf("failed to reload group: %v", err)
+				}
+				if !reloaded.SchedulingEnabled {
+					t.Error("expected scheduling_enabled to remain true (unchanged) after a rejected request, got false")
 				}
 			}
 		})

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -50,6 +50,41 @@ func TestShiftSlotUniqueConstraint(t *testing.T) {
 	}
 }
 
+// TestRemoveMemberFromGroupDeletesShiftSlots verifies that removing a member
+// from a group also deletes their ShiftSlot rows for that group, so a stale
+// schedule doesn't silently resurrect if they rejoin later.
+func TestRemoveMemberFromGroupDeletesShiftSlots(t *testing.T) {
+	db := SetupTestDB(t)
+	admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+	member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+	group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+	db.Create(&models.ShiftSlot{UserID: member.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
+	db.Create(&models.ShiftSlot{UserID: member.ID, GroupID: group.ID, DayOfWeek: 3, Hour: 10})
+
+	c, w := setupGroupTestContext(admin.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "userId", Value: fmt.Sprintf("%d", member.ID)},
+	}
+	c.Request = httptest.NewRequest("DELETE", fmt.Sprintf("/api/groups/%d/members/%d", group.ID, member.ID), nil)
+
+	handler := RemoveMemberFromGroup(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var remaining []models.ShiftSlot
+	if err := db.Where("user_id = ? AND group_id = ?", member.ID, group.ID).Find(&remaining).Error; err != nil {
+		t.Fatalf("failed to query remaining slots: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("expected all ShiftSlot rows for the removed member to be deleted, found %d", len(remaining))
+	}
+}
+
 func TestGetMySchedule(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -249,3 +249,193 @@ func TestUpdateMySchedule(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMemberSchedule(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*gorm.DB) (contextUser, targetUser *models.User, group *models.Group)
+		isAdmin        bool
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			name: "group admin can view another member's schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				db.Create(&models.ShiftSlot{UserID: member.ID, GroupID: group.ID, DayOfWeek: 1, Hour: 8})
+				return groupAdmin, member, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusOK,
+			expectedCount:  1,
+		},
+		{
+			name: "site admin can view any member's schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				siteAdmin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				return siteAdmin, member, group
+			},
+			isAdmin:        true,
+			expectedStatus: http.StatusOK,
+			expectedCount:  0,
+		},
+		{
+			name: "regular member is denied viewing another member's schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				return regular, member, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name: "group admin viewing a non-member's schedule gets 404",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				nonMember := CreateTestUser(t, db, "outsider", "outsider@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, nonMember, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			contextUser, targetUser, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(contextUser.ID, tt.isAdmin)
+			c.Params = gin.Params{
+				{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+				{Key: "userId", Value: fmt.Sprintf("%d", targetUser.ID)},
+			}
+			c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, targetUser.ID), nil)
+
+			handler := GetMemberSchedule(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedStatus == http.StatusOK {
+				var resp struct {
+					Slots []scheduleSlotResponse `json:"slots"`
+				}
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if len(resp.Slots) != tt.expectedCount {
+					t.Errorf("expected %d slots, got %d", tt.expectedCount, len(resp.Slots))
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateMemberSchedule(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*gorm.DB) (contextUser, targetUser *models.User, group *models.Group)
+		isAdmin        bool
+		body           string
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name: "group admin can set another member's schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				return groupAdmin, member, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":4,"hour":12}]}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "regular member is denied editing another member's schedule",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				return regular, member, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[]}`,
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "Admin access required",
+		},
+		{
+			name: "group admin editing a non-member gets 404",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				nonMember := CreateTestUser(t, db, "outsider", "outsider@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, nonMember, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[]}`,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "invalid slot payload is rejected",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				member := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+				return groupAdmin, member, group
+			},
+			isAdmin:        false,
+			body:           `{"slots":[{"day_of_week":2,"hour":25}]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "hour",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			contextUser, targetUser, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(contextUser.ID, tt.isAdmin)
+			c.Params = gin.Params{
+				{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+				{Key: "userId", Value: fmt.Sprintf("%d", targetUser.ID)},
+			}
+			c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, targetUser.ID), bytes.NewBufferString(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			handler := UpdateMemberSchedule(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedError != "" && !strings.Contains(w.Body.String(), tt.expectedError) {
+				t.Errorf("expected error containing %q, got %q", tt.expectedError, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -54,6 +54,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&models.AnimalTag{},
 		&models.AnimalNameHistory{},
 		&models.APIToken{},
+		&models.ShiftSlot{},
 	)
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -65,23 +65,24 @@ type APIToken struct {
 
 // Group represents a volunteer group (dogs, cats, modsquad, etc.)
 type Group struct {
-	ID             uint            `gorm:"primaryKey" json:"id"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
-	DeletedAt      gorm.DeletedAt  `gorm:"index" json:"-"`
-	Name           string          `gorm:"uniqueIndex;not null" json:"name"`
-	Description    string          `json:"description"`
-	ImageURL       string          `json:"image_url"`
-	HeroImageURL   string          `json:"hero_image_url"`
-	HasProtocols   bool            `gorm:"column:has_protocols;default:false" json:"has_protocols"`     // Enable protocols feature for this group
-	GroupMeBotID   string          `gorm:"column:groupme_bot_id" json:"-"`                              // GroupMe Bot ID — omitted from API responses; exposed via adminGroupResponse only
-	GroupMeEnabled bool            `gorm:"column:groupme_enabled;default:false" json:"groupme_enabled"` // Enable GroupMe integration for this group
-	Users          []User          `gorm:"many2many:user_groups;" json:"users,omitempty"`
-	Animals        []Animal        `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
-	Updates        []Update        `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
-	Protocols      []Protocol      `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
-	Scripts        []Script        `gorm:"foreignKey:GroupID" json:"scripts,omitempty"`
-	Documents      []GroupDocument `gorm:"foreignKey:GroupID" json:"documents,omitempty"`
+	ID                uint            `gorm:"primaryKey" json:"id"`
+	CreatedAt         time.Time       `json:"created_at"`
+	UpdatedAt         time.Time       `json:"updated_at"`
+	DeletedAt         gorm.DeletedAt  `gorm:"index" json:"-"`
+	Name              string          `gorm:"uniqueIndex;not null" json:"name"`
+	Description       string          `json:"description"`
+	ImageURL          string          `json:"image_url"`
+	HeroImageURL      string          `json:"hero_image_url"`
+	HasProtocols      bool            `gorm:"column:has_protocols;default:false" json:"has_protocols"`           // Enable protocols feature for this group
+	SchedulingEnabled bool            `gorm:"column:scheduling_enabled;default:false" json:"scheduling_enabled"` // Enable volunteer shift scheduling feature for this group
+	GroupMeBotID      string          `gorm:"column:groupme_bot_id" json:"-"`                                    // GroupMe Bot ID — omitted from API responses; exposed via adminGroupResponse only
+	GroupMeEnabled    bool            `gorm:"column:groupme_enabled;default:false" json:"groupme_enabled"`       // Enable GroupMe integration for this group
+	Users             []User          `gorm:"many2many:user_groups;" json:"users,omitempty"`
+	Animals           []Animal        `gorm:"foreignKey:GroupID" json:"animals,omitempty"`
+	Updates           []Update        `gorm:"foreignKey:GroupID" json:"updates,omitempty"`
+	Protocols         []Protocol      `gorm:"foreignKey:GroupID" json:"protocols,omitempty"`
+	Scripts           []Script        `gorm:"foreignKey:GroupID" json:"scripts,omitempty"`
+	Documents         []GroupDocument `gorm:"foreignKey:GroupID" json:"documents,omitempty"`
 }
 
 // Animal represents an animal in a group

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -512,3 +512,19 @@ type UserGroup struct {
 	User         User      `gorm:"foreignKey:UserID" json:"user,omitempty"`
 	Group        Group     `gorm:"foreignKey:GroupID" json:"group,omitempty"`
 }
+
+// ShiftSlot represents a single 1-hour block of a volunteer's recurring
+// weekly shift schedule within a specific group. Rows are sparse — a row
+// only exists for an hour the volunteer is signed up for. day_of_week is
+// 0=Sunday..6=Saturday; hour is the slot's start hour, 8..17 (8am-6pm).
+type ShiftSlot struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	UserID    uint      `gorm:"not null;uniqueIndex:idx_shift_slot_unique;index:idx_shift_slot_user" json:"user_id"`
+	GroupID   uint      `gorm:"not null;uniqueIndex:idx_shift_slot_unique;index:idx_shift_slot_group" json:"group_id"`
+	DayOfWeek int       `gorm:"not null;uniqueIndex:idx_shift_slot_unique" json:"day_of_week"`
+	Hour      int       `gorm:"not null;uniqueIndex:idx_shift_slot_unique" json:"hour"`
+	User      User      `gorm:"foreignKey:UserID" json:"-"`
+	Group     Group     `gorm:"foreignKey:GroupID" json:"-"`
+}


### PR DESCRIPTION
## Summary

Adds a weekly recurring shift-scheduling feature for volunteers, scoped per group, as the core version of the feature described in the linked planning discussion (coverage requests are an explicit stretch goal, not built here).

- **Weekly schedule per group**: Sun-Sat, 8am-6pm, 1-hour increments. A volunteer's schedule is a sparse set of `ShiftSlot` rows keyed by `(user_id, group_id, day_of_week, hour)` with a composite unique index. Editing is replace-all in a single transaction (no per-slot diffing).
- **Self-edit**: `GET/PUT /groups/:id/schedule/me` — a volunteer views/edits their own weekly schedule for a group they're a member of.
- **Admin-edit-all**: `GET/PUT /groups/:id/schedule/:userId` — a group admin (or site admin) views/edits any member's schedule for that group. Returns 404 if the target user isn't actually a member.
- **Per-group enable/disable toggle**: `Group.SchedulingEnabled` (default `false`) gates all four schedule endpoints — including for site admins, since it's a feature gate, not an authorization gate (mirrors the existing `Group.HasProtocols` pattern). `PATCH /groups/:id/scheduling` (group-admin gated) flips it; disabling never deletes existing `ShiftSlot` data.
- **Frontend**: a new "Schedule" tab inside `GroupPage.tsx` (gated on `group.scheduling_enabled` + membership, matching how Animals/Activity Feed are organized per-group — no new top-level route), an isolated `ScheduleTab` component (7x10 toggle grid + a volunteer picker for group admins), and an "Enable/Disable Scheduling" control in the existing group-admin Quick Actions bar.

## Review fixes

An independent subagent review (not self-review) of the full diff surfaced three lower-confidence items, all addressed:

- `ScheduleTab.tsx`'s schedule fetch now uses the same `AbortController` pattern `GroupPage.tsx` already uses for `loadAnimals`/`loadActivityFeed`, so a superseded (older) response can't overwrite fresher data.
- The scheduling-toggle endpoint's `enabled` field is now a `*bool`, so an omitted field is rejected with a 400 instead of silently binding to `false` and disabling the feature.
- The 404-on-disabled behavior for schedule endpoints (vs. the 400 used by some other feature-gated write paths) was reviewed and left as-is — it's intentional, matching the existing read-path `HasProtocols` convention.

## Test plan

- [x] Backend: TDD throughout — model/unique-index test, both endpoint families (self and admin), the scheduling-enabled gate (all 4 endpoints + site-admin-still-blocked), the toggle endpoint (group admin/site admin/regular-member-denied/omitted-field-rejected), validation (day/hour range, duplicate slots), replace-all semantics.
- [x] Frontend: `ScheduleTab` component tests (load/toggle/save, admin picker, stale-response race) and `GroupPage` tests (tab visibility gating, toggle control, admin-only visibility).
- [x] Verified end-to-end against a real local Postgres: migrations created the table/index/FKs correctly, exercised every endpoint and the full enable/disable/enable cycle via curl, and drove the toggle live in a browser (tab appears/disappears immediately, no console errors).
- [x] Full suites green: `go test ./...`, `npm run type-check` (`tsc -b`), and the frontend vitest suite — aside from two pre-existing failures unrelated to this branch (`TestCreateGroup/accepts_valid_GroupMe_bot_id`, `AnimalForm.test.tsx`), both present on `main` before this work started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)