### PR TITLE
Add group schedule overview (admin-only heatmap)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -449,6 +449,7 @@ func main() {
 			group.PATCH("/scheduling", handlers.UpdateGroupScheduling(db))
 			group.GET("/schedule/me", handlers.GetMySchedule(db))
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
+			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))
 			group.PUT("/schedule/:userId", handlers.UpdateMemberSchedule(db))
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -625,6 +625,23 @@ export interface ScheduleResponse {
   slots: ScheduleSlot[];
 }
 
+export interface ScheduleOverviewMember {
+  user_id: number;
+  username: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface ScheduleOverviewSlot {
+  day_of_week: number;
+  hour: number;
+  members: ScheduleOverviewMember[];
+}
+
+export interface ScheduleOverviewResponse {
+  slots: ScheduleOverviewSlot[];
+}
+
 export const scheduleApi = {
   getMine: (groupId: number, options?: { signal?: AbortSignal }) =>
     api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { signal: options?.signal }),
@@ -634,6 +651,8 @@ export const scheduleApi = {
     api.get<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { signal: options?.signal }),
   updateForMember: (groupId: number, userId: number, slots: ScheduleSlot[]) =>
     api.put<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { slots }),
+  getOverview: (groupId: number, options?: { signal?: AbortSignal }) =>
+    api.get<ScheduleOverviewResponse>(`/groups/${groupId}/schedule/overview`, { signal: options?.signal }),
 };
 
 // Animals API

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -47,6 +47,20 @@
   z-index: 10;
   min-width: 140px;
   max-width: 220px;
+  /* Caps the rendered height regardless of member-list length (unbounded -
+     up to one entry per group member) so ESTIMATED_POPOVER_HEIGHT in
+     ScheduleOverview.tsx's popoverPositionFor() can treat this value as a
+     guaranteed fact rather than a guess: without a cap, a slot with enough
+     available members renders taller than any fixed estimate, the flip
+     logic wrongly concludes there's room below, and the popover clips off
+     the viewport again. Long lists get an internal scrollbar instead of
+     growing the box. 220px comfortably shows ~6-7 names before scrolling
+     and matches the existing max-width for a consistent max footprint.
+     `* { box-sizing: border-box }` (index.css) is in effect globally, so
+     this 220px already includes the padding/border below - no extra
+     bookkeeping needed to keep ESTIMATED_POPOVER_HEIGHT in sync. */
+  max-height: 220px;
+  overflow-y: auto;
   background: var(--surface);
   border: 1px solid var(--neutral-300);
   border-radius: 6px;

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -1,10 +1,5 @@
 .schedule-overview {
   padding: 1rem 0;
-  overflow-x: auto;
-}
-
-.schedule-overview .schedule-grid {
-  overflow: visible;
 }
 
 .schedule-overview__cell-wrapper {
@@ -38,9 +33,16 @@
 }
 
 .schedule-overview__popover {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 50%;
+  /* top/left are set inline from the clicked cell's live bounding rect (see
+     ScheduleOverview.tsx) so the popover is positioned relative to the
+     viewport rather than any scrolling/overflow ancestor - this is what
+     lets it escape .schedule-grid's clipping (overflow-x: auto forces
+     overflow-y: auto per the CSS spec, making it a clipping ancestor for
+     position: absolute descendants). position: fixed is only taken out of
+     that flow when no ancestor sets transform/filter/perspective/
+     will-change; none of .schedule-overview, .schedule-grid, or
+     .schedule-overview__cell-wrapper do. */
+  position: fixed;
   transform: translateX(-50%);
   z-index: 10;
   min-width: 140px;

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -1,0 +1,59 @@
+.schedule-overview {
+  padding: 1rem 0;
+}
+
+.schedule-overview__cell-wrapper {
+  position: relative;
+}
+
+.schedule-grid__slot--tier-0 {
+  background: var(--surface);
+  border-color: var(--neutral-200);
+}
+
+.schedule-grid__slot--tier-1 {
+  background: color-mix(in srgb, var(--brand) 20%, var(--surface));
+}
+
+.schedule-grid__slot--tier-2 {
+  background: color-mix(in srgb, var(--brand) 45%, var(--surface));
+}
+
+.schedule-grid__slot--tier-3 {
+  background: color-mix(in srgb, var(--brand) 70%, var(--surface));
+}
+
+.schedule-grid__slot--tier-4 {
+  background: var(--brand);
+}
+
+.schedule-overview__popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  min-width: 140px;
+  max-width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--neutral-300);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  padding: 0.5rem 0.75rem;
+}
+
+.schedule-overview__popover ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.schedule-overview__popover li + li {
+  margin-top: 0.25rem;
+}
+
+[data-theme='dark'] .schedule-grid__slot--tier-0 {
+  border-color: var(--neutral-300);
+}

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -1,9 +1,19 @@
 .schedule-overview {
   padding: 1rem 0;
+  overflow-x: auto;
+}
+
+.schedule-overview .schedule-grid {
+  overflow: visible;
 }
 
 .schedule-overview__cell-wrapper {
   position: relative;
+  display: flex;
+}
+
+.schedule-overview__cell-wrapper .schedule-grid__slot {
+  flex: 1;
 }
 
 .schedule-grid__slot--tier-0 {

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -99,4 +99,29 @@ describe('ScheduleOverview', () => {
     fireEvent.mouseDown(document.body);
     await waitFor(() => expect(screen.queryByText('vol1')).not.toBeInTheDocument());
   });
+
+  it('renders every member in a long list even though the popover box is height-capped', async () => {
+    // jsdom doesn't compute layout, so this can't verify the CSS
+    // max-height/overflow-y clamp actually kicks in visually (that's
+    // covered by the Playwright verification instead) - but it does
+    // confirm the popover keeps rendering all members in the DOM (for
+    // scrolling to reveal) rather than e.g. truncating the list to fit.
+    const members = Array.from({ length: 20 }, (_, i) => ({
+      user_id: i + 1,
+      username: `vol${i + 1}`,
+      first_name: `Member`,
+      last_name: `${i + 1}`,
+    }));
+    mockOverview({
+      slots: [{ day_of_week: 2, hour: 9, members }],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={20} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*20 available/i });
+    fireEvent.click(cell);
+
+    expect(await screen.findByText('Member 1')).toBeInTheDocument();
+    expect(screen.getByText('Member 20')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(20);
+  });
 });

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ScheduleOverview from './ScheduleOverview';
+import { scheduleApi } from '../../api/client';
+import type { AxiosResponse } from 'axios';
+import type { ScheduleOverviewResponse } from '../../api/client';
+
+vi.mock('../../api/client', () => ({
+  scheduleApi: {
+    getOverview: vi.fn(),
+  },
+}));
+
+function mockOverview(data: ScheduleOverviewResponse) {
+  vi.mocked(scheduleApi.getOverview).mockResolvedValue({ data } as unknown as AxiosResponse<ScheduleOverviewResponse>);
+}
+
+describe('ScheduleOverview', () => {
+  beforeEach(() => {
+    mockOverview({ slots: [] });
+  });
+
+  it('loads the overview for the given group on mount', async () => {
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    await waitFor(() => expect(scheduleApi.getOverview).toHaveBeenCalledWith(7, expect.objectContaining({ signal: expect.any(AbortSignal) })));
+  });
+
+  it('renders a tier class proportional to how many members are available', async () => {
+    mockOverview({
+      slots: [
+        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }, { user_id: 2, username: 'vol2' }] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*2 available/i });
+    // 2 of 4 members = 50%, falls in the 26-50% tier.
+    expect(cell).toHaveClass('schedule-grid__slot--tier-2');
+  });
+
+  it('a cell with nobody available is not clickable and has the zero tier', async () => {
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    const cell = await screen.findByRole('cell', { name: 'Sun 8:00 AM, 0 available' });
+    expect(cell).toHaveClass('schedule-grid__slot--tier-0');
+    expect(cell.tagName).not.toBe('BUTTON');
+  });
+
+  it('clicking a non-empty cell opens a popover listing member names', async () => {
+    mockOverview({
+      slots: [
+        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1', first_name: 'Jane', last_name: 'Doe' }] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
+    fireEvent.click(cell);
+
+    expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+  });
+
+  it('falls back to username when first/last name are blank', async () => {
+    mockOverview({
+      slots: [{ day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }] }],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
+    fireEvent.click(cell);
+
+    expect(await screen.findByText('vol1')).toBeInTheDocument();
+  });
+
+  it('clicking outside the popover closes it', async () => {
+    mockOverview({
+      slots: [{ day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }] }],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
+    fireEvent.click(cell);
+    expect(await screen.findByText('vol1')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByText('vol1')).not.toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -71,6 +71,21 @@ describe('ScheduleOverview', () => {
     expect(await screen.findByText('vol1')).toBeInTheDocument();
   });
 
+  it('falls back to a data-derived denominator when totalMembers is 0 but slots have members', async () => {
+    mockOverview({
+      slots: [
+        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }, { user_id: 2, username: 'vol2' }] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={0} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*2 available/i });
+    // totalMembers is 0 (unreliable), so the fallback denominator is derived
+    // from the fetched data: max slot size of 2, so 2/2 = 100% = tier-4.
+    expect(cell).not.toHaveClass('schedule-grid__slot--tier-0');
+    expect(cell).toHaveClass('schedule-grid__slot--tier-4');
+  });
+
   it('clicking outside the popover closes it', async () => {
     mockOverview({
       slots: [{ day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }] }],

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -34,16 +34,20 @@ const VIEWPORT_MARGIN = 8;
 const POPOVER_WIDTH = 220;
 const POPOVER_HALF_WIDTH = POPOVER_WIDTH / 2;
 
-// The popover's actual height depends on how many members are in the slot
-// (unbounded list length), which we don't know until it renders. Rather
-// than measure post-render (extra state + effect for a one-frame
-// correction), we use a conservative fixed estimate for the flip decision:
-// enough for a handful of names (padding 2x8px + border 2x1px + ~6 lines at
-// ~16px + 5 inter-item gaps at 4px, from the `.schedule-overview__popover`
-// rule in ScheduleOverview.css, is ~120px). This won't be pixel-perfect for
-// slots with many available members, but it reliably keeps the popover
-// on-screen, which is what this fix requires.
-const ESTIMATED_POPOVER_HEIGHT = 120;
+// The popover's member list is unbounded in length, but
+// `.schedule-overview__popover` in ScheduleOverview.css caps the rendered
+// box at `max-height: 220px` (with `overflow-y: auto` so long lists scroll
+// internally instead of growing the box). Because of that cap, this is no
+// longer an estimate of a variable height - it's the guaranteed maximum,
+// so the flip decision below is correct for every member count, not just
+// typical ones.
+//
+// MUST match `.schedule-overview__popover`'s `max-height` in
+// ScheduleOverview.css exactly. `* { box-sizing: border-box }` (index.css)
+// applies globally, so that 220px already includes the popover's own
+// padding/border - nothing to add here. Nothing enforces this link
+// automatically; if the CSS value changes, update this constant too.
+const ESTIMATED_POPOVER_HEIGHT = 220;
 
 // Computes a fixed-position anchor point for the popover, derived from the
 // clicked cell's live bounding rect (so it's correct regardless of scroll

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -17,6 +17,32 @@ function memberDisplayName(member: ScheduleOverviewMember): string {
   return [member.first_name, member.last_name].filter(Boolean).join(' ') || member.username;
 }
 
+interface PopoverPosition {
+  top: number;
+  left: number;
+}
+
+// The popover's own rendered width isn't known before it renders (it's
+// content-sized up to the 220px max-width in ScheduleOverview.css), so we
+// don't try to compute an exact clamp for its edges. Instead we clamp the
+// raw anchor point itself to a small margin from the viewport edges before
+// the CSS `transform: translateX(-50%)` centers the popover under it. This
+// isn't pixel-perfect at extreme edges (the popover can still peek past the
+// margin by roughly half its width there) but keeps it from running
+// substantially off-screen, which is all this bug requires.
+const VIEWPORT_MARGIN = 8;
+
+// Computes a fixed-position anchor point (bottom-center of the clicked
+// cell), clamped so it won't sit at the very left/right edge of the
+// viewport. Using the button's live bounding rect means this is correct
+// regardless of scroll position within any clipping ancestor.
+function popoverPositionFor(rect: DOMRect): PopoverPosition {
+  const top = rect.bottom + 4;
+  const rawLeft = rect.left + rect.width / 2;
+  const left = Math.min(Math.max(rawLeft, VIEWPORT_MARGIN), window.innerWidth - VIEWPORT_MARGIN);
+  return { top, left };
+}
+
 // Buckets a slot's availability into one of 5 shading tiers based on what
 // fraction of the group is free, so the heatmap reads consistently
 // regardless of group size: 0%, 1-25%, 26-50%, 51-75%, 76-100%.
@@ -34,6 +60,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   // Cancels any in-flight request before starting a new one - matching
@@ -86,10 +113,14 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
     const handleClickOutside = (event: MouseEvent) => {
       if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
         setActiveCellKey(null);
+        setPopoverPosition(null);
       }
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setActiveCellKey(null);
+      if (event.key === 'Escape') {
+        setActiveCellKey(null);
+        setPopoverPosition(null);
+      }
     };
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
@@ -157,10 +188,22 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                     role="cell"
                     aria-label={label}
                     className={`schedule-grid__slot schedule-grid__slot--tier-${tier}`}
-                    onClick={() => setActiveCellKey(isActive ? null : key)}
+                    onClick={(event) => {
+                      if (isActive) {
+                        setActiveCellKey(null);
+                        setPopoverPosition(null);
+                      } else {
+                        setPopoverPosition(popoverPositionFor(event.currentTarget.getBoundingClientRect()));
+                        setActiveCellKey(key);
+                      }
+                    }}
                   />
-                  {isActive && (
-                    <div className="schedule-overview__popover" ref={popoverRef}>
+                  {isActive && popoverPosition && (
+                    <div
+                      className="schedule-overview__popover"
+                      ref={popoverRef}
+                      style={{ top: popoverPosition.top, left: popoverPosition.left }}
+                    >
                       <ul>
                         {members.map(member => (
                           <li key={member.user_id}>{memberDisplayName(member)}</li>

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { scheduleApi } from '../../api/client';
+import type { ScheduleOverviewMember } from '../../api/client';
+import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
+import SkeletonLoader from '../../components/SkeletonLoader';
+import ErrorState from '../../components/ErrorState';
+import './ScheduleOverview.css';
+
+export interface ScheduleOverviewProps {
+  groupId: number;
+  totalMembers: number;
+}
+
+function memberDisplayName(member: ScheduleOverviewMember): string {
+  return [member.first_name, member.last_name].filter(Boolean).join(' ') || member.username;
+}
+
+// Buckets a slot's availability into one of 5 shading tiers based on what
+// fraction of the group is free, so the heatmap reads consistently
+// regardless of group size: 0%, 1-25%, 26-50%, 51-75%, 76-100%.
+function tierFor(count: number, totalMembers: number): number {
+  if (count === 0 || totalMembers === 0) return 0;
+  const fraction = count / totalMembers;
+  if (fraction <= 0.25) return 1;
+  if (fraction <= 0.5) return 2;
+  if (fraction <= 0.75) return 3;
+  return 4;
+}
+
+const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembers }) => {
+  const [membersBySlot, setMembersBySlot] = useState<Map<string, ScheduleOverviewMember[]>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeCellKey, setActiveCellKey] = useState<string | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  const loadOverview = () => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    scheduleApi.getOverview(groupId, { signal: controller.signal })
+      .then(res => {
+        const map = new Map<string, ScheduleOverviewMember[]>();
+        res.data.slots.forEach(slot => {
+          map.set(slotKey(slot.day_of_week, slot.hour), slot.members);
+        });
+        setMembersBySlot(map);
+      })
+      .catch(err => {
+        if (axios.isCancel(err)) return;
+        setError('Unable to load schedule overview.');
+      })
+      .finally(() => setLoading(false));
+    return controller;
+  };
+
+  useEffect(() => {
+    const controller = loadOverview();
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId]);
+
+  useEffect(() => {
+    if (activeCellKey === null) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
+        setActiveCellKey(null);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setActiveCellKey(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [activeCellKey]);
+
+  if (loading) {
+    return <SkeletonLoader variant="card" count={1} />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={loadOverview} />;
+  }
+
+  return (
+    <div className="schedule-overview">
+      <div className="schedule-grid" role="table" aria-label="Weekly availability overview">
+        <div className="schedule-grid__row schedule-grid__row--header" role="row">
+          <div className="schedule-grid__cell schedule-grid__cell--corner" role="columnheader" />
+          {DAYS.map(day => (
+            <div key={day} className="schedule-grid__cell schedule-grid__cell--header" role="columnheader">
+              {day}
+            </div>
+          ))}
+        </div>
+        {HOURS.map(hour => (
+          <div key={hour} className="schedule-grid__row" role="row">
+            <div className="schedule-grid__cell schedule-grid__cell--header" role="rowheader">
+              {formatHourLabel(hour)}
+            </div>
+            {DAYS.map((_, dayOfWeek) => {
+              const key = slotKey(dayOfWeek, hour);
+              const members = membersBySlot.get(key) ?? [];
+              const tier = tierFor(members.length, totalMembers);
+              const label = `${DAYS[dayOfWeek]} ${formatHourLabel(hour)}, ${members.length} available`;
+              const isActive = activeCellKey === key;
+
+              if (members.length === 0) {
+                return (
+                  <div
+                    key={key}
+                    role="cell"
+                    aria-label={label}
+                    className={`schedule-grid__slot schedule-grid__slot--tier-${tier}`}
+                  />
+                );
+              }
+
+              return (
+                <div key={key} className="schedule-overview__cell-wrapper">
+                  <button
+                    type="button"
+                    role="cell"
+                    aria-label={label}
+                    className={`schedule-grid__slot schedule-grid__slot--tier-${tier}`}
+                    onClick={() => setActiveCellKey(isActive ? null : key)}
+                  />
+                  {isActive && (
+                    <div className="schedule-overview__popover" ref={popoverRef}>
+                      <ul>
+                        {members.map(member => (
+                          <li key={member.user_id}>{memberDisplayName(member)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleOverview;

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -107,6 +107,15 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
     return <ErrorState message={error} onRetry={loadOverview} />;
   }
 
+  // If the caller couldn't supply a member count (e.g. its own member-list
+  // fetch failed or hadn't resolved yet), fall back to a denominator derived
+  // from the fetched slot data itself rather than trusting `totalMembers`
+  // blindly - otherwise every cell renders as tier-0 ("nobody available")
+  // even when real availability data exists.
+  const effectiveTotal = totalMembers > 0
+    ? totalMembers
+    : Math.max(0, ...Array.from(membersBySlot.values()).map(m => m.length));
+
   return (
     <div className="schedule-overview">
       <div className="schedule-grid" role="table" aria-label="Weekly availability overview">
@@ -126,7 +135,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
             {DAYS.map((_, dayOfWeek) => {
               const key = slotKey(dayOfWeek, hour);
               const members = membersBySlot.get(key) ?? [];
-              const tier = tierFor(members.length, totalMembers);
+              const tier = tierFor(members.length, effectiveTotal);
               const label = `${DAYS[dayOfWeek]} ${formatHourLabel(hour)}, ${members.length} available`;
               const isActive = activeCellKey === key;
 

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { scheduleApi } from '../../api/client';
 import type { ScheduleOverviewMember } from '../../api/client';
 import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
+import './ScheduleTab.css';
 import './ScheduleOverview.css';
 
 export interface ScheduleOverviewProps {
@@ -35,8 +36,18 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
-  const loadOverview = () => {
+  // Cancels any in-flight request before starting a new one - matching
+  // ScheduleTab.tsx's loadSchedule AbortController pattern - so both the
+  // initial mount fetch and a user-triggered retry go through the same
+  // ref-guarded controller: whichever request is superseded gets aborted,
+  // and only the request still current when it finishes is allowed to
+  // clear `loading`.
+  const loadAbortControllerRef = useRef<AbortController | null>(null);
+  const loadOverview = useCallback(() => {
+    loadAbortControllerRef.current?.abort();
     const controller = new AbortController();
+    loadAbortControllerRef.current = controller;
+
     setLoading(true);
     setError(null);
     scheduleApi.getOverview(groupId, { signal: controller.signal })
@@ -51,15 +62,24 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
         if (axios.isCancel(err)) return;
         setError('Unable to load schedule overview.');
       })
-      .finally(() => setLoading(false));
-    return controller;
-  };
+      .finally(() => {
+        if (loadAbortControllerRef.current === controller) {
+          setLoading(false);
+        }
+      });
+  }, [groupId]);
 
   useEffect(() => {
-    const controller = loadOverview();
-    return () => controller.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupId]);
+    loadOverview();
+  }, [loadOverview]);
+
+  // Cancel any in-flight overview request on unmount so it can't set state
+  // on an unmounted component.
+  useEffect(() => {
+    return () => {
+      loadAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (activeCellKey === null) return;

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -22,24 +22,48 @@ interface PopoverPosition {
   left: number;
 }
 
-// The popover's own rendered width isn't known before it renders (it's
-// content-sized up to the 220px max-width in ScheduleOverview.css), so we
-// don't try to compute an exact clamp for its edges. Instead we clamp the
-// raw anchor point itself to a small margin from the viewport edges before
-// the CSS `transform: translateX(-50%)` centers the popover under it. This
-// isn't pixel-perfect at extreme edges (the popover can still peek past the
-// margin by roughly half its width there) but keeps it from running
-// substantially off-screen, which is all this bug requires.
 const VIEWPORT_MARGIN = 8;
 
-// Computes a fixed-position anchor point (bottom-center of the clicked
-// cell), clamped so it won't sit at the very left/right edge of the
-// viewport. Using the button's live bounding rect means this is correct
-// regardless of scroll position within any clipping ancestor.
+// The popover is horizontally centered on the anchor point via the CSS
+// `transform: translateX(-50%)`, so its rendered left/right edges sit
+// `POPOVER_WIDTH / 2` away from whatever `left` we compute here. We clamp
+// against the *widest* it can ever render - `max-width` from
+// ScheduleOverview.css (140px min-width / 220px max-width; content-sized
+// in between) - so the clamp holds even for popovers with long member
+// lists that hit the max-width.
+const POPOVER_WIDTH = 220;
+const POPOVER_HALF_WIDTH = POPOVER_WIDTH / 2;
+
+// The popover's actual height depends on how many members are in the slot
+// (unbounded list length), which we don't know until it renders. Rather
+// than measure post-render (extra state + effect for a one-frame
+// correction), we use a conservative fixed estimate for the flip decision:
+// enough for a handful of names (padding 2x8px + border 2x1px + ~6 lines at
+// ~16px + 5 inter-item gaps at 4px, from the `.schedule-overview__popover`
+// rule in ScheduleOverview.css, is ~120px). This won't be pixel-perfect for
+// slots with many available members, but it reliably keeps the popover
+// on-screen, which is what this fix requires.
+const ESTIMATED_POPOVER_HEIGHT = 120;
+
+// Computes a fixed-position anchor point for the popover, derived from the
+// clicked cell's live bounding rect (so it's correct regardless of scroll
+// position within any clipping ancestor). Clamps both axes against the
+// viewport:
+//  - Vertically, flips the popover above the cell when there isn't enough
+//    room below for the estimated popover height.
+//  - Horizontally, accounts for the popover's own (max) rendered width when
+//    clamping, not just the raw anchor point, since the anchor is the
+//    horizontal *center* of the popover, not its edge.
 function popoverPositionFor(rect: DOMRect): PopoverPosition {
-  const top = rect.bottom + 4;
+  const spaceBelow = window.innerHeight - rect.bottom - 4;
+  const top = spaceBelow >= ESTIMATED_POPOVER_HEIGHT
+    ? rect.bottom + 4
+    : Math.max(VIEWPORT_MARGIN, rect.top - 4 - ESTIMATED_POPOVER_HEIGHT);
+
   const rawLeft = rect.left + rect.width / 2;
-  const left = Math.min(Math.max(rawLeft, VIEWPORT_MARGIN), window.innerWidth - VIEWPORT_MARGIN);
+  const minLeft = VIEWPORT_MARGIN + POPOVER_HALF_WIDTH;
+  const maxLeft = window.innerWidth - VIEWPORT_MARGIN - POPOVER_HALF_WIDTH;
+  const left = Math.min(Math.max(rawLeft, minLeft), maxLeft);
   return { top, left };
 }
 

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -17,6 +17,12 @@
   color: var(--text-primary);
 }
 
+.schedule-tab__view-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
 .schedule-grid {
   display: grid;
   grid-template-columns: 90px repeat(7, 1fr);

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -4,7 +4,7 @@ import ScheduleTab from './ScheduleTab';
 import { scheduleApi, groupsApi } from '../../api/client';
 import { CanceledError } from 'axios';
 import type { AxiosResponse } from 'axios';
-import type { ScheduleResponse, GroupMember } from '../../api/client';
+import type { ScheduleResponse, GroupMember, ScheduleOverviewResponse } from '../../api/client';
 import { ToastProvider } from '../../contexts/ToastContext';
 
 vi.mock('../../api/client', () => ({
@@ -13,6 +13,7 @@ vi.mock('../../api/client', () => ({
     updateMine: vi.fn(),
     getForMember: vi.fn(),
     updateForMember: vi.fn(),
+    getOverview: vi.fn(),
   },
   groupsApi: {
     getMembers: vi.fn(),
@@ -32,6 +33,7 @@ describe('ScheduleTab', () => {
     vi.mocked(scheduleApi.getMine).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleResponse>);
     vi.mocked(scheduleApi.updateMine).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleResponse>);
     vi.mocked(groupsApi.getMembers).mockResolvedValue({ data: [] } as unknown as AxiosResponse<GroupMember[]>);
+    vi.mocked(scheduleApi.getOverview).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleOverviewResponse>);
   });
 
   it('loads and displays the caller\'s own schedule by default', async () => {
@@ -138,5 +140,29 @@ describe('ScheduleTab', () => {
 
     expect(screen.getByRole('cell', { name: 'Sat 5:00 PM' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('cell', { name: 'Sun 8:00 AM' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('does not show the individual/overview toggle for a non-admin member', async () => {
+    renderScheduleTab(false);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: /overview/i })).not.toBeInTheDocument();
+  });
+
+  it('a group admin can switch to the overview and back to individual view', async () => {
+    vi.mocked(groupsApi.getMembers).mockResolvedValue({
+      data: [{ user_id: 42, username: 'vol2', is_group_admin: false, is_site_admin: false, email: '', skill_tags: [] }],
+    } as unknown as AxiosResponse<GroupMember[]>);
+
+    renderScheduleTab(true);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: /overview/i }));
+
+    await waitFor(() => expect(scheduleApi.getOverview).toHaveBeenCalledWith(1, expect.objectContaining({ signal: expect.any(AbortSignal) })));
+    expect(screen.queryByLabelText(/viewing schedule for/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save schedule/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /individual/i }));
+    expect(await screen.findByLabelText(/viewing schedule for/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -5,24 +5,13 @@ import type { GroupMember } from '../../api/client';
 import { useToast } from '../../hooks/useToast';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
+import ScheduleOverview from './ScheduleOverview';
+import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
 import './ScheduleTab.css';
 
 export interface ScheduleTabProps {
   groupId: number;
   canManageMembers: boolean;
-}
-
-const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
-
-function slotKey(dayOfWeek: number, hour: number): string {
-  return `${dayOfWeek}-${hour}`;
-}
-
-function formatHourLabel(hour: number): string {
-  const period = hour < 12 ? 'AM' : 'PM';
-  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
-  return `${displayHour}:00 ${period}`;
 }
 
 const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) => {
@@ -33,6 +22,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [viewMode, setViewMode] = useState<'individual' | 'overview'>('individual');
 
   // Cancels any in-flight request before starting a new one - matching
   // GroupPage.tsx's loadAnimals/loadActivityFeed AbortController pattern -
@@ -126,59 +116,84 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) 
   return (
     <div className="schedule-tab">
       {canManageMembers && (
-        <div className="schedule-tab__picker">
-          <label htmlFor="schedule-member-select">Viewing schedule for</label>
-          <select
-            id="schedule-member-select"
-            value={selectedUserId ?? ''}
-            onChange={e => setSelectedUserId(e.target.value === '' ? null : Number(e.target.value))}
+        <div className="schedule-tab__view-toggle" role="group" aria-label="Schedule view">
+          <button
+            type="button"
+            className={viewMode === 'individual' ? 'btn-primary' : 'btn-secondary'}
+            onClick={() => setViewMode('individual')}
           >
-            <option value="">My Schedule</option>
-            {members.map(m => (
-              <option key={m.user_id} value={m.user_id}>
-                {[m.first_name, m.last_name].filter(Boolean).join(' ') || m.username}
-              </option>
-            ))}
-          </select>
+            Individual
+          </button>
+          <button
+            type="button"
+            className={viewMode === 'overview' ? 'btn-primary' : 'btn-secondary'}
+            onClick={() => setViewMode('overview')}
+          >
+            Overview
+          </button>
         </div>
       )}
 
-      <div className="schedule-grid" role="table" aria-label="Weekly shift schedule">
-        <div className="schedule-grid__row schedule-grid__row--header" role="row">
-          <div className="schedule-grid__cell schedule-grid__cell--corner" role="columnheader" />
-          {DAYS.map(day => (
-            <div key={day} className="schedule-grid__cell schedule-grid__cell--header" role="columnheader">
-              {day}
+      {viewMode === 'overview' && canManageMembers ? (
+        <ScheduleOverview groupId={groupId} totalMembers={members.length} />
+      ) : (
+        <>
+          {canManageMembers && (
+            <div className="schedule-tab__picker">
+              <label htmlFor="schedule-member-select">Viewing schedule for</label>
+              <select
+                id="schedule-member-select"
+                value={selectedUserId ?? ''}
+                onChange={e => setSelectedUserId(e.target.value === '' ? null : Number(e.target.value))}
+              >
+                <option value="">My Schedule</option>
+                {members.map(m => (
+                  <option key={m.user_id} value={m.user_id}>
+                    {[m.first_name, m.last_name].filter(Boolean).join(' ') || m.username}
+                  </option>
+                ))}
+              </select>
             </div>
-          ))}
-        </div>
-        {HOURS.map(hour => (
-          <div key={hour} className="schedule-grid__row" role="row">
-            <div className="schedule-grid__cell schedule-grid__cell--header" role="rowheader">
-              {formatHourLabel(hour)}
-            </div>
-            {DAYS.map((_, dayOfWeek) => {
-              const key = slotKey(dayOfWeek, hour);
-              const active = selectedSlots.has(key);
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  role="cell"
-                  className={`schedule-grid__slot ${active ? 'schedule-grid__slot--active' : ''}`}
-                  aria-pressed={active}
-                  aria-label={`${DAYS[dayOfWeek]} ${formatHourLabel(hour)}`}
-                  onClick={() => toggleSlot(dayOfWeek, hour)}
-                />
-              );
-            })}
-          </div>
-        ))}
-      </div>
+          )}
 
-      <button type="button" className="btn-primary schedule-tab__save" onClick={handleSave} disabled={saving}>
-        {saving ? 'Saving…' : 'Save Schedule'}
-      </button>
+          <div className="schedule-grid" role="table" aria-label="Weekly shift schedule">
+            <div className="schedule-grid__row schedule-grid__row--header" role="row">
+              <div className="schedule-grid__cell schedule-grid__cell--corner" role="columnheader" />
+              {DAYS.map(day => (
+                <div key={day} className="schedule-grid__cell schedule-grid__cell--header" role="columnheader">
+                  {day}
+                </div>
+              ))}
+            </div>
+            {HOURS.map(hour => (
+              <div key={hour} className="schedule-grid__row" role="row">
+                <div className="schedule-grid__cell schedule-grid__cell--header" role="rowheader">
+                  {formatHourLabel(hour)}
+                </div>
+                {DAYS.map((_, dayOfWeek) => {
+                  const key = slotKey(dayOfWeek, hour);
+                  const active = selectedSlots.has(key);
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      role="cell"
+                      className={`schedule-grid__slot ${active ? 'schedule-grid__slot--active' : ''}`}
+                      aria-pressed={active}
+                      aria-label={`${DAYS[dayOfWeek]} ${formatHourLabel(hour)}`}
+                      onClick={() => toggleSlot(dayOfWeek, hour)}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+
+          <button type="button" className="btn-primary schedule-tab__save" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save Schedule'}
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/group/scheduleGrid.ts
+++ b/frontend/src/pages/group/scheduleGrid.ts
@@ -1,0 +1,12 @@
+export const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+export const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
+
+export function slotKey(dayOfWeek: number, hour: number): string {
+  return `${dayOfWeek}-${hour}`;
+}
+
+export function formatHourLabel(hour: number): string {
+  const period = hour < 12 ? 'AM' : 'PM';
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${displayHour}:00 ${period}`;
+}

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -334,3 +334,84 @@ func UpdateMemberSchedule(db *gorm.DB) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"slots": toScheduleSlotResponses(slots)})
 	}
 }
+
+// scheduleOverviewMember identifies one member available for a given slot in
+// a GetGroupScheduleOverview response. Fields mirror GetGroupMembers'
+// MemberInfo naming so the frontend can reuse its existing display-name
+// fallback logic.
+type scheduleOverviewMember struct {
+	UserID    uint   `json:"user_id"`
+	Username  string `json:"username"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// scheduleOverviewSlot is one (day_of_week, hour) slot with at least one
+// available member.
+type scheduleOverviewSlot struct {
+	DayOfWeek int                      `json:"day_of_week"`
+	Hour      int                      `json:"hour"`
+	Members   []scheduleOverviewMember `json:"members"`
+}
+
+// GetGroupScheduleOverview returns every group member's weekly shift slots
+// aggregated by (day_of_week, hour), so an admin can see who is available at
+// a glance instead of paging through members one at a time via
+// GetMemberSchedule. Requires group admin or site admin access. Only slots
+// with at least one available member are included, ordered by
+// (day_of_week, hour) ascending.
+func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			return
+		}
+
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		var slots []models.ShiftSlot
+		if err := db.Preload("User").Where("group_id = ?", groupIDParam).
+			Order("day_of_week, hour").Find(&slots).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch schedule overview"})
+			return
+		}
+
+		type key struct {
+			DayOfWeek int
+			Hour      int
+		}
+		order := make([]key, 0)
+		bucketed := make(map[key][]scheduleOverviewMember)
+		for _, s := range slots {
+			k := key{DayOfWeek: s.DayOfWeek, Hour: s.Hour}
+			if _, exists := bucketed[k]; !exists {
+				order = append(order, k)
+			}
+			bucketed[k] = append(bucketed[k], scheduleOverviewMember{
+				UserID:    s.UserID,
+				Username:  s.User.Username,
+				FirstName: s.User.FirstName,
+				LastName:  s.User.LastName,
+			})
+		}
+
+		result := make([]scheduleOverviewSlot, 0, len(order))
+		for _, k := range order {
+			result = append(result, scheduleOverviewSlot{
+				DayOfWeek: k.DayOfWeek,
+				Hour:      k.Hour,
+				Members:   bucketed[k],
+			})
+		}
+
+		c.JSON(http.StatusOK, gin.H{"slots": result})
+	}
+}

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -715,3 +715,117 @@ func TestUpdateGroupScheduling(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGroupScheduleOverview(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*gorm.DB) (contextUser *models.User, group *models.Group)
+		isAdmin        bool
+		expectedStatus int
+	}{
+		{
+			name: "regular member is denied",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
+				return regular, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name: "scheduling disabled for the group returns 404",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				group := CreateTestGroup(t, db, "Dogs", "Dog volunteers") // scheduling left off
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "group admin sees empty slots for a group with no shifts set",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				groupAdmin := CreateTestUser(t, db, "gadmin", "gadmin@test.com", "password123", false)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				AddUserToGroupWithAdmin(t, db, groupAdmin.ID, group.ID, true)
+				return groupAdmin, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "site admin sees slots aggregated across multiple members",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				siteAdmin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				member1 := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+				member2 := CreateTestUser(t, db, "vol2", "vol2@test.com", "password123", false)
+				AddUserToGroupWithAdmin(t, db, member1.ID, group.ID, false)
+				AddUserToGroupWithAdmin(t, db, member2.ID, group.ID, false)
+				// Both members overlap on (day 2, hour 9); member1 alone on (day 3, hour 10).
+				db.Create(&models.ShiftSlot{UserID: member1.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
+				db.Create(&models.ShiftSlot{UserID: member2.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 9})
+				db.Create(&models.ShiftSlot{UserID: member1.ID, GroupID: group.ID, DayOfWeek: 3, Hour: 10})
+				return siteAdmin, group
+			},
+			isAdmin:        true,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t)
+			contextUser, group := tt.setupFunc(db)
+
+			c, w := setupGroupTestContext(contextUser.ID, tt.isAdmin)
+			c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+			c.Request = httptest.NewRequest("GET", fmt.Sprintf("/api/groups/%d/schedule/overview", group.ID), nil)
+
+			handler := GetGroupScheduleOverview(db)
+			handler(c)
+
+			if w.Code != tt.expectedStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.expectedStatus, w.Code, w.Body.String())
+			}
+			if tt.expectedStatus != http.StatusOK {
+				return
+			}
+
+			var resp struct {
+				Slots []scheduleOverviewSlot `json:"slots"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			switch tt.name {
+			case "group admin sees empty slots for a group with no shifts set":
+				if len(resp.Slots) != 0 {
+					t.Errorf("expected 0 slots, got %d", len(resp.Slots))
+				}
+			case "site admin sees slots aggregated across multiple members":
+				if len(resp.Slots) != 2 {
+					t.Fatalf("expected 2 distinct slots, got %d", len(resp.Slots))
+				}
+				overlap := resp.Slots[0]
+				if overlap.DayOfWeek != 2 || overlap.Hour != 9 {
+					t.Errorf("expected first slot to be day 2 hour 9, got day %d hour %d", overlap.DayOfWeek, overlap.Hour)
+				}
+				if len(overlap.Members) != 2 {
+					t.Errorf("expected 2 members on the overlapping slot, got %d", len(overlap.Members))
+				}
+				solo := resp.Slots[1]
+				if solo.DayOfWeek != 3 || solo.Hour != 10 {
+					t.Errorf("expected second slot to be day 3 hour 10, got day %d hour %d", solo.DayOfWeek, solo.Hour)
+				}
+				if len(solo.Members) != 1 || solo.Members[0].Username != "vol1" {
+					t.Errorf("expected solo slot to contain only vol1, got %+v", solo.Members)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Admin-only `GET /groups/:id/schedule/overview` endpoint aggregating every member's weekly shift availability by (day, hour), so admins can see who's free at a glance instead of paging through members one at a time.
- New read-only heatmap view (`ScheduleOverview`) toggled in alongside the existing per-member schedule editor in the group's Schedule tab — shading scales with what fraction of the group is available each slot, click a slot to see names in a popover.
- Group-scoped only (no cross-group aggregation), per scope decision during design.

## Test plan
- [x] `go test ./internal/handlers/...` — new `TestGetGroupScheduleOverview` passing (admin gate, disabled-scheduling gate, empty group, multi-member aggregation); only pre-existing unrelated failure (`TestCreateGroup/accepts_valid_GroupMe_bot_id`, confirmed present on `main` before this branch)
- [x] `npx vitest run` (frontend) — 401/402 passing; only pre-existing unrelated failure (`AnimalForm.test.tsx` timing assertion, confirmed present on `main`, untouched by this branch's diff)
- [x] `npx tsc --noEmit` clean
- [x] Popover positioning (viewport clipping for last-row/rightmost-column cells, and for slots with many available members) independently verified with Playwright/Chromium across desktop and mobile viewports — not just jsdom, which can't render real layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)