### PR TITLE
Add shift coverage requests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -36,6 +36,9 @@ import (
 )
 
 func main() {
+	// time.Local is forced to UTC in internal/database's init() (imported
+	// below via internal/database) - see that file for why.
+
 	// Load environment variables first so everything below — logging,
 	// telemetry, database config — observes vars set only in .env, not just
 	// the process environment. The "no .env file" notice itself is logged

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -451,6 +451,7 @@ func main() {
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
 			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
 			group.POST("/schedule/coverage-requests", handlers.CreateCoverageRequest(db, emailService, groupMeService))
+			group.POST("/schedule/coverage-requests/:requestId/claim", handlers.ClaimCoverageRequest(db, emailService, groupMeService))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))
 			group.PUT("/schedule/:userId", handlers.UpdateMemberSchedule(db))
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -452,6 +452,7 @@ func main() {
 			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
 			group.POST("/schedule/coverage-requests", handlers.CreateCoverageRequest(db, emailService, groupMeService))
 			group.POST("/schedule/coverage-requests/:requestId/claim", handlers.ClaimCoverageRequest(db, emailService, groupMeService))
+			group.DELETE("/schedule/coverage-requests/:requestId", handlers.CancelCoverageRequest(db))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))
 			group.PUT("/schedule/:userId", handlers.UpdateMemberSchedule(db))
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -451,6 +451,7 @@ func main() {
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
 			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
 			group.POST("/schedule/coverage-requests", handlers.CreateCoverageRequest(db, emailService, groupMeService))
+			group.POST("/schedule/coverage-requests/batch", handlers.CreateCoverageRequestsBatch(db, emailService, groupMeService))
 			group.POST("/schedule/coverage-requests/:requestId/claim", handlers.ClaimCoverageRequest(db, emailService, groupMeService))
 			group.DELETE("/schedule/coverage-requests/:requestId", handlers.CancelCoverageRequest(db))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -450,6 +450,7 @@ func main() {
 			group.GET("/schedule/me", handlers.GetMySchedule(db))
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
 			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
+			group.POST("/schedule/coverage-requests", handlers.CreateCoverageRequest(db, emailService, groupMeService))
 			group.GET("/schedule/:userId", handlers.GetMemberSchedule(db))
 			group.PUT("/schedule/:userId", handlers.UpdateMemberSchedule(db))
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -630,16 +630,32 @@ export interface ScheduleOverviewMember {
   username: string;
   first_name?: string;
   last_name?: string;
+  status: 'normal' | 'needs_coverage' | 'covering';
+  coverage_request_id?: number;
+  claimable?: boolean;
+  conflict?: boolean;
 }
 
 export interface ScheduleOverviewSlot {
+  date: string;
   day_of_week: number;
   hour: number;
   members: ScheduleOverviewMember[];
 }
 
 export interface ScheduleOverviewResponse {
+  week_start: string;
   slots: ScheduleOverviewSlot[];
+}
+
+export interface CoverageRequest {
+  id: number;
+  group_id: number;
+  requested_by_user_id: number;
+  date: string;
+  hour: number;
+  status: 'open' | 'claimed' | 'cancelled';
+  claimed_by_user_id: number | null;
 }
 
 export const scheduleApi = {
@@ -651,8 +667,21 @@ export const scheduleApi = {
     api.get<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { signal: options?.signal }),
   updateForMember: (groupId: number, userId: number, slots: ScheduleSlot[]) =>
     api.put<ScheduleResponse>(`/groups/${groupId}/schedule/${userId}`, { slots }),
-  getOverview: (groupId: number, options?: { signal?: AbortSignal }) =>
-    api.get<ScheduleOverviewResponse>(`/groups/${groupId}/schedule/overview`, { signal: options?.signal }),
+  getOverview: (groupId: number, options?: { weekStart?: string; signal?: AbortSignal }) =>
+    api.get<ScheduleOverviewResponse>(`/groups/${groupId}/schedule/overview`, {
+      params: options?.weekStart ? { week_start: options.weekStart } : undefined,
+      signal: options?.signal,
+    }),
+  createCoverageRequest: (groupId: number, payload: { date: string; hour: number; userId?: number }) =>
+    api.post<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests`, {
+      date: payload.date,
+      hour: payload.hour,
+      user_id: payload.userId,
+    }),
+  claimCoverageRequest: (groupId: number, requestId: number) =>
+    api.post<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests/${requestId}/claim`),
+  cancelCoverageRequest: (groupId: number, requestId: number) =>
+    api.delete<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests/${requestId}`),
 };
 
 // Animals API

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -658,6 +658,22 @@ export interface CoverageRequest {
   claimed_by_user_id: number | null;
 }
 
+export interface CoverageRequestBatchItem {
+  date: string;
+  hour: number;
+}
+
+export interface CoverageRequestBatchSkipped {
+  date: string;
+  hour: number;
+  reason: string;
+}
+
+export interface CoverageRequestBatchResult {
+  created: CoverageRequest[];
+  skipped: CoverageRequestBatchSkipped[];
+}
+
 export const scheduleApi = {
   getMine: (groupId: number, options?: { signal?: AbortSignal }) =>
     api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { signal: options?.signal }),
@@ -682,6 +698,8 @@ export const scheduleApi = {
     api.post<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests/${requestId}/claim`),
   cancelCoverageRequest: (groupId: number, requestId: number) =>
     api.delete<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests/${requestId}`),
+  createCoverageRequestsBatch: (groupId: number, requests: CoverageRequestBatchItem[]) =>
+    api.post<CoverageRequestBatchResult>(`/groups/${groupId}/schedule/coverage-requests/batch`, { requests }),
 };
 
 // Animals API

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -31,7 +31,7 @@ const NAME_SEARCH_DEBOUNCE_MS = 400;
 
 const GroupPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  useAuth(); // Ensure user is authenticated
+  const { user } = useAuth(); // Ensure user is authenticated; also need their id for schedule actions
   const navigate = useNavigate();
   const toast = useToast();
   const [searchParams] = useSearchParams();
@@ -1625,6 +1625,7 @@ const GroupPage: React.FC = () => {
           <ScheduleTab
             groupId={Number(id)}
             canManageMembers={!!(membership?.is_group_admin || membership?.is_site_admin)}
+            currentUserId={user?.id ?? 0}
           />
         </div>
       )}

--- a/frontend/src/pages/group/RequestCoverageRangeForm.css
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.css
@@ -1,0 +1,50 @@
+.request-coverage-range-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.request-coverage-range-form__dates {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.request-coverage-range-form__dates label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.request-coverage-range-form__warning {
+  color: var(--warning, #d97706);
+  font-size: 0.85rem;
+}
+
+.request-coverage-range-form__select-all {
+  font-size: 0.9rem;
+}
+
+.request-coverage-range-form__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--neutral-200);
+  border-radius: 6px;
+}
+
+.request-coverage-range-form__list li {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--neutral-200);
+}
+
+.request-coverage-range-form__list li:last-child {
+  border-bottom: none;
+}
+
+.request-coverage-range-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/frontend/src/pages/group/RequestCoverageRangeForm.css
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.css
@@ -21,7 +21,15 @@
 }
 
 .request-coverage-range-form__select-all {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   font-size: 0.9rem;
+}
+
+.request-coverage-range-form__count {
+  color: var(--text-secondary, var(--neutral-500, #6b7280));
+  font-size: 0.85rem;
 }
 
 .request-coverage-range-form__list {

--- a/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
@@ -164,4 +164,39 @@ describe('RequestCoverageRangeForm', () => {
       vi.useRealTimers();
     }
   });
+
+  it('shows the selected count and blocks submit once the selection exceeds the batch cap', async () => {
+    // Regression test: MAX_RANGE_DAYS (90 days) alone doesn't guarantee the
+    // occurrence count stays under the backend's 200-item cap - a busy
+    // recurring schedule over a wide-but-legal range can still exceed it.
+    // Every weekday at every hour (8am-5pm = 10 hours x 7 days = 70 slots)
+    // over a 30-day range produces ~300 occurrences, comfortably over 200.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      const busySlots: ScheduleSlot[] = [];
+      for (let day = 0; day <= 6; day++) {
+        for (let hour = 8; hour <= 17; hour++) {
+          busySlots.push({ day_of_week: day, hour });
+        }
+      }
+
+      render(<RequestCoverageRangeForm groupId={7} slots={busySlots} />);
+      fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+      fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-09-09' } });
+
+      await waitFor(() => expect(screen.getByText(/\d+ selected/i)).toBeInTheDocument());
+      expect(screen.getByText(/^(2\d{2}|[3-9]\d{2}) selected$/i)).toBeInTheDocument();
+      expect(screen.getByText(/at most 200 shifts/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /request coverage/i })).toBeDisabled();
+
+      // Deselecting enough occurrences to drop back under the cap clears
+      // the warning and re-enables submit.
+      fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+      expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+      expect(screen.queryByText(/at most 200 shifts/i)).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
@@ -17,19 +17,29 @@ vi.mock('../../hooks/useToast', () => ({
 
 describe('computeCandidateOccurrences', () => {
   it('finds every occurrence of the recurring slots within the range', () => {
-    // 2026-08-11 is a Tuesday; 2026-08-13 is a Thursday.
-    const slots: ScheduleSlot[] = [
-      { day_of_week: 2, hour: 10 }, // Tuesday 10am
-      { day_of_week: 4, hour: 14 }, // Thursday 2pm
-    ];
-    const result = computeCandidateOccurrences(slots, '2026-08-11', '2026-08-20');
-    // Expect Tuesdays 8/11 and 8/18, Thursdays 8/13 and 8/20.
-    expect(result).toEqual([
-      { date: '2026-08-11', hour: 10 },
-      { date: '2026-08-13', hour: 14 },
-      { date: '2026-08-18', hour: 10 },
-      { date: '2026-08-20', hour: 14 },
-    ]);
+    // Pin "now" safely before the fixture range so the past-date exclusion
+    // in computeCandidateOccurrences never drops 2026-08-11 depending on
+    // the real wall clock (matches the vi.useFakeTimers({toFake: ['Date']})
+    // + try/finally convention used in ScheduleOverview.test.tsx).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      // 2026-08-11 is a Tuesday; 2026-08-13 is a Thursday.
+      const slots: ScheduleSlot[] = [
+        { day_of_week: 2, hour: 10 }, // Tuesday 10am
+        { day_of_week: 4, hour: 14 }, // Thursday 2pm
+      ];
+      const result = computeCandidateOccurrences(slots, '2026-08-11', '2026-08-20');
+      // Expect Tuesdays 8/11 and 8/18, Thursdays 8/13 and 8/20.
+      expect(result).toEqual([
+        { date: '2026-08-11', hour: 10 },
+        { date: '2026-08-13', hour: 14 },
+        { date: '2026-08-18', hour: 10 },
+        { date: '2026-08-20', hour: 14 },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('excludes dates before today even if within the given range', () => {
@@ -53,37 +63,56 @@ describe('RequestCoverageRangeForm', () => {
   });
 
   it('pre-checks every computed occurrence and lets select-all toggle them', async () => {
-    render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
-    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
-    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
+    // Same pinning rationale as the computeCandidateOccurrences test above:
+    // this test's expected checkbox count (2) depends on 2026-08-11 not
+    // being excluded by the component's own past-date filtering, which
+    // reads the real wall clock unless pinned.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
+      fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+      fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
 
-    const checkboxes = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
-    expect(checkboxes).toHaveLength(2);
-    checkboxes.forEach(cb => expect(cb).toBeChecked());
+      const checkboxes = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+      expect(checkboxes).toHaveLength(2);
+      checkboxes.forEach(cb => expect(cb).toBeChecked());
 
-    fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
-    checkboxes.forEach(cb => expect(cb).not.toBeChecked());
+      fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+      checkboxes.forEach(cb => expect(cb).not.toBeChecked());
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('submits only the checked occurrences and shows the created/skipped summary', async () => {
-    const result: CoverageRequestBatchResult = {
-      created: [{ id: 1, group_id: 7, requested_by_user_id: 1, date: '2026-08-11', hour: 10, status: 'open', claimed_by_user_id: null }],
-      skipped: [{ date: '2026-08-18', hour: 10, reason: 'a coverage request already exists for that date and hour' }],
-    };
-    vi.mocked(scheduleApi.createCoverageRequestsBatch).mockResolvedValue({ data: result } as AxiosResponse<CoverageRequestBatchResult>);
+    // Pinned for the same reason: the submitted payload asserted below
+    // includes 2026-08-11, which only survives the component's past-date
+    // filtering when "today" is pinned on or before that date.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      const result: CoverageRequestBatchResult = {
+        created: [{ id: 1, group_id: 7, requested_by_user_id: 1, date: '2026-08-11', hour: 10, status: 'open', claimed_by_user_id: null }],
+        skipped: [{ date: '2026-08-18', hour: 10, reason: 'a coverage request already exists for that date and hour' }],
+      };
+      vi.mocked(scheduleApi.createCoverageRequestsBatch).mockResolvedValue({ data: result } as AxiosResponse<CoverageRequestBatchResult>);
 
-    render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
-    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
-    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
-    await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+      render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
+      fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+      fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
+      await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
 
-    fireEvent.click(screen.getByRole('button', { name: /request coverage/i }));
+      fireEvent.click(screen.getByRole('button', { name: /request coverage/i }));
 
-    await waitFor(() => expect(scheduleApi.createCoverageRequestsBatch).toHaveBeenCalledWith(7, [
-      { date: '2026-08-11', hour: 10 },
-      { date: '2026-08-18', hour: 10 },
-    ]));
-    expect(await screen.findByText(/requested coverage for 1 shift/i)).toBeInTheDocument();
-    expect(screen.getByText(/1 skipped/i)).toBeInTheDocument();
+      await waitFor(() => expect(scheduleApi.createCoverageRequestsBatch).toHaveBeenCalledWith(7, [
+        { date: '2026-08-11', hour: 10 },
+        { date: '2026-08-18', hour: 10 },
+      ]));
+      expect(await screen.findByText(/requested coverage for 1 shift/i)).toBeInTheDocument();
+      expect(screen.getByText(/1 skipped/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
@@ -115,4 +115,53 @@ describe('RequestCoverageRangeForm', () => {
       vi.useRealTimers();
     }
   });
+
+  it('shows the result screen even when a consumer passes onSuccess, and Done calls onCancel not onSuccess', async () => {
+    // Regression test for the onSuccess/result-screen race: ScheduleTab used
+    // to pass an onSuccess that closed its modal, and because React batches
+    // setResult(...) and onSuccess?.() from the same submit handler, the
+    // parent's onSuccess-driven unmount raced the result screen's paint -
+    // in practice the modal closed before the created/skipped summary (and
+    // its "Done" button) ever became visible. ScheduleTab has since stopped
+    // passing onSuccess at all (relying solely on onCancel to close), but
+    // this component still accepts onSuccess as an optional prop for other
+    // future consumers, so it must keep behaving correctly when one is
+    // supplied: the result screen must actually render (not be skipped or
+    // torn down by onSuccess having fired), and re-reading the component's
+    // current code confirms the "Done" button's onClick invokes onCancel,
+    // not onSuccess - so clicking it must not fire onSuccess again.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      const result: CoverageRequestBatchResult = {
+        created: [{ id: 1, group_id: 7, requested_by_user_id: 1, date: '2026-08-11', hour: 10, status: 'open', claimed_by_user_id: null }],
+        skipped: [],
+      };
+      vi.mocked(scheduleApi.createCoverageRequestsBatch).mockResolvedValue({ data: result } as AxiosResponse<CoverageRequestBatchResult>);
+
+      const onSuccess = vi.fn();
+      const onCancel = vi.fn();
+      render(<RequestCoverageRangeForm groupId={7} slots={slots} onSuccess={onSuccess} onCancel={onCancel} />);
+      fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+      fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-11' } });
+      await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+
+      fireEvent.click(screen.getByRole('button', { name: /request coverage/i }));
+
+      // The result screen must actually be visible - this is the part that
+      // was previously dead code in the real app because ScheduleTab's old
+      // onSuccess handler unmounted the form (via closing the Modal) before
+      // this ever painted.
+      expect(await screen.findByText(/requested coverage for 1 shift/i)).toBeInTheDocument();
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onCancel).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('button', { name: /done/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      // Done must not invoke onSuccess again - it only calls onCancel.
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RequestCoverageRangeForm, { computeCandidateOccurrences } from './RequestCoverageRangeForm';
+import { scheduleApi } from '../../api/client';
+import type { AxiosResponse } from 'axios';
+import type { CoverageRequestBatchResult, ScheduleSlot } from '../../api/client';
+
+vi.mock('../../api/client', () => ({
+  scheduleApi: {
+    createCoverageRequestsBatch: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}));
+
+describe('computeCandidateOccurrences', () => {
+  it('finds every occurrence of the recurring slots within the range', () => {
+    // 2026-08-11 is a Tuesday; 2026-08-13 is a Thursday.
+    const slots: ScheduleSlot[] = [
+      { day_of_week: 2, hour: 10 }, // Tuesday 10am
+      { day_of_week: 4, hour: 14 }, // Thursday 2pm
+    ];
+    const result = computeCandidateOccurrences(slots, '2026-08-11', '2026-08-20');
+    // Expect Tuesdays 8/11 and 8/18, Thursdays 8/13 and 8/20.
+    expect(result).toEqual([
+      { date: '2026-08-11', hour: 10 },
+      { date: '2026-08-13', hour: 14 },
+      { date: '2026-08-18', hour: 10 },
+      { date: '2026-08-20', hour: 14 },
+    ]);
+  });
+
+  it('excludes dates before today even if within the given range', () => {
+    const slots: ScheduleSlot[] = [{ day_of_week: 2, hour: 10 }];
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const result = computeCandidateOccurrences(slots, yesterday, yesterday);
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when start is after end', () => {
+    const slots: ScheduleSlot[] = [{ day_of_week: 2, hour: 10 }];
+    expect(computeCandidateOccurrences(slots, '2026-08-20', '2026-08-11')).toEqual([]);
+  });
+});
+
+describe('RequestCoverageRangeForm', () => {
+  const slots: ScheduleSlot[] = [{ day_of_week: 2, hour: 10 }];
+
+  beforeEach(() => {
+    vi.mocked(scheduleApi.createCoverageRequestsBatch).mockReset();
+  });
+
+  it('pre-checks every computed occurrence and lets select-all toggle them', async () => {
+    render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
+    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
+
+    const checkboxes = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+    expect(checkboxes).toHaveLength(2);
+    checkboxes.forEach(cb => expect(cb).toBeChecked());
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+    checkboxes.forEach(cb => expect(cb).not.toBeChecked());
+  });
+
+  it('submits only the checked occurrences and shows the created/skipped summary', async () => {
+    const result: CoverageRequestBatchResult = {
+      created: [{ id: 1, group_id: 7, requested_by_user_id: 1, date: '2026-08-11', hour: 10, status: 'open', claimed_by_user_id: null }],
+      skipped: [{ date: '2026-08-18', hour: 10, reason: 'a coverage request already exists for that date and hour' }],
+    };
+    vi.mocked(scheduleApi.createCoverageRequestsBatch).mockResolvedValue({ data: result } as AxiosResponse<CoverageRequestBatchResult>);
+
+    render(<RequestCoverageRangeForm groupId={7} slots={slots} />);
+    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-18' } });
+    await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+
+    fireEvent.click(screen.getByRole('button', { name: /request coverage/i }));
+
+    await waitFor(() => expect(scheduleApi.createCoverageRequestsBatch).toHaveBeenCalledWith(7, [
+      { date: '2026-08-11', hour: 10 },
+      { date: '2026-08-18', hour: 10 },
+    ]));
+    expect(await screen.findByText(/requested coverage for 1 shift/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 skipped/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/group/RequestCoverageRangeForm.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { scheduleApi } from '../../api/client';
+import type { ScheduleSlot, CoverageRequestBatchItem, CoverageRequestBatchResult } from '../../api/client';
+import { useToast } from '../../hooks/useToast';
+import { formatHourLabel } from './scheduleGrid';
+import './RequestCoverageRangeForm.css';
+
+export interface RequestCoverageRangeFormProps {
+  groupId: number;
+  slots: ScheduleSlot[];
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+const MAX_RANGE_DAYS = 90;
+
+interface Occurrence {
+  date: string;
+  hour: number;
+}
+
+function occurrenceKey(o: Occurrence): string {
+  return `${o.date}-${o.hour}`;
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// computeCandidateOccurrences finds every date within [startDate, endDate]
+// (inclusive, both YYYY-MM-DD) whose weekday matches one of the given
+// slots, paired with that slot's hour - i.e. every real calendar
+// occurrence of the user's recurring pattern within the range. Excludes
+// dates before today, mirroring the backend's own past-date rejection so
+// the checklist never pre-checks something that would just get skipped
+// server-side.
+export function computeCandidateOccurrences(slots: ScheduleSlot[], startDate: string, endDate: string): Occurrence[] {
+  if (!startDate || !endDate || startDate > endDate) return [];
+  const today = todayIso();
+  const [sy, sm, sd] = startDate.split('-').map(Number);
+  const [ey, em, ed] = endDate.split('-').map(Number);
+  const start = new Date(Date.UTC(sy, sm - 1, sd));
+  const end = new Date(Date.UTC(ey, em - 1, ed));
+
+  const occurrences: Occurrence[] = [];
+  for (const cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+    const dateStr = cursor.toISOString().slice(0, 10);
+    if (dateStr < today) continue;
+    const dayOfWeek = cursor.getUTCDay();
+    for (const slot of slots) {
+      if (slot.day_of_week === dayOfWeek) {
+        occurrences.push({ date: dateStr, hour: slot.hour });
+      }
+    }
+  }
+  occurrences.sort((a, b) => (a.date === b.date ? a.hour - b.hour : a.date.localeCompare(b.date)));
+  return occurrences;
+}
+
+function rangeExceedsMaxDays(startDate: string, endDate: string): boolean {
+  if (!startDate || !endDate) return false;
+  const [sy, sm, sd] = startDate.split('-').map(Number);
+  const [ey, em, ed] = endDate.split('-').map(Number);
+  const start = Date.UTC(sy, sm - 1, sd);
+  const end = Date.UTC(ey, em - 1, ed);
+  return (end - start) / (1000 * 60 * 60 * 24) > MAX_RANGE_DAYS;
+}
+
+const RequestCoverageRangeForm: React.FC<RequestCoverageRangeFormProps> = ({ groupId, slots, onSuccess, onCancel }) => {
+  const toast = useToast();
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [checkedKeys, setCheckedKeys] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<CoverageRequestBatchResult | null>(null);
+
+  const rangeTooLong = rangeExceedsMaxDays(startDate, endDate);
+  const candidates = useMemo(
+    () => (rangeTooLong ? [] : computeCandidateOccurrences(slots, startDate, endDate)),
+    [slots, startDate, endDate, rangeTooLong]
+  );
+
+  // Re-derive which occurrences are checked whenever the candidate list
+  // itself changes (start/end date edited, or the range became too long) -
+  // a side effect, so it belongs in useEffect, not inside the useMemo above.
+  useEffect(() => {
+    setCheckedKeys(new Set(candidates.map(occurrenceKey)));
+  }, [candidates]);
+
+  const toggleOccurrence = (key: string) => {
+    setCheckedKeys(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const allChecked = candidates.length > 0 && candidates.every(o => checkedKeys.has(occurrenceKey(o)));
+  const toggleAll = () => {
+    setCheckedKeys(allChecked ? new Set() : new Set(candidates.map(occurrenceKey)));
+  };
+
+  const handleSubmit = () => {
+    const requests: CoverageRequestBatchItem[] = candidates
+      .filter(o => checkedKeys.has(occurrenceKey(o)))
+      .map(o => ({ date: o.date, hour: o.hour }));
+    if (requests.length === 0) {
+      toast.showError('Select at least one shift.');
+      return;
+    }
+    setSubmitting(true);
+    scheduleApi.createCoverageRequestsBatch(groupId, requests)
+      .then(res => {
+        setResult(res.data);
+        if (res.data.created.length > 0) {
+          toast.showSuccess(`Requested coverage for ${res.data.created.length} shift${res.data.created.length === 1 ? '' : 's'}.`);
+        }
+        onSuccess?.();
+      })
+      .catch(err => {
+        const message = (err as { response?: { data?: { error?: string } } }).response?.data?.error || 'Failed to request coverage.';
+        toast.showError(message);
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  if (result) {
+    return (
+      <div className="request-coverage-range-form">
+        <p>Requested coverage for {result.created.length} shift{result.created.length === 1 ? '' : 's'}.</p>
+        {result.skipped.length > 0 && (
+          <>
+            <p>{result.skipped.length} skipped:</p>
+            <ul>
+              {result.skipped.map(s => (
+                <li key={`${s.date}-${s.hour}`}>
+                  {s.date} at {formatHourLabel(s.hour)} — {s.reason}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+        <button type="button" className="btn-primary" onClick={onCancel}>
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="request-coverage-range-form">
+      <div className="request-coverage-range-form__dates">
+        <label htmlFor="coverage-range-start">Start date</label>
+        <input
+          id="coverage-range-start"
+          type="date"
+          value={startDate}
+          min={todayIso()}
+          onChange={e => setStartDate(e.target.value)}
+        />
+        <label htmlFor="coverage-range-end">End date</label>
+        <input
+          id="coverage-range-end"
+          type="date"
+          value={endDate}
+          min={startDate || todayIso()}
+          onChange={e => setEndDate(e.target.value)}
+        />
+      </div>
+
+      {rangeTooLong && (
+        <p className="request-coverage-range-form__warning">Please choose a range of {MAX_RANGE_DAYS} days or fewer.</p>
+      )}
+
+      {candidates.length > 0 && (
+        <>
+          <div className="request-coverage-range-form__select-all">
+            <label>
+              <input type="checkbox" checked={allChecked} onChange={toggleAll} aria-label="Select all" />
+              Select all
+            </label>
+          </div>
+          <ul className="request-coverage-range-form__list">
+            {candidates.map(o => {
+              const key = occurrenceKey(o);
+              const label = `${o.date} — ${formatHourLabel(o.hour)}`;
+              return (
+                <li key={key}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={checkedKeys.has(key)}
+                      onChange={() => toggleOccurrence(key)}
+                      aria-label={label}
+                    />
+                    {label}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {startDate && endDate && !rangeTooLong && candidates.length === 0 && (
+        <p>No recurring shifts fall in that range.</p>
+      )}
+
+      <div className="request-coverage-range-form__actions">
+        <button type="button" className="btn-secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleSubmit}
+          disabled={submitting || rangeTooLong || checkedKeys.size === 0}
+        >
+          {submitting ? 'Requesting…' : 'Request Coverage'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RequestCoverageRangeForm;

--- a/frontend/src/pages/group/RequestCoverageRangeForm.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.tsx
@@ -13,6 +13,14 @@ export interface RequestCoverageRangeFormProps {
 }
 
 const MAX_RANGE_DAYS = 90;
+// Must match maxBatchItems in internal/handlers/schedule_coverage.go's
+// CreateCoverageRequestsBatch - a wide date range with a busy recurring
+// schedule (e.g. 90 days x several shifts/week) can exceed the backend's
+// cap even though it's within MAX_RANGE_DAYS, so this is enforced
+// separately, with the selected count always visible so an over-cap
+// selection is something the user can actually act on rather than a bare
+// rejected-batch error.
+const MAX_BATCH_ITEMS = 200;
 
 interface Occurrence {
   date: string;
@@ -112,6 +120,10 @@ const RequestCoverageRangeForm: React.FC<RequestCoverageRangeFormProps> = ({ gro
       toast.showError('Select at least one shift.');
       return;
     }
+    if (requests.length > MAX_BATCH_ITEMS) {
+      toast.showError(`You can request coverage for at most ${MAX_BATCH_ITEMS} shifts at once.`);
+      return;
+    }
     setSubmitting(true);
     scheduleApi.createCoverageRequestsBatch(groupId, requests)
       .then(res => {
@@ -183,7 +195,15 @@ const RequestCoverageRangeForm: React.FC<RequestCoverageRangeFormProps> = ({ gro
               <input type="checkbox" checked={allChecked} onChange={toggleAll} aria-label="Select all" />
               Select all
             </label>
+            <span className="request-coverage-range-form__count">
+              {checkedKeys.size} selected
+            </span>
           </div>
+          {checkedKeys.size > MAX_BATCH_ITEMS && (
+            <p className="request-coverage-range-form__warning">
+              You can request coverage for at most {MAX_BATCH_ITEMS} shifts at once — uncheck {checkedKeys.size - MAX_BATCH_ITEMS} to continue.
+            </p>
+          )}
           <ul className="request-coverage-range-form__list">
             {candidates.map(o => {
               const key = occurrenceKey(o);
@@ -218,7 +238,7 @@ const RequestCoverageRangeForm: React.FC<RequestCoverageRangeFormProps> = ({ gro
           type="button"
           className="btn-primary"
           onClick={handleSubmit}
-          disabled={submitting || rangeTooLong || checkedKeys.size === 0}
+          disabled={submitting || rangeTooLong || checkedKeys.size === 0 || checkedKeys.size > MAX_BATCH_ITEMS}
         >
           {submitting ? 'Requesting…' : 'Request Coverage'}
         </button>

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -83,3 +83,35 @@
 [data-theme='dark'] .schedule-grid__slot--tier-0 {
   border-color: var(--neutral-300);
 }
+
+.schedule-overview__week-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.schedule-grid__slot--needs-coverage {
+  outline: 2px solid var(--warning);
+  outline-offset: -2px;
+}
+
+.schedule-overview__popover-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.schedule-overview__tag {
+  font-size: 0.75rem;
+  color: var(--warning);
+}
+
+.schedule-overview__action {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -182,18 +182,36 @@ describe('ScheduleOverview', () => {
   });
 
   it('shows a Request coverage button next to the current user\'s own name on a future date', async () => {
-    mockOverview({
-      week_start: '2026-08-09',
-      slots: [
-        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
-          { user_id: 1, username: 'me', status: 'normal' },
-        ] },
-      ],
-    });
-    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+    // The component only renders the currently-displayed week by default
+    // (defaulting to the real current week), and "future" is checked
+    // against the real clock - so a hardcoded fixture date is only
+    // future-and-in-the-rendered-week on some days of the year, and would
+    // start failing permanently once real "today" passes it (or even
+    // sooner, on any day where Tuesday of the current week has already
+    // passed). Pin the clock instead: only `Date` is faked here (not
+    // `setTimeout`/timers), so `findByRole`/`waitFor`'s internal real-timer
+    // polling keeps working, while the component's `currentWeekStart()` and
+    // "is this date in the future" check both resolve against this fixed
+    // Monday - making 2026-08-11 (that Monday's Tuesday) deterministically
+    // future, forever.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z')); // a Monday
+    try {
+      mockOverview({
+        week_start: '2026-08-09',
+        slots: [
+          { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+            { user_id: 1, username: 'me', status: 'normal' },
+          ] },
+        ],
+      });
+      render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
-    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM/i });
-    fireEvent.click(cell);
-    expect(await screen.findByRole('button', { name: /request coverage/i })).toBeInTheDocument();
+      const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM/i });
+      fireEvent.click(cell);
+      expect(await screen.findByRole('button', { name: /request coverage/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -3,12 +3,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ScheduleOverview from './ScheduleOverview';
 import { scheduleApi } from '../../api/client';
 import type { AxiosResponse } from 'axios';
-import type { ScheduleOverviewResponse } from '../../api/client';
+import type { ScheduleOverviewResponse, CoverageRequest } from '../../api/client';
 
 vi.mock('../../api/client', () => ({
   scheduleApi: {
     getOverview: vi.fn(),
+    claimCoverageRequest: vi.fn(),
+    createCoverageRequest: vi.fn(),
   },
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
 }));
 
 function mockOverview(data: ScheduleOverviewResponse) {
@@ -17,21 +23,25 @@ function mockOverview(data: ScheduleOverviewResponse) {
 
 describe('ScheduleOverview', () => {
   beforeEach(() => {
-    mockOverview({ slots: [] });
+    mockOverview({ week_start: '2026-08-09', slots: [] });
   });
 
-  it('loads the overview for the given group on mount', async () => {
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+  it('loads the overview for the given group and week on mount', async () => {
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
     await waitFor(() => expect(scheduleApi.getOverview).toHaveBeenCalledWith(7, expect.objectContaining({ signal: expect.any(AbortSignal) })));
   });
 
   it('renders a tier class proportional to how many members are available', async () => {
     mockOverview({
+      week_start: '2026-08-09',
       slots: [
-        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }, { user_id: 2, username: 'vol2' }] },
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 1, username: 'vol1', status: 'normal' },
+          { user_id: 2, username: 'vol2', status: 'normal' },
+        ] },
       ],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*2 available/i });
     // 2 of 4 members = 50%, falls in the 26-50% tier.
@@ -39,7 +49,7 @@ describe('ScheduleOverview', () => {
   });
 
   it('a cell with nobody available is not clickable and has the zero tier', async () => {
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
     const cell = await screen.findByRole('cell', { name: 'Sun 8:00 AM, 0 available' });
     expect(cell).toHaveClass('schedule-grid__slot--tier-0');
     expect(cell.tagName).not.toBe('BUTTON');
@@ -47,11 +57,14 @@ describe('ScheduleOverview', () => {
 
   it('clicking a non-empty cell opens a popover listing member names', async () => {
     mockOverview({
+      week_start: '2026-08-09',
       slots: [
-        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1', first_name: 'Jane', last_name: 'Doe' }] },
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol1', first_name: 'Jane', last_name: 'Doe', status: 'normal' },
+        ] },
       ],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
     fireEvent.click(cell);
@@ -61,9 +74,10 @@ describe('ScheduleOverview', () => {
 
   it('falls back to username when first/last name are blank', async () => {
     mockOverview({
-      slots: [{ day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }] }],
+      week_start: '2026-08-09',
+      slots: [{ date: '2026-08-11', day_of_week: 2, hour: 9, members: [{ user_id: 2, username: 'vol1', status: 'normal' }] }],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
     fireEvent.click(cell);
@@ -73,11 +87,15 @@ describe('ScheduleOverview', () => {
 
   it('falls back to a data-derived denominator when totalMembers is 0 but slots have members', async () => {
     mockOverview({
+      week_start: '2026-08-09',
       slots: [
-        { day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }, { user_id: 2, username: 'vol2' }] },
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 1, username: 'vol1', status: 'normal' },
+          { user_id: 2, username: 'vol2', status: 'normal' },
+        ] },
       ],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={0} />);
+    render(<ScheduleOverview groupId={7} totalMembers={0} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*2 available/i });
     // totalMembers is 0 (unreliable), so the fallback denominator is derived
@@ -88,9 +106,10 @@ describe('ScheduleOverview', () => {
 
   it('clicking outside the popover closes it', async () => {
     mockOverview({
-      slots: [{ day_of_week: 2, hour: 9, members: [{ user_id: 1, username: 'vol1' }] }],
+      week_start: '2026-08-09',
+      slots: [{ date: '2026-08-11', day_of_week: 2, hour: 9, members: [{ user_id: 2, username: 'vol1', status: 'normal' }] }],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={4} />);
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
     fireEvent.click(cell);
@@ -107,15 +126,17 @@ describe('ScheduleOverview', () => {
     // confirm the popover keeps rendering all members in the DOM (for
     // scrolling to reveal) rather than e.g. truncating the list to fit.
     const members = Array.from({ length: 20 }, (_, i) => ({
-      user_id: i + 1,
+      user_id: i + 2,
       username: `vol${i + 1}`,
       first_name: `Member`,
       last_name: `${i + 1}`,
+      status: 'normal' as const,
     }));
     mockOverview({
-      slots: [{ day_of_week: 2, hour: 9, members }],
+      week_start: '2026-08-09',
+      slots: [{ date: '2026-08-11', day_of_week: 2, hour: 9, members }],
     });
-    render(<ScheduleOverview groupId={7} totalMembers={20} />);
+    render(<ScheduleOverview groupId={7} totalMembers={20} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*20 available/i });
     fireEvent.click(cell);
@@ -123,5 +144,56 @@ describe('ScheduleOverview', () => {
     expect(await screen.findByText('Member 1')).toBeInTheDocument();
     expect(screen.getByText('Member 20')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(20);
+  });
+
+  it('flags a cell with an open coverage request as needing coverage', async () => {
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol2', status: 'needs_coverage', coverage_request_id: 42, claimable: true },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    expect(cell).toHaveClass('schedule-grid__slot--needs-coverage');
+  });
+
+  it('shows a Claim button for another member\'s open request and claims it on click', async () => {
+    vi.mocked(scheduleApi.claimCoverageRequest).mockResolvedValue({ data: {} as CoverageRequest } as AxiosResponse<CoverageRequest>);
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol2', status: 'needs_coverage', coverage_request_id: 42, claimable: true },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+    const claimButton = await screen.findByRole('button', { name: /claim/i });
+    fireEvent.click(claimButton);
+
+    await waitFor(() => expect(scheduleApi.claimCoverageRequest).toHaveBeenCalledWith(7, 42));
+  });
+
+  it('shows a Request coverage button next to the current user\'s own name on a future date', async () => {
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 1, username: 'me', status: 'normal' },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM/i });
+    fireEvent.click(cell);
+    expect(await screen.findByRole('button', { name: /request coverage/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../api/client', () => ({
     getOverview: vi.fn(),
     claimCoverageRequest: vi.fn(),
     createCoverageRequest: vi.fn(),
+    cancelCoverageRequest: vi.fn(),
   },
 }));
 
@@ -213,5 +214,119 @@ describe('ScheduleOverview', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('disables the Request coverage button while its own POST is in flight, so a double-click cannot fire two requests', async () => {
+    // Backend fix: a partial unique index backstops the DB against a
+    // duplicate-request race, but the friendly first line of defense is the
+    // UI never firing a second POST in the first place - mirroring how
+    // handleClaim already guards via busyRequestId. Resolve the mocked
+    // createCoverageRequest call manually so we can assert the disabled
+    // state while the first request is still pending.
+    let resolveCreate: (() => void) | undefined;
+    vi.mocked(scheduleApi.createCoverageRequest).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = () => resolve({ data: {} as CoverageRequest } as AxiosResponse<CoverageRequest>);
+      })
+    );
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z')); // a Monday
+    try {
+      mockOverview({
+        week_start: '2026-08-09',
+        slots: [
+          { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+            { user_id: 1, username: 'me', status: 'normal' },
+          ] },
+        ],
+      });
+      render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+      const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM/i });
+      fireEvent.click(cell);
+      const requestButton = await screen.findByRole('button', { name: /request coverage/i });
+
+      fireEvent.click(requestButton);
+      fireEvent.click(requestButton);
+
+      expect(scheduleApi.createCoverageRequest).toHaveBeenCalledTimes(1);
+      expect(requestButton).toBeDisabled();
+
+      // Flush the pending promise and its .then/.finally chain (which
+      // closes the popover) so no state update leaks past this test.
+      resolveCreate?.();
+      await waitFor(() => expect(requestButton).not.toBeInTheDocument());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renders the Claim button disabled with a tooltip for a conflicting request, instead of hiding it', async () => {
+    // The backend sets claimable = !conflict, so claimable and conflict are
+    // never both true for a needs_coverage entry that isn't the viewer's
+    // own - meaning a render condition gated on `member.claimable` can never
+    // reach the button's own conflict-disabled/tooltip branch. That left a
+    // member with a real scheduling conflict seeing no button and no
+    // explanation at all. The fix drops the claimable gate from visibility
+    // and lets `conflict` continue to drive disabled/tooltip.
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol2', status: 'needs_coverage', coverage_request_id: 42, claimable: false, conflict: true },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+
+    const claimButton = await screen.findByRole('button', { name: /claim/i });
+    expect(claimButton).toBeDisabled();
+    expect(claimButton).toHaveAttribute('title', 'You already have a conflicting shift at this time');
+  });
+
+  it('shows a Cancel request button on the caller\'s own open request and cancels it on click', async () => {
+    // The backend CancelCoverageRequest endpoint and scheduleApi client
+    // method were already fully tested, but nothing in the UI called them -
+    // once a volunteer requested coverage there was no way to undo it. This
+    // covers the minimum viable UI path: the requester's own open
+    // (needs_coverage) row gets a Cancel request button.
+    vi.mocked(scheduleApi.cancelCoverageRequest).mockResolvedValue({ data: {} as CoverageRequest } as AxiosResponse<CoverageRequest>);
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 1, username: 'me', status: 'needs_coverage', coverage_request_id: 99 },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+    const cancelButton = await screen.findByRole('button', { name: /cancel request/i });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(scheduleApi.cancelCoverageRequest).toHaveBeenCalledWith(7, 99));
+  });
+
+  it('does not show a Claim button on the caller\'s own needs_coverage row', async () => {
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 1, username: 'me', status: 'needs_coverage', coverage_request_id: 99 },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+    await screen.findByRole('button', { name: /cancel request/i });
+
+    expect(screen.queryByRole('button', { name: /^claim$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -14,8 +14,10 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
+const mockShowSuccess = vi.fn();
+const mockShowError = vi.fn();
 vi.mock('../../hooks/useToast', () => ({
-  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
 }));
 
 function mockOverview(data: ScheduleOverviewResponse) {
@@ -25,6 +27,8 @@ function mockOverview(data: ScheduleOverviewResponse) {
 describe('ScheduleOverview', () => {
   beforeEach(() => {
     mockOverview({ week_start: '2026-08-09', slots: [] });
+    mockShowSuccess.mockClear();
+    mockShowError.mockClear();
   });
 
   it('loads the overview for the given group and week on mount', async () => {
@@ -310,6 +314,103 @@ describe('ScheduleOverview', () => {
     fireEvent.click(cancelButton);
 
     await waitFor(() => expect(scheduleApi.cancelCoverageRequest).toHaveBeenCalledWith(7, 99));
+  });
+
+  it('shows a Request coverage button for the current user\'s own name on the same day (today counts as future)', async () => {
+    // Backend fix: CreateCoverageRequest now allows same-day-or-later
+    // (date.Before(today) rejects only the past), matching the product
+    // decision that requesting coverage for later today is a normal use
+    // case. The frontend's button-visibility condition changed from
+    // `date > today` to `date >= today` to match - this pins the clock to
+    // exactly the slot's own date/time so `date === today` is exercised.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-11T12:00:00Z')); // the Tuesday itself
+    try {
+      mockOverview({
+        week_start: '2026-08-09',
+        slots: [
+          { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+            { user_id: 1, username: 'me', status: 'normal' },
+          ] },
+        ],
+      });
+      render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+      const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM/i });
+      fireEvent.click(cell);
+      expect(await screen.findByRole('button', { name: /request coverage/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('disables every Claim button in the popover while any claim is in flight, not just the one clicked', async () => {
+    // Backend hardening: idx_coverage_request_claimed_unique now backstops
+    // the DB against the same user claiming two different requests at the
+    // same (date, hour), but the UI previously only disabled the specific
+    // button clicked (busyRequestId === member.coverage_request_id), so a
+    // second Claim button in the same popover stayed clickable while the
+    // first claim was still in flight.
+    let resolveClaim: (() => void) | undefined;
+    vi.mocked(scheduleApi.claimCoverageRequest).mockReturnValue(
+      new Promise((resolve) => {
+        resolveClaim = () => resolve({ data: {} as CoverageRequest } as AxiosResponse<CoverageRequest>);
+      })
+    );
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol2', status: 'needs_coverage', coverage_request_id: 42, claimable: true },
+          { user_id: 3, username: 'vol3', status: 'needs_coverage', coverage_request_id: 43, claimable: true },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+    const claimButtons = await screen.findAllByRole('button', { name: /claim/i });
+    expect(claimButtons).toHaveLength(2);
+
+    const overviewCallsBefore = vi.mocked(scheduleApi.getOverview).mock.calls.length;
+    fireEvent.click(claimButtons[0]);
+
+    expect(claimButtons[0]).toBeDisabled();
+    expect(claimButtons[1]).toBeDisabled();
+
+    resolveClaim?.();
+    await waitFor(() => expect(vi.mocked(scheduleApi.getOverview).mock.calls.length).toBe(overviewCallsBefore + 1));
+  });
+
+  it('surfaces the backend error message when a claim fails, and reloads the overview', async () => {
+    // Established codebase convention (see GroupPage.tsx, Settings.tsx):
+    // surface err.response.data.error over a generic fallback string, and
+    // reload data on failure so the UI doesn't show a stale state (e.g. a
+    // claim that silently failed but still looks available).
+    vi.mocked(scheduleApi.claimCoverageRequest).mockRejectedValue({
+      response: { data: { error: 'Request is no longer open' } },
+    });
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [
+        { date: '2026-08-11', day_of_week: 2, hour: 9, members: [
+          { user_id: 2, username: 'vol2', status: 'needs_coverage', coverage_request_id: 42, claimable: true },
+        ] },
+      ],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /needs coverage/i });
+    fireEvent.click(cell);
+    const claimButton = await screen.findByRole('button', { name: /claim/i });
+    const overviewCallsBefore = vi.mocked(scheduleApi.getOverview).mock.calls.length;
+    fireEvent.click(claimButton);
+
+    await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('Request is no longer open'));
+    // The catch block calls loadOverview() so a failed claim doesn't leave
+    // stale UI state (e.g. a button that stays disabled-looking).
+    await waitFor(() => expect(vi.mocked(scheduleApi.getOverview).mock.calls.length).toBe(overviewCallsBefore + 1));
   });
 
   it('does not show a Claim button on the caller\'s own needs_coverage row', async () => {

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -137,6 +137,12 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null);
   const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null);
   const [busyRequestId, setBusyRequestId] = useState<number | null>(null);
+  // Guards handleRequestCoverage the same way busyRequestId guards
+  // handleClaim/handleCancelRequest: keyed by the (date, hour) slot key so
+  // the "Request coverage" button for the in-flight cell disables itself
+  // mid-request, preventing a double-click from firing two concurrent
+  // POSTs (which the DB-level unique index would otherwise let race).
+  const [busyRequestSlotKey, setBusyRequestSlotKey] = useState<string | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   // Cancels any in-flight request before starting a new one - matching
@@ -227,7 +233,21 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
       .finally(() => setBusyRequestId(null));
   };
 
-  const handleRequestCoverage = (date: string, hour: number) => {
+  const handleCancelRequest = (requestId: number) => {
+    setBusyRequestId(requestId);
+    scheduleApi.cancelCoverageRequest(groupId, requestId)
+      .then(() => {
+        toast.showSuccess('Coverage request cancelled.');
+        setActiveCellKey(null);
+        setPopoverPosition(null);
+        loadOverview();
+      })
+      .catch(() => toast.showError('Failed to cancel coverage request.'))
+      .finally(() => setBusyRequestId(null));
+  };
+
+  const handleRequestCoverage = (slotKeyValue: string, date: string, hour: number) => {
+    setBusyRequestSlotKey(slotKeyValue);
     scheduleApi.createCoverageRequest(groupId, { date, hour })
       .then(() => {
         toast.showSuccess('Coverage requested.');
@@ -235,7 +255,8 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
         setPopoverPosition(null);
         loadOverview();
       })
-      .catch(() => toast.showError('Failed to request coverage.'));
+      .catch(() => toast.showError('Failed to request coverage.'))
+      .finally(() => setBusyRequestSlotKey(null));
   };
 
   if (loading) {
@@ -334,7 +355,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                               {member.status === 'needs_coverage' && <span className="schedule-overview__tag"> needs coverage</span>}
                               {member.status === 'covering' && <span className="schedule-overview__tag"> covering</span>}
                             </span>
-                            {member.status === 'needs_coverage' && member.claimable && member.coverage_request_id !== undefined && (
+                            {member.status === 'needs_coverage' && member.coverage_request_id !== undefined && member.user_id !== currentUserId && (
                               <button
                                 type="button"
                                 className="btn-secondary schedule-overview__action"
@@ -349,9 +370,20 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                               <button
                                 type="button"
                                 className="btn-secondary schedule-overview__action"
-                                onClick={() => handleRequestCoverage(date, hour)}
+                                disabled={busyRequestSlotKey === key}
+                                onClick={() => handleRequestCoverage(key, date, hour)}
                               >
                                 Request coverage
+                              </button>
+                            )}
+                            {member.user_id === currentUserId && member.status === 'needs_coverage' && member.coverage_request_id !== undefined && (
+                              <button
+                                type="button"
+                                className="btn-secondary schedule-overview__action"
+                                disabled={busyRequestId === member.coverage_request_id}
+                                onClick={() => handleCancelRequest(member.coverage_request_id as number)}
+                              >
+                                Cancel request
                               </button>
                             )}
                           </li>

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { scheduleApi } from '../../api/client';
 import type { ScheduleOverviewMember } from '../../api/client';
+import { useToast } from '../../hooks/useToast';
 import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
@@ -11,6 +12,7 @@ import './ScheduleOverview.css';
 export interface ScheduleOverviewProps {
   groupId: number;
   totalMembers: number;
+  currentUserId: number;
 }
 
 function memberDisplayName(member: ScheduleOverviewMember): string {
@@ -83,20 +85,66 @@ function tierFor(count: number, totalMembers: number): number {
   return 4;
 }
 
-const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembers }) => {
+// dateForWeekStart returns the ISO date (YYYY-MM-DD) for the given offset
+// (0-6) within the week starting at weekStart. Computed via UTC-anchored
+// Date arithmetic (rather than local-time Date parsing) so DST transitions
+// in the viewer's timezone can never shift the result by a day.
+function dateForWeekStart(weekStart: string, dayOfWeek: number): string {
+  const [y, m, d] = weekStart.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, d));
+  start.setUTCDate(start.getUTCDate() + dayOfWeek);
+  return start.toISOString().slice(0, 10);
+}
+
+function addDays(isoDate: string, days: number): string {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function formatWeekLabel(weekStart: string): string {
+  const start = new Date(`${weekStart}T00:00:00Z`);
+  const end = new Date(`${addDays(weekStart, 6)}T00:00:00Z`);
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', timeZone: 'UTC' };
+  return `Week of ${start.toLocaleDateString(undefined, opts)} – ${end.toLocaleDateString(undefined, opts)}`;
+}
+
+// currentWeekStart returns the ISO date (YYYY-MM-DD) of the Sunday that
+// starts "this week" in the viewer's local timezone.
+function currentWeekStart(): string {
+  const now = new Date();
+  const utcToday = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+  utcToday.setUTCDate(utcToday.getUTCDate() - utcToday.getUTCDay());
+  return utcToday.toISOString().slice(0, 10);
+}
+
+// todayIso returns "today" (viewer's local date) as an ISO YYYY-MM-DD
+// string, for comparing against slot dates (which are also plain
+// YYYY-MM-DD, with no time component) to decide whether a date is in the
+// future.
+function todayIso(): string {
+  const now = new Date();
+  return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())).toISOString().slice(0, 10);
+}
+
+const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembers, currentUserId }) => {
+  const toast = useToast();
+  const [weekStart, setWeekStart] = useState<string>(currentWeekStart());
   const [membersBySlot, setMembersBySlot] = useState<Map<string, ScheduleOverviewMember[]>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null);
   const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null);
+  const [busyRequestId, setBusyRequestId] = useState<number | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   // Cancels any in-flight request before starting a new one - matching
   // ScheduleTab.tsx's loadSchedule AbortController pattern - so both the
-  // initial mount fetch and a user-triggered retry go through the same
-  // ref-guarded controller: whichever request is superseded gets aborted,
-  // and only the request still current when it finishes is allowed to
-  // clear `loading`.
+  // initial mount fetch and a user-triggered retry (or week navigation) go
+  // through the same ref-guarded controller: whichever request is
+  // superseded gets aborted, and only the request still current when it
+  // finishes is allowed to clear `loading`.
   const loadAbortControllerRef = useRef<AbortController | null>(null);
   const loadOverview = useCallback(() => {
     loadAbortControllerRef.current?.abort();
@@ -105,7 +153,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
 
     setLoading(true);
     setError(null);
-    scheduleApi.getOverview(groupId, { signal: controller.signal })
+    scheduleApi.getOverview(groupId, { weekStart, signal: controller.signal })
       .then(res => {
         const map = new Map<string, ScheduleOverviewMember[]>();
         res.data.slots.forEach(slot => {
@@ -122,7 +170,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
           setLoading(false);
         }
       });
-  }, [groupId]);
+  }, [groupId, weekStart]);
 
   useEffect(() => {
     loadOverview();
@@ -135,6 +183,14 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
       loadAbortControllerRef.current?.abort();
     };
   }, []);
+
+  // Changing weeks invalidates whatever cell was open (its data belongs to
+  // the previous week), so close the popover to avoid showing stale
+  // members/actions against the wrong date.
+  useEffect(() => {
+    setActiveCellKey(null);
+    setPopoverPosition(null);
+  }, [weekStart]);
 
   useEffect(() => {
     if (activeCellKey === null) return;
@@ -158,6 +214,30 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
     };
   }, [activeCellKey]);
 
+  const handleClaim = (requestId: number) => {
+    setBusyRequestId(requestId);
+    scheduleApi.claimCoverageRequest(groupId, requestId)
+      .then(() => {
+        toast.showSuccess('Shift claimed.');
+        setActiveCellKey(null);
+        setPopoverPosition(null);
+        loadOverview();
+      })
+      .catch(() => toast.showError('Failed to claim shift.'))
+      .finally(() => setBusyRequestId(null));
+  };
+
+  const handleRequestCoverage = (date: string, hour: number) => {
+    scheduleApi.createCoverageRequest(groupId, { date, hour })
+      .then(() => {
+        toast.showSuccess('Coverage requested.');
+        setActiveCellKey(null);
+        setPopoverPosition(null);
+        loadOverview();
+      })
+      .catch(() => toast.showError('Failed to request coverage.'));
+  };
+
   if (loading) {
     return <SkeletonLoader variant="card" count={1} />;
   }
@@ -175,14 +255,26 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
     ? totalMembers
     : Math.max(0, ...Array.from(membersBySlot.values()).map(m => m.length));
 
+  const today = todayIso();
+
   return (
     <div className="schedule-overview">
+      <div className="schedule-overview__week-nav">
+        <button type="button" className="btn-secondary" onClick={() => setWeekStart(addDays(weekStart, -7))} aria-label="Previous week">
+          ◀
+        </button>
+        <span>{formatWeekLabel(weekStart)}</span>
+        <button type="button" className="btn-secondary" onClick={() => setWeekStart(addDays(weekStart, 7))} aria-label="Next week">
+          ▶
+        </button>
+      </div>
+
       <div className="schedule-grid" role="table" aria-label="Weekly availability overview">
         <div className="schedule-grid__row schedule-grid__row--header" role="row">
           <div className="schedule-grid__cell schedule-grid__cell--corner" role="columnheader" />
-          {DAYS.map(day => (
+          {DAYS.map((day, dayOfWeek) => (
             <div key={day} className="schedule-grid__cell schedule-grid__cell--header" role="columnheader">
-              {day}
+              {day} {new Date(`${dateForWeekStart(weekStart, dayOfWeek)}T00:00:00Z`).getUTCDate()}
             </div>
           ))}
         </div>
@@ -195,7 +287,9 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
               const key = slotKey(dayOfWeek, hour);
               const members = membersBySlot.get(key) ?? [];
               const tier = tierFor(members.length, effectiveTotal);
-              const label = `${DAYS[dayOfWeek]} ${formatHourLabel(hour)}, ${members.length} available`;
+              const date = dateForWeekStart(weekStart, dayOfWeek);
+              const needsCoverage = members.some(m => m.status === 'needs_coverage');
+              const label = `${DAYS[dayOfWeek]} ${formatHourLabel(hour)}, ${members.length} available${needsCoverage ? ', needs coverage' : ''}`;
               const isActive = activeCellKey === key;
 
               if (members.length === 0) {
@@ -215,7 +309,7 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                     type="button"
                     role="cell"
                     aria-label={label}
-                    className={`schedule-grid__slot schedule-grid__slot--tier-${tier}`}
+                    className={`schedule-grid__slot schedule-grid__slot--tier-${tier}${needsCoverage ? ' schedule-grid__slot--needs-coverage' : ''}`}
                     onClick={(event) => {
                       if (isActive) {
                         setActiveCellKey(null);
@@ -234,7 +328,33 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                     >
                       <ul>
                         {members.map(member => (
-                          <li key={member.user_id}>{memberDisplayName(member)}</li>
+                          <li key={member.user_id} className="schedule-overview__popover-row">
+                            <span>
+                              {memberDisplayName(member)}
+                              {member.status === 'needs_coverage' && <span className="schedule-overview__tag"> needs coverage</span>}
+                              {member.status === 'covering' && <span className="schedule-overview__tag"> covering</span>}
+                            </span>
+                            {member.status === 'needs_coverage' && member.claimable && member.coverage_request_id !== undefined && (
+                              <button
+                                type="button"
+                                className="btn-secondary schedule-overview__action"
+                                disabled={busyRequestId === member.coverage_request_id || member.conflict}
+                                title={member.conflict ? 'You already have a conflicting shift at this time' : undefined}
+                                onClick={() => handleClaim(member.coverage_request_id as number)}
+                              >
+                                Claim
+                              </button>
+                            )}
+                            {member.user_id === currentUserId && member.status === 'normal' && date > today && (
+                              <button
+                                type="button"
+                                className="btn-secondary schedule-overview__action"
+                                onClick={() => handleRequestCoverage(date, hour)}
+                              >
+                                Request coverage
+                              </button>
+                            )}
+                          </li>
                         ))}
                       </ul>
                     </div>

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -119,13 +119,11 @@ function currentWeekStart(): string {
   return utcToday.toISOString().slice(0, 10);
 }
 
-// todayIso returns "today" (viewer's local date) as an ISO YYYY-MM-DD
-// string, for comparing against slot dates (which are also plain
-// YYYY-MM-DD, with no time component) to decide whether a date is in the
-// future.
+// todayIso returns "today" (UTC calendar date, matching the backend's
+// same-day-or-later check in CreateCoverageRequest) as an ISO YYYY-MM-DD
+// string, for comparing against slot dates.
 function todayIso(): string {
-  const now = new Date();
-  return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())).toISOString().slice(0, 10);
+  return new Date().toISOString().slice(0, 10);
 }
 
 const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembers, currentUserId }) => {
@@ -229,7 +227,10 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
         setPopoverPosition(null);
         loadOverview();
       })
-      .catch(() => toast.showError('Failed to claim shift.'))
+      .catch(err => {
+        toast.showError(err.response?.data?.error || 'Failed to claim shift.');
+        loadOverview();
+      })
       .finally(() => setBusyRequestId(null));
   };
 
@@ -242,7 +243,10 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
         setPopoverPosition(null);
         loadOverview();
       })
-      .catch(() => toast.showError('Failed to cancel coverage request.'))
+      .catch(err => {
+        toast.showError(err.response?.data?.error || 'Failed to cancel coverage request.');
+        loadOverview();
+      })
       .finally(() => setBusyRequestId(null));
   };
 
@@ -255,7 +259,10 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
         setPopoverPosition(null);
         loadOverview();
       })
-      .catch(() => toast.showError('Failed to request coverage.'))
+      .catch(err => {
+        toast.showError(err.response?.data?.error || 'Failed to request coverage.');
+        loadOverview();
+      })
       .finally(() => setBusyRequestSlotKey(null));
   };
 
@@ -359,14 +366,14 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                               <button
                                 type="button"
                                 className="btn-secondary schedule-overview__action"
-                                disabled={busyRequestId === member.coverage_request_id || member.conflict}
+                                disabled={busyRequestId !== null || member.conflict}
                                 title={member.conflict ? 'You already have a conflicting shift at this time' : undefined}
                                 onClick={() => handleClaim(member.coverage_request_id as number)}
                               >
                                 Claim
                               </button>
                             )}
-                            {member.user_id === currentUserId && member.status === 'normal' && date > today && (
+                            {member.user_id === currentUserId && member.status === 'normal' && date >= today && (
                               <button
                                 type="button"
                                 className="btn-secondary schedule-overview__action"

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -205,36 +205,49 @@ describe('ScheduleTab', () => {
     // not the live, possibly-unsaved grid selection - otherwise the form
     // pre-checks occurrences the backend will just skip (unsaved additions)
     // or silently drops real shifts (unsaved removals).
-    vi.mocked(scheduleApi.getMine).mockResolvedValue({
-      data: { slots: [{ day_of_week: 2, hour: 9 }] }, // Tuesday 9am, persisted
-    } as unknown as AxiosResponse<ScheduleResponse>);
+    //
+    // The assertions below depend on 2026-08-11/2026-08-12 being real
+    // "today or later" occurrences (computeCandidateOccurrences drops
+    // anything before today), so the system clock is pinned here - matching
+    // RequestCoverageRangeForm.test.tsx's convention - rather than relying
+    // on the real wall clock, which would make this test start failing the
+    // day after the pinned date.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    try {
+      vi.mocked(scheduleApi.getMine).mockResolvedValue({
+        data: { slots: [{ day_of_week: 2, hour: 9 }] }, // Tuesday 9am, persisted
+      } as unknown as AxiosResponse<ScheduleResponse>);
 
-    render(
-      <ToastProvider>
-        <ScheduleTab groupId={7} canManageMembers={false} currentUserId={1} />
-      </ToastProvider>
-    );
-    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+      render(
+        <ToastProvider>
+          <ScheduleTab groupId={7} canManageMembers={false} currentUserId={1} />
+        </ToastProvider>
+      );
+      await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
 
-    // Toggle on an additional, unsaved cell (Wednesday 10am) without saving.
-    const unsavedCell = await screen.findByRole('cell', { name: 'Wed 10:00 AM' });
-    fireEvent.click(unsavedCell);
-    expect(unsavedCell).toHaveAttribute('aria-pressed', 'true');
+      // Toggle on an additional, unsaved cell (Wednesday 10am) without saving.
+      const unsavedCell = await screen.findByRole('cell', { name: 'Wed 10:00 AM' });
+      fireEvent.click(unsavedCell);
+      expect(unsavedCell).toHaveAttribute('aria-pressed', 'true');
 
-    fireEvent.click(screen.getByRole('button', { name: /request coverage for a date range/i }));
-    await screen.findByRole('dialog');
+      fireEvent.click(screen.getByRole('button', { name: /request coverage for a date range/i }));
+      await screen.findByRole('dialog');
 
-    // Pick a date range spanning the persisted Tuesday slot's one occurrence
-    // (2026-08-11) and the unsaved Wednesday toggle's occurrence the next
-    // day (2026-08-12).
-    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
-    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-12' } });
+      // Pick a date range spanning the persisted Tuesday slot's one occurrence
+      // (2026-08-11) and the unsaved Wednesday toggle's occurrence the next
+      // day (2026-08-12).
+      fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+      fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-12' } });
 
-    // Only the persisted Tuesday 9am occurrence should be offered - the
-    // unsaved Wednesday 10am toggle must not appear as a candidate.
-    const candidates = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
-    expect(candidates).toHaveLength(1);
-    expect(screen.getByRole('checkbox', { name: /9:00 AM/ })).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: /10:00 AM/ })).not.toBeInTheDocument();
+      // Only the persisted Tuesday 9am occurrence should be offered - the
+      // unsaved Wednesday 10am toggle must not appear as a candidate.
+      const candidates = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+      expect(candidates).toHaveLength(1);
+      expect(screen.getByRole('checkbox', { name: /9:00 AM/ })).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /10:00 AM/ })).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -196,4 +196,45 @@ describe('ScheduleTab', () => {
     fireEvent.change(screen.getByLabelText(/viewing schedule for/i), { target: { value: '2' } });
     await waitFor(() => expect(screen.queryByRole('button', { name: /request coverage for a date range/i })).not.toBeInTheDocument());
   });
+
+  it('offers the request-coverage form only the persisted schedule, not an unsaved toggle', async () => {
+    // Regression test: the "Request Coverage for a Date Range" button sits
+    // directly below "Save Schedule", so "toggle a cell, then open Request
+    // Coverage without saving" is a natural flow. The form's candidate list
+    // must reflect only what's actually persisted server-side (savedSlots),
+    // not the live, possibly-unsaved grid selection - otherwise the form
+    // pre-checks occurrences the backend will just skip (unsaved additions)
+    // or silently drops real shifts (unsaved removals).
+    vi.mocked(scheduleApi.getMine).mockResolvedValue({
+      data: { slots: [{ day_of_week: 2, hour: 9 }] }, // Tuesday 9am, persisted
+    } as unknown as AxiosResponse<ScheduleResponse>);
+
+    render(
+      <ToastProvider>
+        <ScheduleTab groupId={7} canManageMembers={false} currentUserId={1} />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+
+    // Toggle on an additional, unsaved cell (Wednesday 10am) without saving.
+    const unsavedCell = await screen.findByRole('cell', { name: 'Wed 10:00 AM' });
+    fireEvent.click(unsavedCell);
+    expect(unsavedCell).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: /request coverage for a date range/i }));
+    await screen.findByRole('dialog');
+
+    // Pick a date range spanning the persisted Tuesday slot's one occurrence
+    // (2026-08-11) and the unsaved Wednesday toggle's occurrence the next
+    // day (2026-08-12).
+    fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2026-08-11' } });
+    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: '2026-08-12' } });
+
+    // Only the persisted Tuesday 9am occurrence should be offered - the
+    // unsaved Wednesday 10am toggle must not appear as a candidate.
+    const candidates = await screen.findAllByRole('checkbox', { name: /2026-08-\d{2}/ });
+    expect(candidates).toHaveLength(1);
+    expect(screen.getByRole('checkbox', { name: /9:00 AM/ })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /10:00 AM/ })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -168,4 +168,32 @@ describe('ScheduleTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /individual/i }));
     expect(await screen.findByLabelText(/viewing schedule for/i)).toBeInTheDocument();
   });
+
+  it('opens the bulk request-coverage form when viewing my own schedule, and hides it when viewing another member\'s', async () => {
+    vi.mocked(scheduleApi.getMine).mockResolvedValue({
+      data: { slots: [{ day_of_week: 2, hour: 9 }] },
+    } as unknown as AxiosResponse<ScheduleResponse>);
+    vi.mocked(groupsApi.getMembers).mockResolvedValue({
+      data: [{ user_id: 2, username: 'vol2', is_group_admin: false, is_site_admin: false, email: '', skill_tags: [] }],
+    } as unknown as AxiosResponse<GroupMember[]>);
+    vi.mocked(scheduleApi.getForMember).mockResolvedValue({
+      data: { slots: [] },
+    } as unknown as AxiosResponse<ScheduleResponse>);
+
+    render(
+      <ToastProvider>
+        <ScheduleTab groupId={7} canManageMembers={true} currentUserId={1} />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /request coverage for a date range/i })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /request coverage for a date range/i }));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+
+    // Closing and switching to another member's schedule hides the button.
+    fireEvent.click(screen.getByRole('button', { name: /close modal/i }));
+    fireEvent.change(screen.getByLabelText(/viewing schedule for/i), { target: { value: '2' } });
+    await waitFor(() => expect(screen.queryByRole('button', { name: /request coverage for a date range/i })).not.toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../api/client', () => ({
 function renderScheduleTab(canManageMembers: boolean) {
   return render(
     <ToastProvider>
-      <ScheduleTab groupId={1} canManageMembers={canManageMembers} />
+      <ScheduleTab groupId={1} canManageMembers={canManageMembers} currentUserId={1} />
     </ToastProvider>
   );
 }
@@ -114,7 +114,7 @@ describe('ScheduleTab', () => {
 
     const { rerender } = render(
       <ToastProvider>
-        <ScheduleTab groupId={1} canManageMembers={false} />
+        <ScheduleTab groupId={1} canManageMembers={false} currentUserId={1} />
       </ToastProvider>
     );
 
@@ -124,7 +124,7 @@ describe('ScheduleTab', () => {
     // Switching to a new group before the first request resolves must abort it.
     rerender(
       <ToastProvider>
-        <ScheduleTab groupId={2} canManageMembers={false} />
+        <ScheduleTab groupId={2} canManageMembers={false} currentUserId={1} />
       </ToastProvider>
     );
     await waitFor(() => expect(capturedFirstSignal?.aborted).toBe(true));
@@ -142,10 +142,13 @@ describe('ScheduleTab', () => {
     expect(screen.getByRole('cell', { name: 'Sun 8:00 AM' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('does not show the individual/overview toggle for a non-admin member', async () => {
-    renderScheduleTab(false);
-    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
-    expect(screen.queryByRole('button', { name: /overview/i })).not.toBeInTheDocument();
+  it('shows the Individual/Overview toggle for non-admin members too', async () => {
+    render(
+      <ToastProvider>
+        <ScheduleTab groupId={7} canManageMembers={false} currentUserId={1} />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(screen.getByRole('group', { name: /schedule view/i })).toBeInTheDocument());
   });
 
   it('a group admin can switch to the overview and back to individual view', async () => {

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { scheduleApi, groupsApi } from '../../api/client';
-import type { GroupMember } from '../../api/client';
+import type { GroupMember, ScheduleSlot } from '../../api/client';
 import { useToast } from '../../hooks/useToast';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
@@ -22,6 +22,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
   const [members, setMembers] = useState<GroupMember[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [selectedSlots, setSelectedSlots] = useState<Set<string>>(new Set());
+  const [savedSlots, setSavedSlots] = useState<ScheduleSlot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -47,6 +48,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
     request
       .then(res => {
         setSelectedSlots(new Set(res.data.slots.map(s => slotKey(s.day_of_week, s.hour))));
+        setSavedSlots(res.data.slots);
       })
       .catch(err => {
         if (axios.isCancel(err)) return;
@@ -103,7 +105,10 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
       ? scheduleApi.updateMine(groupId, slots)
       : scheduleApi.updateForMember(groupId, selectedUserId, slots);
     request
-      .then(() => toast.showSuccess('Schedule saved.'))
+      .then(() => {
+        toast.showSuccess('Schedule saved.');
+        setSavedSlots(slots.map(s => ({ day_of_week: s.day_of_week, hour: s.hour })));
+      })
       .catch(() => toast.showError('Failed to save schedule.'))
       .finally(() => setSaving(false));
   };
@@ -213,11 +218,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
       >
         <RequestCoverageRangeForm
           groupId={groupId}
-          slots={Array.from(selectedSlots).map(key => {
-            const [dayOfWeek, hour] = key.split('-').map(Number);
-            return { day_of_week: dayOfWeek, hour };
-          })}
-          onSuccess={() => setShowRequestRangeModal(false)}
+          slots={savedSlots}
           onCancel={() => setShowRequestRangeModal(false)}
         />
       </Modal>

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -12,9 +12,10 @@ import './ScheduleTab.css';
 export interface ScheduleTabProps {
   groupId: number;
   canManageMembers: boolean;
+  currentUserId: number;
 }
 
-const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) => {
+const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, currentUserId }) => {
   const toast = useToast();
   const [members, setMembers] = useState<GroupMember[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
@@ -71,11 +72,10 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) 
   }, []);
 
   useEffect(() => {
-    if (!canManageMembers) return;
     groupsApi.getMembers(groupId)
       .then(res => setMembers(res.data))
-      .catch(() => { /* picker just won't populate; own-schedule view still works */ });
-  }, [groupId, canManageMembers]);
+      .catch(() => { /* picker/overview member count just won't populate; own-schedule view still works */ });
+  }, [groupId]);
 
   const toggleSlot = (dayOfWeek: number, hour: number) => {
     setSelectedSlots(prev => {
@@ -115,27 +115,25 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers }) 
 
   return (
     <div className="schedule-tab">
-      {canManageMembers && (
-        <div className="schedule-tab__view-toggle" role="group" aria-label="Schedule view">
-          <button
-            type="button"
-            className={viewMode === 'individual' ? 'btn-primary' : 'btn-secondary'}
-            onClick={() => setViewMode('individual')}
-          >
-            Individual
-          </button>
-          <button
-            type="button"
-            className={viewMode === 'overview' ? 'btn-primary' : 'btn-secondary'}
-            onClick={() => setViewMode('overview')}
-          >
-            Overview
-          </button>
-        </div>
-      )}
+      <div className="schedule-tab__view-toggle" role="group" aria-label="Schedule view">
+        <button
+          type="button"
+          className={viewMode === 'individual' ? 'btn-primary' : 'btn-secondary'}
+          onClick={() => setViewMode('individual')}
+        >
+          Individual
+        </button>
+        <button
+          type="button"
+          className={viewMode === 'overview' ? 'btn-primary' : 'btn-secondary'}
+          onClick={() => setViewMode('overview')}
+        >
+          Overview
+        </button>
+      </div>
 
-      {viewMode === 'overview' && canManageMembers ? (
-        <ScheduleOverview groupId={groupId} totalMembers={members.length} />
+      {viewMode === 'overview' ? (
+        <ScheduleOverview groupId={groupId} totalMembers={members.length} currentUserId={currentUserId} />
       ) : (
         <>
           {canManageMembers && (

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -6,6 +6,8 @@ import { useToast } from '../../hooks/useToast';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
 import ScheduleOverview from './ScheduleOverview';
+import Modal from '../../components/Modal';
+import RequestCoverageRangeForm from './RequestCoverageRangeForm';
 import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
 import './ScheduleTab.css';
 
@@ -24,6 +26,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [viewMode, setViewMode] = useState<'individual' | 'overview'>('individual');
+  const [showRequestRangeModal, setShowRequestRangeModal] = useState(false);
 
   // Cancels any in-flight request before starting a new one - matching
   // GroupPage.tsx's loadAnimals/loadActivityFeed AbortController pattern -
@@ -190,8 +193,34 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
           <button type="button" className="btn-primary schedule-tab__save" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving…' : 'Save Schedule'}
           </button>
+
+          {selectedUserId === null && (
+            <button
+              type="button"
+              className="btn-secondary schedule-tab__request-range"
+              onClick={() => setShowRequestRangeModal(true)}
+            >
+              Request Coverage for a Date Range
+            </button>
+          )}
         </>
       )}
+
+      <Modal
+        isOpen={showRequestRangeModal}
+        onClose={() => setShowRequestRangeModal(false)}
+        title="Request Coverage for a Date Range"
+      >
+        <RequestCoverageRangeForm
+          groupId={groupId}
+          slots={Array.from(selectedSlots).map(key => {
+            const [dayOfWeek, hour] = key.split('-').map(Number);
+            return { day_of_week: dayOfWeek, hour };
+          })}
+          onSuccess={() => setShowRequestRangeModal(false)}
+          onCancel={() => setShowRequestRangeModal(false)}
+        />
+      </Modal>
     </div>
   );
 };

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -46,6 +46,16 @@ const vectorEmbeddingDimension = 1024
 // exactly once before any of them read a single row. SQLite (used by every
 // other test) doesn't exhibit this driver behavior, which is why this went
 // undetected until a real Postgres run.
+//
+// pgx does offer a narrower, connection-scoped fix (registering a
+// TimestamptzCodec with ScanLocation: time.UTC on the type map), which
+// would avoid this process-global mutation - deliberately not used here
+// because it requires building an explicit pgx connector instead of
+// `postgres.Open(dsn)`, and the *_postgres_test.go files each call
+// gorm.Open(postgres.Open(dsn), ...) directly, so they'd need that same
+// connector wiring duplicated rather than getting the fix for free via
+// this package's init(). See TestLocalTimeIsUTC in database_test.go for
+// the (non-Postgres, always-run) regression guard for this line.
 func init() {
 	time.Local = time.UTC
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -700,6 +700,27 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created partial unique index idx_coverage_request_active_unique")
 	}
 
+	// Partial unique index backstopping the app-level check-then-write logic
+	// in ClaimCoverageRequest against a race between two concurrent claims by
+	// the SAME user for two DIFFERENT open requests at the same (date, hour):
+	// that check is a plain count-then-write across different rows (not a
+	// conditional update gated on a single row's state, unlike the per-
+	// request claim itself), so under READ COMMITTED (Postgres in
+	// production) both claims can pass the check and both succeed. This
+	// index rejects the second claim at the DB level as a last line of
+	// defense. Scoped to claimed rows only, so an open or cancelled request
+	// never counts against it.
+	coverageRequestClaimedUniqueIndexQuery := `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_coverage_request_claimed_unique
+		ON shift_coverage_requests (claimed_by_user_id, date, hour)
+		WHERE status = 'claimed'
+	`
+	if err := db.Exec(coverageRequestClaimedUniqueIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create partial unique index idx_coverage_request_claimed_unique")
+	} else {
+		logging.Info("Created partial unique index idx_coverage_request_claimed_unique")
+	}
+
 	logging.Info("Custom indexes creation completed")
 	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -681,6 +681,25 @@ func createCustomIndexes(db *gorm.DB) error {
 		logging.Info("Created index idx_animal_comments_animal_deleted_created")
 	}
 
+	// Partial unique index backstopping the app-level check-then-create logic
+	// in CreateCoverageRequest against a race under READ COMMITTED (Postgres
+	// in production): a transaction alone doesn't make that check-then-insert
+	// atomic, so two concurrent creates for the same (group, user, date,
+	// hour) can both pass the app-level check and both insert. This index
+	// rejects the second insert at the DB level as a last line of defense.
+	// Scoped to non-cancelled rows so a cancelled request never blocks a
+	// fresh one for the same slot.
+	coverageRequestActiveUniqueIndexQuery := `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_coverage_request_active_unique
+		ON shift_coverage_requests (group_id, requested_by_user_id, date, hour)
+		WHERE status <> 'cancelled'
+	`
+	if err := db.Exec(coverageRequestActiveUniqueIndexQuery).Error; err != nil {
+		logging.WithField("error", err.Error()).Warn("Failed to create partial unique index on shift_coverage_requests")
+	} else {
+		logging.Info("Created partial unique index idx_coverage_request_active_unique")
+	}
+
 	logging.Info("Custom indexes creation completed")
 	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -28,6 +28,28 @@ import (
 // only needs updating in two places instead of four.
 const vectorEmbeddingDimension = 1024
 
+// gorm.io/driver/postgres (via pgx) decodes `timestamptz` columns into
+// time.Time using time.Local, not UTC - so without this, any date/time
+// value read back from Postgres comes back shifted to whatever the
+// OS/container's local timezone is, silently breaking any .Format()/
+// .Weekday() call on it (e.g. ShiftCoverageRequest.Date's date-keyed
+// lookups in GetGroupScheduleOverview, notification content, weekday-based
+// conflict checks) whenever that local timezone isn't already UTC. This
+// codebase's date/time handling is UTC-anchored throughout by design (see
+// e.g. ShiftSlot's day-of-week convention) - this makes that actually true
+// for every timestamptz read, not just freshly-parsed values.
+//
+// An init() (rather than a line in cmd/api/main.go) so every path that
+// touches Postgres gets it - the production binary, cmd/seed, and the
+// *_postgres_test.go files (which open their own *gorm.DB directly,
+// bypassing Initialize() below) all import this package, so this runs
+// exactly once before any of them read a single row. SQLite (used by every
+// other test) doesn't exhibit this driver behavior, which is why this went
+// undetected until a real Postgres run.
+func init() {
+	time.Local = time.UTC
+}
+
 // Initialize creates and returns a database connection
 func Initialize() (*gorm.DB, error) {
 	dbHost := os.Getenv("DB_HOST")

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -203,6 +203,7 @@ func RunMigrations(db *gorm.DB) error {
 		&models.GroupDocument{},
 		&models.APIToken{},
 		&models.ShiftSlot{},
+		&models.ShiftCoverageRequest{},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,9 +1,11 @@
 package database
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
 	"gorm.io/driver/sqlite"
@@ -125,6 +127,83 @@ func TestCreateDefaultAnimalTags_RespectsDeletedTag(t *testing.T) {
 	}
 	if !rows[0].DeletedAt.Valid {
 		t.Fatalf("expected iso tag to remain soft-deleted after rerun, but deleted_at was cleared")
+	}
+}
+
+// TestCreateCustomIndexes_CoverageRequestActiveUnique verifies the partial
+// unique index (idx_coverage_request_active_unique) that backstops
+// CreateCoverageRequest's app-level check-then-create logic in
+// internal/handlers/schedule_coverage.go. A transaction alone does not make
+// that check-then-insert atomic under READ COMMITTED (Postgres in
+// production), so two concurrent creates for the same (group,
+// requested_by_user_id, date, hour) can both pass the app-level check and
+// both insert. This test bypasses the app-level check entirely (two direct
+// db.Create calls) to isolate and confirm the DB-level backstop actually
+// rejects the second insert - and that a cancelled row for the same key
+// does NOT block a fresh active one, since the index is scoped to
+// status <> 'cancelled'.
+func TestCreateCustomIndexes_CoverageRequestActiveUnique(t *testing.T) {
+	// Use a per-test-run unique shared-cache DSN so this test's tables don't
+	// collide with TestCreateDefaultAnimalTags_RespectsDeletedTag, which
+	// uses the same "file::memory:?cache=shared" pattern.
+	dsn := fmt.Sprintf("file:coverage_idx_test_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+
+	if err := db.AutoMigrate(&models.User{}, &models.Group{}, &models.ShiftCoverageRequest{}); err != nil {
+		t.Fatalf("failed to automigrate: %v", err)
+	}
+	if err := createCustomIndexes(db); err != nil {
+		t.Fatalf("createCustomIndexes failed: %v", err)
+	}
+
+	user := models.User{Username: "vol1", Email: "vol1@test.com", Password: "hashed"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	group := models.Group{Name: "Dogs"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	date := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	first := models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: user.ID,
+		Date:              date,
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(&first).Error; err != nil {
+		t.Fatalf("expected first insert to succeed, got: %v", err)
+	}
+
+	second := models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: user.ID,
+		Date:              date,
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(&second).Error; err == nil {
+		t.Fatal("expected second insert for the same (group, user, date, hour) to be rejected by the unique index, got no error")
+	}
+
+	// A cancelled row for the same key must not block a fresh active one.
+	if err := db.Model(&first).Update("status", models.CoverageRequestCancelled).Error; err != nil {
+		t.Fatalf("failed to cancel first request: %v", err)
+	}
+	third := models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: user.ID,
+		Date:              date,
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(&third).Error; err != nil {
+		t.Fatalf("expected insert after cancelling the conflicting row to succeed, got: %v", err)
 	}
 }
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -207,6 +207,93 @@ func TestCreateCustomIndexes_CoverageRequestActiveUnique(t *testing.T) {
 	}
 }
 
+// TestCreateCustomIndexes_CoverageRequestClaimedUnique verifies the partial
+// unique index (idx_coverage_request_claimed_unique) that backstops
+// ClaimCoverageRequest's app-level check-then-write logic in
+// internal/handlers/schedule_coverage.go. That check is a plain
+// count-then-write across different rows (not a conditional update gated on
+// a single row's state, unlike the per-request claim update itself), so
+// under READ COMMITTED (Postgres in production) two concurrent claims by the
+// SAME user for two DIFFERENT open requests at the same (date, hour) can
+// both pass the check and both succeed. This test bypasses the app-level
+// check entirely (two direct db.Create calls for claimed rows) to isolate
+// and confirm the DB-level backstop actually rejects the second insert -
+// and that an open (non-claimed) row for the same claimant/date/hour does
+// NOT block it, since the index is scoped to status = 'claimed'.
+func TestCreateCustomIndexes_CoverageRequestClaimedUnique(t *testing.T) {
+	// Use a per-test-run unique shared-cache DSN so this test's tables don't
+	// collide with other tests using the same "file::memory:?cache=shared"
+	// pattern.
+	dsn := fmt.Sprintf("file:coverage_claimed_idx_test_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+
+	if err := db.AutoMigrate(&models.User{}, &models.Group{}, &models.ShiftCoverageRequest{}); err != nil {
+		t.Fatalf("failed to automigrate: %v", err)
+	}
+	if err := createCustomIndexes(db); err != nil {
+		t.Fatalf("createCustomIndexes failed: %v", err)
+	}
+
+	alice := models.User{Username: "alice", Email: "alice@test.com", Password: "hashed"}
+	if err := db.Create(&alice).Error; err != nil {
+		t.Fatalf("failed to create user alice: %v", err)
+	}
+	bob := models.User{Username: "bob", Email: "bob@test.com", Password: "hashed"}
+	if err := db.Create(&bob).Error; err != nil {
+		t.Fatalf("failed to create user bob: %v", err)
+	}
+	claimant := models.User{Username: "claimant", Email: "claimant@test.com", Password: "hashed"}
+	if err := db.Create(&claimant).Error; err != nil {
+		t.Fatalf("failed to create claimant: %v", err)
+	}
+	group := models.Group{Name: "Dogs"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	date := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+
+	// Two DIFFERENT requests (different requesters), same claimant, same
+	// (date, hour). The first claim should succeed.
+	first := models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: alice.ID,
+		Date:              date,
+		Hour:              10,
+		Status:            models.CoverageRequestClaimed,
+		ClaimedByUserID:   &claimant.ID,
+	}
+	if err := db.Create(&first).Error; err != nil {
+		t.Fatalf("expected first claimed insert to succeed, got: %v", err)
+	}
+
+	// A second, still-open request for a different requester at the same
+	// (date, hour) must not be blocked by the claimed-only index.
+	second := models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: bob.ID,
+		Date:              date,
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(&second).Error; err != nil {
+		t.Fatalf("expected second (still-open) insert to succeed, got: %v", err)
+	}
+
+	// Now claim the second request with the SAME claimant at the same
+	// (date, hour) as the first claim - this is exactly the double-claim
+	// race the index defends against, and must be rejected.
+	if err := db.Model(&second).Updates(map[string]interface{}{
+		"status":             models.CoverageRequestClaimed,
+		"claimed_by_user_id": claimant.ID,
+	}).Error; err == nil {
+		t.Fatal("expected second claim for the same (claimant, date, hour) to be rejected by the unique index, got no error")
+	}
+}
+
 func TestDBLogLevel_Parsing(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -364,8 +364,13 @@ func TestDBLogLevel_Parsing(t *testing.T) {
 // meaningful, so it runs (and actually enforces something) in every `go
 // test ./...` invocation, everywhere.
 func TestLocalTimeIsUTC(t *testing.T) {
+	// This is a pointer-identity check, not a name/offset check - on an
+	// already-UTC host, a deleted init() would still print "time.Local =
+	// UTC" (Go's fallback local-zone name), which reads as a passing value
+	// even though it's the wrong *Location. Printing both pointers makes a
+	// failure unambiguous regardless of the host's own timezone.
 	if time.Local != time.UTC {
-		t.Fatalf("time.Local = %v, want UTC - this package's init() must force UTC so gorm.io/driver/postgres (via pgx) decodes timestamptz columns as UTC instead of the process's local timezone", time.Local)
+		t.Fatalf("time.Local (name %v, pointer %p) is not the time.UTC Location (pointer %p) - this package's init() must force time.Local = time.UTC so gorm.io/driver/postgres (via pgx) decodes timestamptz columns as UTC instead of the process's local timezone", time.Local, time.Local, time.UTC)
 	}
 }
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -353,6 +353,22 @@ func TestDBLogLevel_Parsing(t *testing.T) {
 	}
 }
 
+// TestLocalTimeIsUTC guards this package's init() (see database.go): if
+// that line is ever removed, this is the only test in the whole repo that
+// would actually catch it. The *_postgres_test.go files that exercise the
+// real bug this fixes (a timestamptz round-tripping through pgx comes back
+// in time.Local, not UTC) only run in CI's e2e job, which never runs `go
+// test`, and even where they do run, GitHub Actions runners default to UTC
+// - so they'd pass identically whether or not the fix is in place. This
+// test needs no Postgres and no particular process timezone to be
+// meaningful, so it runs (and actually enforces something) in every `go
+// test ./...` invocation, everywhere.
+func TestLocalTimeIsUTC(t *testing.T) {
+	if time.Local != time.UTC {
+		t.Fatalf("time.Local = %v, want UTC - this package's init() must force UTC so gorm.io/driver/postgres (via pgx) decodes timestamptz columns as UTC instead of the process's local timezone", time.Local)
+	}
+}
+
 func TestConfigureTracing_RegistersPluginWithoutError(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
@@ -365,4 +381,3 @@ func TestConfigureTracing_RegistersPluginWithoutError(t *testing.T) {
 		t.Fatalf("configureTracing returned error: %v", err)
 	}
 }
-

--- a/internal/handlers/group.go
+++ b/internal/handlers/group.go
@@ -342,13 +342,26 @@ func AddUserToGroup(db *gorm.DB) gin.HandlerFunc {
 // removeUserFromGroupAndSchedule removes the group membership association
 // and deletes any ShiftSlot rows the user has for that group, in a single
 // transaction - otherwise a stale schedule would silently reappear if they
-// rejoin the group later.
+// rejoin the group later. It also blanket-cancels any non-cancelled
+// ShiftCoverageRequest in that group where the user is either the original
+// requester or the claimant: since the user is leaving the group entirely,
+// they can neither need coverage nor provide it there anymore, regardless
+// of whether their old slot or the other party's slot still exists.
+// Without this, a removed member who had claimed someone else's request
+// keeps showing up in the schedule overview roster tagged "covering" even
+// though they're no longer even in the group.
 func removeUserFromGroupAndSchedule(db *gorm.DB, user *models.User, group *models.Group) error {
 	return db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(user).Association("Groups").Delete(group); err != nil {
 			return err
 		}
-		return tx.Where("user_id = ? AND group_id = ?", user.ID, group.ID).Delete(&models.ShiftSlot{}).Error
+		if err := tx.Where("user_id = ? AND group_id = ?", user.ID, group.ID).Delete(&models.ShiftSlot{}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&models.ShiftCoverageRequest{}).
+			Where("group_id = ? AND status != ? AND (requested_by_user_id = ? OR claimed_by_user_id = ?)",
+				group.ID, models.CoverageRequestCancelled, user.ID, user.ID).
+			Update("status", models.CoverageRequestCancelled).Error
 	})
 }
 

--- a/internal/handlers/group_test.go
+++ b/internal/handlers/group_test.go
@@ -29,7 +29,7 @@ func setupGroupTestDB(t *testing.T) *gorm.DB {
 	}
 
 	// Run migrations
-	err = db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}, &models.ShiftSlot{})
+	err = db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}, &models.ShiftSlot{}, &models.ShiftCoverageRequest{})
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)
 	}

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -93,9 +93,43 @@ func replaceGroupScheduleForUser(db *gorm.DB, userID, groupID uint, slots []sche
 			}
 			result = append(result, slot)
 		}
+		if err := cancelOrphanedRequesterCoverageRequests(tx, userID, groupID); err != nil {
+			return err
+		}
 		return nil
 	})
 	return result, err
+}
+
+// cancelOrphanedRequesterCoverageRequests cancels any non-cancelled
+// ShiftCoverageRequest this user made (as the original requester, not as
+// a claimant - claiming never touches ShiftSlot) whose underlying weekday/
+// hour no longer has a matching ShiftSlot row, so GetGroupScheduleOverview
+// never surfaces a request tied to a shift the requester no longer has.
+// Must run inside the same transaction as the slot replace, after the new
+// slots are inserted.
+func cancelOrphanedRequesterCoverageRequests(tx *gorm.DB, userID, groupID uint) error {
+	var requests []models.ShiftCoverageRequest
+	if err := tx.Where("group_id = ? AND requested_by_user_id = ? AND status != ?",
+		groupID, userID, models.CoverageRequestCancelled).Find(&requests).Error; err != nil {
+		return err
+	}
+	for _, r := range requests {
+		var count int64
+		if err := tx.Model(&models.ShiftSlot{}).
+			Where("group_id = ? AND user_id = ? AND day_of_week = ? AND hour = ?",
+				groupID, userID, int(r.Date.Weekday()), r.Hour).
+			Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			if err := tx.Model(&models.ShiftCoverageRequest{ID: r.ID}).
+				Update("status", models.CoverageRequestCancelled).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // GetMySchedule returns the caller's weekly shift slots for the given group.

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
@@ -335,31 +336,56 @@ func UpdateMemberSchedule(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
-// scheduleOverviewMember identifies one member available for a given slot in
-// a GetGroupScheduleOverview response. Fields mirror GetGroupMembers'
-// MemberInfo naming so the frontend can reuse its existing display-name
-// fallback logic.
+// scheduleOverviewMember identifies one member's status for a given
+// (date, hour) slot in a GetGroupScheduleOverview response.
 type scheduleOverviewMember struct {
-	UserID    uint   `json:"user_id"`
-	Username  string `json:"username"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
+	UserID            uint   `json:"user_id"`
+	Username          string `json:"username"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	Status            string `json:"status"` // normal | needs_coverage | covering
+	CoverageRequestID *uint  `json:"coverage_request_id,omitempty"`
+	Claimable         bool   `json:"claimable,omitempty"`
+	Conflict          bool   `json:"conflict,omitempty"`
 }
 
-// scheduleOverviewSlot is one (day_of_week, hour) slot with at least one
-// available member.
+// scheduleOverviewSlot is the effective roster for one specific calendar
+// date + hour within the viewed week.
 type scheduleOverviewSlot struct {
+	Date      string                   `json:"date"`
 	DayOfWeek int                      `json:"day_of_week"`
 	Hour      int                      `json:"hour"`
 	Members   []scheduleOverviewMember `json:"members"`
 }
 
-// GetGroupScheduleOverview returns every group member's weekly shift slots
-// aggregated by (day_of_week, hour), so an admin can see who is available at
-// a glance instead of paging through members one at a time via
-// GetMemberSchedule. Requires group admin or site admin access. Only slots
-// with at least one available member are included, ordered by
-// (day_of_week, hour) ascending.
+type dateHourKey struct {
+	Date string
+	Hour int
+}
+
+// parseWeekStart parses an optional "2006-01-02" week_start query param and
+// snaps it back to that week's Sunday. An empty string defaults to the
+// current week's Sunday (UTC).
+func parseWeekStart(raw string) (time.Time, error) {
+	ref := time.Now().UTC()
+	if raw != "" {
+		parsed, err := time.Parse("2006-01-02", raw)
+		if err != nil {
+			return time.Time{}, err
+		}
+		ref = parsed
+	}
+	ref = ref.Truncate(24 * time.Hour)
+	return ref.AddDate(0, 0, -int(ref.Weekday())), nil
+}
+
+// GetGroupScheduleOverview returns the effective roster for every (date,
+// hour) slot in the requested week: the group's recurring ShiftSlot
+// assignments for that weekday/hour, overlaid with any open or claimed
+// ShiftCoverageRequest for that exact date. Open requests keep the original
+// requester listed (tagged needs_coverage); claimed requests swap the
+// requester for the claimant (tagged covering). Requires group membership
+// (or site admin) - open to every member, not just admins.
 func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := middleware.GetDB(c, db)
@@ -368,14 +394,26 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 		userID, _ := c.Get("user_id")
 		isAdmin, _ := c.Get("is_admin")
 
-		if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
 			return
 		}
-
 		if !requireSchedulingEnabled(c, db, groupIDParam) {
 			return
 		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		weekStart, err := parseWeekStart(c.Query("week_start"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "week_start must be in YYYY-MM-DD format"})
+			return
+		}
+		weekEnd := weekStart.AddDate(0, 0, 6)
 
 		var slots []models.ShiftSlot
 		if err := db.Preload("User").Where("group_id = ?", groupIDParam).
@@ -384,34 +422,111 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		type key struct {
+		type slotBucket struct {
 			DayOfWeek int
 			Hour      int
+			Members   []models.ShiftSlot
 		}
-		order := make([]key, 0)
-		bucketed := make(map[key][]scheduleOverviewMember)
+		order := make([]slotBucket, 0)
+		bucketIndex := make(map[[2]int]int)
 		for _, s := range slots {
-			k := key{DayOfWeek: s.DayOfWeek, Hour: s.Hour}
-			if _, exists := bucketed[k]; !exists {
-				order = append(order, k)
+			key := [2]int{s.DayOfWeek, s.Hour}
+			idx, exists := bucketIndex[key]
+			if !exists {
+				idx = len(order)
+				bucketIndex[key] = idx
+				order = append(order, slotBucket{DayOfWeek: s.DayOfWeek, Hour: s.Hour})
 			}
-			bucketed[k] = append(bucketed[k], scheduleOverviewMember{
-				UserID:    s.UserID,
-				Username:  s.User.Username,
-				FirstName: s.User.FirstName,
-				LastName:  s.User.LastName,
-			})
+			order[idx].Members = append(order[idx].Members, s)
 		}
 
-		result := make([]scheduleOverviewSlot, 0, len(order))
-		for _, k := range order {
-			result = append(result, scheduleOverviewSlot{
-				DayOfWeek: k.DayOfWeek,
-				Hour:      k.Hour,
-				Members:   bucketed[k],
-			})
+		var coverageRequests []models.ShiftCoverageRequest
+		if err := db.Preload("ClaimedByUser").
+			Where("group_id = ? AND date >= ? AND date <= ? AND status != ?",
+				groupIDParam, weekStart, weekEnd, models.CoverageRequestCancelled).
+			Find(&coverageRequests).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch coverage requests"})
+			return
+		}
+		requestsByDateHour := make(map[dateHourKey]models.ShiftCoverageRequest, len(coverageRequests))
+		for _, r := range coverageRequests {
+			requestsByDateHour[dateHourKey{Date: r.Date.Format("2006-01-02"), Hour: r.Hour}] = r
 		}
 
-		c.JSON(http.StatusOK, gin.H{"slots": result})
+		// The viewer's own recurring commitments across every group they're
+		// in, and any request they've already claimed this week - both feed
+		// the per-slot "conflict" flag.
+		var viewerSlots []models.ShiftSlot
+		if err := db.Where("user_id = ?", callerUserID).Find(&viewerSlots).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch schedule overview"})
+			return
+		}
+		viewerBusy := make(map[[2]int]bool, len(viewerSlots))
+		for _, s := range viewerSlots {
+			viewerBusy[[2]int{s.DayOfWeek, s.Hour}] = true
+		}
+		viewerClaimedBusy := make(map[dateHourKey]bool)
+		for _, r := range coverageRequests {
+			if r.Status == models.CoverageRequestClaimed && r.ClaimedByUserID != nil && *r.ClaimedByUserID == callerUserID {
+				viewerClaimedBusy[dateHourKey{Date: r.Date.Format("2006-01-02"), Hour: r.Hour}] = true
+			}
+		}
+
+		result := make([]scheduleOverviewSlot, 0)
+		for _, bucket := range order {
+			for offset := 0; offset < 7; offset++ {
+				date := weekStart.AddDate(0, 0, offset)
+				if int(date.Weekday()) != bucket.DayOfWeek {
+					continue
+				}
+				dateStr := date.Format("2006-01-02")
+				req, hasRequest := requestsByDateHour[dateHourKey{Date: dateStr, Hour: bucket.Hour}]
+				conflict := viewerBusy[[2]int{bucket.DayOfWeek, bucket.Hour}] || viewerClaimedBusy[dateHourKey{Date: dateStr, Hour: bucket.Hour}]
+
+				members := make([]scheduleOverviewMember, 0, len(bucket.Members)+1)
+				for _, s := range bucket.Members {
+					if hasRequest && req.Status == models.CoverageRequestClaimed && req.RequestedByUserID == s.UserID {
+						// This member handed their shift off - drop them,
+						// the claimant is added below instead.
+						continue
+					}
+					m := scheduleOverviewMember{
+						UserID:    s.UserID,
+						Username:  s.User.Username,
+						FirstName: s.User.FirstName,
+						LastName:  s.User.LastName,
+						Status:    "normal",
+					}
+					if hasRequest && req.Status == models.CoverageRequestOpen && req.RequestedByUserID == s.UserID {
+						m.Status = "needs_coverage"
+						reqID := req.ID
+						m.CoverageRequestID = &reqID
+						if s.UserID != callerUserID {
+							m.Claimable = !conflict
+							m.Conflict = conflict
+						}
+					}
+					members = append(members, m)
+				}
+				if hasRequest && req.Status == models.CoverageRequestClaimed && req.ClaimedByUser != nil {
+					members = append(members, scheduleOverviewMember{
+						UserID:    req.ClaimedByUser.ID,
+						Username:  req.ClaimedByUser.Username,
+						FirstName: req.ClaimedByUser.FirstName,
+						LastName:  req.ClaimedByUser.LastName,
+						Status:    "covering",
+					})
+				}
+
+				result = append(result, scheduleOverviewSlot{
+					Date:      dateStr,
+					DayOfWeek: bucket.DayOfWeek,
+					Hour:      bucket.Hour,
+					Members:   members,
+				})
+			}
+		}
+
+		c.JSON(http.StatusOK, gin.H{"week_start": weekStart.Format("2006-01-02"), "slots": result})
 	}
 }

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -363,6 +363,12 @@ type dateHourKey struct {
 	Hour int
 }
 
+type dateHourUserKey struct {
+	Date   string
+	Hour   int
+	UserID uint
+}
+
 // parseWeekStart parses an optional "2006-01-02" week_start query param and
 // snaps it back to that week's Sunday. An empty string defaults to the
 // current week's Sunday (UTC).
@@ -448,9 +454,21 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch coverage requests"})
 			return
 		}
-		requestsByDateHour := make(map[dateHourKey]models.ShiftCoverageRequest, len(coverageRequests))
+		// Keyed by requester so multiple members sharing the same recurring
+		// (day_of_week, hour) bucket can each have their own coverage
+		// request for the same calendar date without clobbering each
+		// other. claimedByDateHour is grouped separately (not keyed by
+		// requester) since a "covering" entry is added per-claim, not
+		// per-original-member.
+		requestsByDateHourUser := make(map[dateHourUserKey]models.ShiftCoverageRequest, len(coverageRequests))
+		claimedByDateHour := make(map[dateHourKey][]models.ShiftCoverageRequest)
 		for _, r := range coverageRequests {
-			requestsByDateHour[dateHourKey{Date: r.Date.Format("2006-01-02"), Hour: r.Hour}] = r
+			dateStr := r.Date.Format("2006-01-02")
+			requestsByDateHourUser[dateHourUserKey{Date: dateStr, Hour: r.Hour, UserID: r.RequestedByUserID}] = r
+			if r.Status == models.CoverageRequestClaimed {
+				key := dateHourKey{Date: dateStr, Hour: r.Hour}
+				claimedByDateHour[key] = append(claimedByDateHour[key], r)
+			}
 		}
 
 		// The viewer's own recurring commitments across every group they're
@@ -480,14 +498,14 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 					continue
 				}
 				dateStr := date.Format("2006-01-02")
-				req, hasRequest := requestsByDateHour[dateHourKey{Date: dateStr, Hour: bucket.Hour}]
 				conflict := viewerBusy[[2]int{bucket.DayOfWeek, bucket.Hour}] || viewerClaimedBusy[dateHourKey{Date: dateStr, Hour: bucket.Hour}]
 
 				members := make([]scheduleOverviewMember, 0, len(bucket.Members)+1)
 				for _, s := range bucket.Members {
-					if hasRequest && req.Status == models.CoverageRequestClaimed && req.RequestedByUserID == s.UserID {
+					req, hasRequest := requestsByDateHourUser[dateHourUserKey{Date: dateStr, Hour: bucket.Hour, UserID: s.UserID}]
+					if hasRequest && req.Status == models.CoverageRequestClaimed {
 						// This member handed their shift off - drop them,
-						// the claimant is added below instead.
+						// the claimant(s) are added below instead.
 						continue
 					}
 					m := scheduleOverviewMember{
@@ -497,7 +515,7 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 						LastName:  s.User.LastName,
 						Status:    "normal",
 					}
-					if hasRequest && req.Status == models.CoverageRequestOpen && req.RequestedByUserID == s.UserID {
+					if hasRequest && req.Status == models.CoverageRequestOpen {
 						m.Status = "needs_coverage"
 						reqID := req.ID
 						m.CoverageRequestID = &reqID
@@ -508,12 +526,15 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 					}
 					members = append(members, m)
 				}
-				if hasRequest && req.Status == models.CoverageRequestClaimed && req.ClaimedByUser != nil {
+				for _, r := range claimedByDateHour[dateHourKey{Date: dateStr, Hour: bucket.Hour}] {
+					if r.ClaimedByUser == nil {
+						continue
+					}
 					members = append(members, scheduleOverviewMember{
-						UserID:    req.ClaimedByUser.ID,
-						Username:  req.ClaimedByUser.Username,
-						FirstName: req.ClaimedByUser.FirstName,
-						LastName:  req.ClaimedByUser.LastName,
+						UserID:    r.ClaimedByUser.ID,
+						Username:  r.ClaimedByUser.Username,
+						FirstName: r.ClaimedByUser.FirstName,
+						LastName:  r.ClaimedByUser.LastName,
 						Status:    "covering",
 					})
 				}

--- a/internal/handlers/schedule.go
+++ b/internal/handlers/schedule.go
@@ -96,6 +96,9 @@ func replaceGroupScheduleForUser(db *gorm.DB, userID, groupID uint, slots []sche
 		if err := cancelOrphanedRequesterCoverageRequests(tx, userID, groupID); err != nil {
 			return err
 		}
+		if err := cancelRedundantClaimsForNewSlots(tx, userID, groupID, slots); err != nil {
+			return err
+		}
 		return nil
 	})
 	return result, err
@@ -123,6 +126,38 @@ func cancelOrphanedRequesterCoverageRequests(tx *gorm.DB, userID, groupID uint) 
 			return err
 		}
 		if count == 0 {
+			if err := tx.Model(&models.ShiftCoverageRequest{ID: r.ID}).
+				Update("status", models.CoverageRequestCancelled).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// cancelRedundantClaimsForNewSlots cancels any ShiftCoverageRequest this
+// user has CLAIMED (covering someone else's shift) whose weekday/hour now
+// collides with a slot they just added to their own recurring schedule.
+// Once they're recurring on that slot themselves, the one-off "covering"
+// arrangement for the same weekday/hour is redundant and would otherwise
+// render them twice in the effective roster - once as a normal member,
+// once as the covering claimant.
+func cancelRedundantClaimsForNewSlots(tx *gorm.DB, userID, groupID uint, slots []scheduleSlotInput) error {
+	if len(slots) == 0 {
+		return nil
+	}
+	newSlotKeys := make(map[[2]int]bool, len(slots))
+	for _, s := range slots {
+		newSlotKeys[[2]int{s.DayOfWeek, s.Hour}] = true
+	}
+
+	var claims []models.ShiftCoverageRequest
+	if err := tx.Where("group_id = ? AND claimed_by_user_id = ? AND status = ?",
+		groupID, userID, models.CoverageRequestClaimed).Find(&claims).Error; err != nil {
+		return err
+	}
+	for _, r := range claims {
+		if newSlotKeys[[2]int{int(r.Date.Weekday()), r.Hour}] {
 			if err := tx.Model(&models.ShiftCoverageRequest{ID: r.ID}).
 				Update("status", models.CoverageRequestCancelled).Error; err != nil {
 				return err
@@ -560,10 +595,22 @@ func GetGroupScheduleOverview(db *gorm.DB) gin.HandlerFunc {
 					}
 					members = append(members, m)
 				}
+				// Dedupe-by-user_id guard: even with the root-cause fix in
+				// replaceGroupScheduleForUser (cancelRedundantClaimsForNewSlots),
+				// this backstop ensures no future code path can ever produce a
+				// duplicate member in one slot's output - e.g. a "normal" entry
+				// from a ShiftSlot and a "covering" entry from a stale claim for
+				// the same user would otherwise both render, causing a duplicate
+				// React key and double-counted availability tallies.
+				seenUserIDs := make(map[uint]bool, len(members))
+				for _, m := range members {
+					seenUserIDs[m.UserID] = true
+				}
 				for _, r := range claimedByDateHour[dateHourKey{Date: dateStr, Hour: bucket.Hour}] {
-					if r.ClaimedByUser == nil {
+					if r.ClaimedByUser == nil || seenUserIDs[r.ClaimedByUser.ID] {
 						continue
 					}
+					seenUserIDs[r.ClaimedByUser.ID] = true
 					members = append(members, scheduleOverviewMember{
 						UserID:    r.ClaimedByUser.ID,
 						Username:  r.ClaimedByUser.Username,

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -138,8 +138,8 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 			return
 		}
 		today := time.Now().UTC().Truncate(24 * time.Hour)
-		if !date.After(today) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "date must be in the future"})
+		if date.Before(today) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "date must not be in the past"})
 			return
 		}
 		if req.Hour < 8 || req.Hour > 17 {
@@ -197,25 +197,44 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 
 		c.JSON(http.StatusCreated, toCoverageRequestResponse(created))
 
-		title := "Coverage needed"
-		content := fmt.Sprintf("A volunteer needs coverage for their %s shift on %s.",
-			formatHourAMPM(req.Hour), date.Format("Monday, January 2"))
+		// Cooldown: skip the group-wide broadcast (but the request itself is
+		// already created above) if this same user created another coverage
+		// request in this group within the last 5 minutes. Otherwise a member
+		// could cancel-and-recreate their own open request repeatedly, re-
+		// firing the group-wide email/GroupMe blast every time - a fan-out
+		// path that, before this feature, was only reachable via admin-gated
+		// /announcements endpoints. Runs on the outer (non-transaction) db
+		// since the transaction has already committed by this point, matching
+		// how the notification goroutines below already run post-commit.
+		var recentCount int64
+		if err := rawDB.Model(&models.ShiftCoverageRequest{}).
+			Where("group_id = ? AND requested_by_user_id = ? AND id != ? AND created_at > ?",
+				groupIDUint, targetUserID, created.ID, time.Now().Add(-5*time.Minute)).
+			Count(&recentCount).Error; err == nil && recentCount == 0 {
+			var requester models.User
+			var grp models.Group
+			rawDB.First(&requester, targetUserID)
+			rawDB.Select("name").First(&grp, groupIDUint)
+			title := fmt.Sprintf("Coverage needed in %s", grp.Name)
+			content := fmt.Sprintf("%s needs coverage for their %s shift on %s.",
+				displayName(requester), formatHourAMPM(req.Hour), date.Format("Monday, January 2"))
 
-		if emailService != nil && emailService.IsConfigured() {
-			go func() {
-				bgCtx := context.Background()
-				if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, groupIDUint, title, content); err != nil {
-					logging.WithContext(bgCtx).Error("Error sending coverage request emails", err)
-				}
-			}()
-		}
-		if groupMeService != nil {
-			go func() {
-				bgCtx := context.Background()
-				if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, groupIDUint, title, content); err != nil {
-					logging.WithContext(bgCtx).Error("Error sending coverage request to GroupMe", err)
-				}
-			}()
+			if emailService != nil && emailService.IsConfigured() {
+				go func() {
+					bgCtx := context.Background()
+					if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, groupIDUint, title, content); err != nil {
+						logging.WithContext(bgCtx).Error("Error sending coverage request emails", err)
+					}
+				}()
+			}
+			if groupMeService != nil {
+				go func() {
+					bgCtx := context.Background()
+					if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, groupIDUint, title, content); err != nil {
+						logging.WithContext(bgCtx).Error("Error sending coverage request to GroupMe", err)
+					}
+				}()
+			}
 		}
 	}
 }

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -659,7 +659,11 @@ func CreateCoverageRequestsBatch(db *gorm.DB, emailService *email.Service, group
 					Date: item.date.Format("2006-01-02"), Hour: item.hour, Reason: err.Error(),
 				})
 			case err != nil:
-				logging.Error("Failed to create coverage request in batch", err)
+				logging.WithContext(c.Request.Context()).WithFields(map[string]interface{}{
+					"group_id": groupIDUint,
+					"date":     item.date.Format("2006-01-02"),
+					"hour":     item.hour,
+				}).Error("Failed to create coverage request in batch", err)
 				response.Skipped = append(response.Skipped, coverageRequestBatchSkipped{
 					Date: item.date.Format("2006-01-02"), Hour: item.hour, Reason: "internal error, please try again",
 				})

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -374,3 +374,60 @@ func notifyRequesterOfClaim(db *gorm.DB, emailService *email.Service, groupMeSer
 		}
 	}()
 }
+
+// CancelCoverageRequest withdraws a coverage request. The original
+// requester can cancel it only while still open; a group admin (or site
+// admin) can cancel it at any status.
+func CancelCoverageRequest(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		requestID, err := strconv.ParseUint(c.Param("requestId"), 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request ID"})
+			return
+		}
+
+		var reqRow models.ShiftCoverageRequest
+		if err := db.Where("id = ? AND group_id = ?", requestID, groupIDParam).First(&reqRow).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Coverage request not found"})
+			return
+		}
+
+		isAdminCaller := checkGroupAdminAccess(db, userID, isAdmin, groupIDParam)
+		isOwnOpenRequest := reqRow.RequestedByUserID == callerUserID && reqRow.Status == models.CoverageRequestOpen
+		if !isOwnOpenRequest && !isAdminCaller {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Cannot cancel this coverage request"})
+			return
+		}
+		if reqRow.Status == models.CoverageRequestCancelled {
+			c.JSON(http.StatusConflict, gin.H{"error": "Coverage request is already cancelled"})
+			return
+		}
+
+		if err := db.Model(&reqRow).Update("status", models.CoverageRequestCancelled).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cancel coverage request"})
+			return
+		}
+
+		c.JSON(http.StatusOK, toCoverageRequestResponse(reqRow))
+	}
+}

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -275,18 +275,23 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 
 		// Cooldown: throttle (not silence) the group-wide broadcast if this
 		// same user created another coverage request in this group within
-		// the last minute, so a rapid double-submission doesn't fire two
-		// near-identical emails/GroupMe posts back to back. Short on purpose:
-		// its only job is absorbing accidental double-clicks, not gatekeeping
-		// a legitimate second request for a different shift moments later -
-		// whenever a notification IS sent (see below), it always lists every
-		// currently-open request this user has in the group, not just the
-		// one that triggered it, so nothing is ever silently left out of the
-		// email because it happened to land inside the cooldown window. Runs
-		// on the outer (non-transaction) db since the transaction has
-		// already committed by this point, matching how the notification
-		// helper below already runs post-commit.
-		const coverageNotificationCooldown = 60 * time.Second
+		// the last few seconds, so a rapid double-submission (e.g. a network
+		// retry on a slow connection) doesn't fire two near-identical emails/
+		// GroupMe posts back to back. Deliberately short: a real, separate
+		// request even a few seconds later should still notify normally.
+		//
+		// KNOWN LIMITATION: this checks "was another row created recently,"
+		// not "was a notification actually sent recently." If a batch create
+		// (CreateCoverageRequestsBatch, which always notifies unconditionally)
+		// is immediately followed by a single create within this window, the
+		// single create's notification is suppressed even though the group
+		// was never told about that specific new item. A fully correct fix
+		// needs a persisted "last notified at" timestamp per (user, group),
+		// which is out of scope here - this short window just keeps the
+		// practical blast radius small. Runs on the outer (non-transaction)
+		// db since the transaction has already committed by this point,
+		// matching how the notification helper below already runs post-commit.
+		const coverageNotificationCooldown = 5 * time.Second
 		var recentCount int64
 		if err := rawDB.Model(&models.ShiftCoverageRequest{}).
 			Where("group_id = ? AND requested_by_user_id = ? AND id != ? AND created_at > ?",
@@ -609,6 +614,11 @@ func CreateCoverageRequestsBatch(db *gorm.DB, emailService *email.Service, group
 		}
 		if len(req.Requests) == 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "requests must not be empty"})
+			return
+		}
+		const maxBatchItems = 200
+		if len(req.Requests) > maxBatchItems {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("requests must not exceed %d items", maxBatchItems)})
 			return
 		}
 

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/email"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/groupme"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/logging"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/middleware"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
+)
+
+var (
+	errNoMatchingSlot   = errors.New("no matching recurring shift for that date and hour")
+	errDuplicateRequest = errors.New("a coverage request already exists for that date and hour")
+	errRequestNotFound  = errors.New("coverage request not found")
+	errRequestNotOpen   = errors.New("coverage request is no longer open")
+	errSelfClaim        = errors.New("cannot claim your own coverage request")
+	errClaimConflict    = errors.New("claimant already has a conflicting shift at that time")
+)
+
+type createCoverageRequestRequest struct {
+	Date   string `json:"date"`
+	Hour   int    `json:"hour"`
+	UserID *uint  `json:"user_id"`
+}
+
+type coverageRequestResponse struct {
+	ID                uint   `json:"id"`
+	GroupID           uint   `json:"group_id"`
+	RequestedByUserID uint   `json:"requested_by_user_id"`
+	Date              string `json:"date"`
+	Hour              int    `json:"hour"`
+	Status            string `json:"status"`
+	ClaimedByUserID   *uint  `json:"claimed_by_user_id"`
+}
+
+func toCoverageRequestResponse(r models.ShiftCoverageRequest) coverageRequestResponse {
+	return coverageRequestResponse{
+		ID:                r.ID,
+		GroupID:           r.GroupID,
+		RequestedByUserID: r.RequestedByUserID,
+		Date:              r.Date.Format("2006-01-02"),
+		Hour:              r.Hour,
+		Status:            string(r.Status),
+		ClaimedByUserID:   r.ClaimedByUserID,
+	}
+}
+
+// displayName mirrors the first/last-name-with-username-fallback logic used
+// for member display names elsewhere, for use in notification text.
+func displayName(u models.User) string {
+	if u.FirstName != "" || u.LastName != "" {
+		name := u.FirstName
+		if u.LastName != "" {
+			if name != "" {
+				name += " "
+			}
+			name += u.LastName
+		}
+		return name
+	}
+	return u.Username
+}
+
+// formatHourAMPM renders a 24-hour ShiftSlot/CoverageRequest hour (8..17)
+// as e.g. "10:00 AM" for notification text.
+func formatHourAMPM(hour int) string {
+	period := "AM"
+	displayHour := hour
+	if hour >= 12 {
+		period = "PM"
+	}
+	if displayHour > 12 {
+		displayHour -= 12
+	}
+	return fmt.Sprintf("%d:00 %s", displayHour, period)
+}
+
+// CreateCoverageRequest flags a specific future occurrence of the caller's
+// (or, for a group admin, another member's) recurring shift as needing
+// coverage. Requires group membership (or site admin) for self-requests;
+// requires group admin (or site admin) to request on behalf of someone else.
+func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// rawDB is captured before the shadow below so the notification
+		// goroutines get the unscoped db, not one bound to this request's
+		// context (which is canceled the instant this handler returns). See
+		// the same pattern in update.go's CreateUpdate.
+		rawDB := db
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		var req createCoverageRequestRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			return
+		}
+
+		targetUserID := callerUserID
+		if req.UserID != nil && *req.UserID != callerUserID {
+			if !checkGroupAdminAccess(db, userID, isAdmin, groupIDParam) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required to request coverage for another member"})
+				return
+			}
+			targetUserID = *req.UserID
+		}
+
+		// time.Parse("2006-01-02", ...) already yields UTC midnight, matching
+		// how ShiftCoverageRequest.Date is stored and compared throughout.
+		date, err := time.Parse("2006-01-02", req.Date)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "date must be in YYYY-MM-DD format"})
+			return
+		}
+		today := time.Now().UTC().Truncate(24 * time.Hour)
+		if !date.After(today) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "date must be in the future"})
+			return
+		}
+		if req.Hour < 8 || req.Hour > 17 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "hour must be between 8 and 17"})
+			return
+		}
+
+		groupIDUint64, err := strconv.ParseUint(groupIDParam, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+			return
+		}
+		groupIDUint := uint(groupIDUint64)
+
+		var created models.ShiftCoverageRequest
+		err = db.Transaction(func(tx *gorm.DB) error {
+			var slot models.ShiftSlot
+			if err := tx.Where("user_id = ? AND group_id = ? AND day_of_week = ? AND hour = ?",
+				targetUserID, groupIDUint, int(date.Weekday()), req.Hour).First(&slot).Error; err != nil {
+				return errNoMatchingSlot
+			}
+
+			var existing models.ShiftCoverageRequest
+			err := tx.Where("group_id = ? AND requested_by_user_id = ? AND date = ? AND hour = ? AND status != ?",
+				groupIDUint, targetUserID, date, req.Hour, models.CoverageRequestCancelled).
+				First(&existing).Error
+			if err == nil {
+				return errDuplicateRequest
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+
+			created = models.ShiftCoverageRequest{
+				GroupID:           groupIDUint,
+				RequestedByUserID: targetUserID,
+				Date:              date,
+				Hour:              req.Hour,
+				Status:            models.CoverageRequestOpen,
+			}
+			return tx.Create(&created).Error
+		})
+
+		switch {
+		case errors.Is(err, errNoMatchingSlot):
+			c.JSON(http.StatusBadRequest, gin.H{"error": errNoMatchingSlot.Error()})
+			return
+		case errors.Is(err, errDuplicateRequest):
+			c.JSON(http.StatusConflict, gin.H{"error": errDuplicateRequest.Error()})
+			return
+		case err != nil:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create coverage request"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, toCoverageRequestResponse(created))
+
+		title := "Coverage needed"
+		content := fmt.Sprintf("A volunteer needs coverage for their %s shift on %s.",
+			formatHourAMPM(req.Hour), date.Format("Monday, January 2"))
+
+		if emailService != nil && emailService.IsConfigured() {
+			go func() {
+				bgCtx := context.Background()
+				if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, groupIDUint, title, content); err != nil {
+					logging.WithContext(bgCtx).Error("Error sending coverage request emails", err)
+				}
+			}()
+		}
+		if groupMeService != nil {
+			go func() {
+				bgCtx := context.Background()
+				if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, groupIDUint, title, content); err != nil {
+					logging.WithContext(bgCtx).Error("Error sending coverage request to GroupMe", err)
+				}
+			}()
+		}
+	}
+}

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -287,13 +287,29 @@ func ClaimCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServi
 				return errClaimConflict
 			}
 
+			// Conditional update, gated on status still being open, is what
+			// actually closes the race between two concurrent claimants who
+			// both passed the checks above under READ COMMITTED (Postgres in
+			// production) - the earlier status check is just a cheap
+			// fast-path rejection, not the correctness guarantee.
 			now := time.Now().UTC()
+			result := tx.Model(&models.ShiftCoverageRequest{}).
+				Where("id = ? AND status = ?", reqRow.ID, models.CoverageRequestOpen).
+				Updates(map[string]interface{}{
+					"status":             models.CoverageRequestClaimed,
+					"claimed_by_user_id": callerUserID,
+					"claimed_at":         now,
+				})
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				return errRequestNotOpen
+			}
+
 			reqRow.Status = models.CoverageRequestClaimed
 			reqRow.ClaimedByUserID = &callerUserID
 			reqRow.ClaimedAt = &now
-			if err := tx.Save(&reqRow).Error; err != nil {
-				return err
-			}
 			claimed = reqRow
 			return nil
 		})

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -546,3 +546,120 @@ func CancelCoverageRequest(db *gorm.DB) gin.HandlerFunc {
 		c.JSON(http.StatusOK, toCoverageRequestResponse(reqRow))
 	}
 }
+
+type createCoverageRequestBatchItem struct {
+	Date string `json:"date"`
+	Hour int    `json:"hour"`
+}
+
+type createCoverageRequestBatchRequest struct {
+	Requests []createCoverageRequestBatchItem `json:"requests"`
+}
+
+type coverageRequestBatchSkipped struct {
+	Date   string `json:"date"`
+	Hour   int    `json:"hour"`
+	Reason string `json:"reason"`
+}
+
+type coverageRequestBatchResponse struct {
+	Created []coverageRequestResponse     `json:"created"`
+	Skipped []coverageRequestBatchSkipped `json:"skipped"`
+}
+
+// CreateCoverageRequestsBatch flags several future occurrences of the
+// caller's own recurring shifts as needing coverage in one call, so a
+// volunteer requesting coverage for multiple shifts (e.g. "I'm out all of
+// next week") triggers exactly one group notification instead of one per
+// shift. Self-service only - always creates on behalf of the caller, no
+// on-behalf-of-another-member support (unlike CreateCoverageRequest).
+// Items that fail per-item validation (no matching slot, already an
+// active request, past date) are skipped and reported rather than failing
+// the whole batch; a structurally invalid item (bad date format,
+// out-of-range hour) fails the whole request with 400, since that's a
+// payload error, not a per-item business-rule rejection. Requires group
+// membership (or site admin).
+func CreateCoverageRequestsBatch(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawDB := db
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		var req createCoverageRequestBatchRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			return
+		}
+		if len(req.Requests) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "requests must not be empty"})
+			return
+		}
+
+		groupIDUint64, err := strconv.ParseUint(groupIDParam, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+			return
+		}
+		groupIDUint := uint(groupIDUint64)
+
+		type parsedItem struct {
+			date time.Time
+			hour int
+		}
+		parsedItems := make([]parsedItem, 0, len(req.Requests))
+		for _, item := range req.Requests {
+			date, err := time.Parse("2006-01-02", item.Date)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid date %q: must be in YYYY-MM-DD format", item.Date)})
+				return
+			}
+			if item.Hour < 8 || item.Hour > 17 {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid hour %d: must be between 8 and 17", item.Hour)})
+				return
+			}
+			parsedItems = append(parsedItems, parsedItem{date: date, hour: item.Hour})
+		}
+
+		response := coverageRequestBatchResponse{
+			Created: make([]coverageRequestResponse, 0, len(parsedItems)),
+			Skipped: make([]coverageRequestBatchSkipped, 0),
+		}
+		for _, item := range parsedItems {
+			created, err := createOneCoverageRequest(db, groupIDUint, callerUserID, item.date, item.hour)
+			switch {
+			case errors.Is(err, errPastDate), errors.Is(err, errNoMatchingSlot), errors.Is(err, errDuplicateRequest):
+				response.Skipped = append(response.Skipped, coverageRequestBatchSkipped{
+					Date: item.date.Format("2006-01-02"), Hour: item.hour, Reason: err.Error(),
+				})
+			case err != nil:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create coverage requests"})
+				return
+			default:
+				response.Created = append(response.Created, toCoverageRequestResponse(created))
+			}
+		}
+
+		c.JSON(http.StatusOK, response)
+
+		if len(response.Created) > 0 {
+			notifyGroupOfOpenCoverageRequests(rawDB, emailService, groupMeService, groupIDUint, callerUserID)
+		}
+	}
+}

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -68,6 +69,23 @@ func displayName(u models.User) string {
 		return name
 	}
 	return u.Username
+}
+
+// buildCoverageRequestSummary renders one requester's currently-open
+// coverage requests as a single bulk notification body, so a member with
+// several shifts needing coverage produces one accurate email/GroupMe post
+// listing all of them instead of a separate, fragmented message per shift.
+func buildCoverageRequestSummary(requesterName string, requests []models.ShiftCoverageRequest) string {
+	if len(requests) == 1 {
+		r := requests[0]
+		return fmt.Sprintf("%s needs coverage for their %s shift on %s.",
+			requesterName, formatHourAMPM(r.Hour), r.Date.Format("Monday, January 2"))
+	}
+	lines := make([]string, 0, len(requests))
+	for _, r := range requests {
+		lines = append(lines, fmt.Sprintf("- %s at %s", r.Date.Format("Monday, January 2"), formatHourAMPM(r.Hour)))
+	}
+	return fmt.Sprintf("%s needs coverage for %d shifts:\n%s", requesterName, len(requests), strings.Join(lines, "\n"))
 }
 
 // formatHourAMPM renders a 24-hour ShiftSlot/CoverageRequest hour (8..17)
@@ -197,27 +215,36 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 
 		c.JSON(http.StatusCreated, toCoverageRequestResponse(created))
 
-		// Cooldown: skip the group-wide broadcast (but the request itself is
-		// already created above) if this same user created another coverage
-		// request in this group within the last 5 minutes. Otherwise a member
-		// could cancel-and-recreate their own open request repeatedly, re-
-		// firing the group-wide email/GroupMe blast every time - a fan-out
-		// path that, before this feature, was only reachable via admin-gated
-		// /announcements endpoints. Runs on the outer (non-transaction) db
-		// since the transaction has already committed by this point, matching
-		// how the notification goroutines below already run post-commit.
+		// Cooldown: throttle (not silence) the group-wide broadcast if this
+		// same user created another coverage request in this group within
+		// the last minute, so a rapid double-submission doesn't fire two
+		// near-identical emails/GroupMe posts back to back. Short on purpose:
+		// its only job is absorbing accidental double-clicks, not gatekeeping
+		// a legitimate second request for a different shift moments later -
+		// whenever a notification IS sent (see below), it always lists every
+		// currently-open request this user has in the group, not just the
+		// one that triggered it, so nothing is ever silently left out of the
+		// email because it happened to land inside the cooldown window. Runs
+		// on the outer (non-transaction) db since the transaction has
+		// already committed by this point, matching how the notification
+		// goroutines below already run post-commit.
+		const coverageNotificationCooldown = 60 * time.Second
 		var recentCount int64
 		if err := rawDB.Model(&models.ShiftCoverageRequest{}).
 			Where("group_id = ? AND requested_by_user_id = ? AND id != ? AND created_at > ?",
-				groupIDUint, targetUserID, created.ID, time.Now().Add(-5*time.Minute)).
+				groupIDUint, targetUserID, created.ID, time.Now().Add(-coverageNotificationCooldown)).
 			Count(&recentCount).Error; err == nil && recentCount == 0 {
 			var requester models.User
 			var grp models.Group
+			var openRequests []models.ShiftCoverageRequest
 			rawDB.First(&requester, targetUserID)
 			rawDB.Select("name").First(&grp, groupIDUint)
+			rawDB.Where("group_id = ? AND requested_by_user_id = ? AND status = ?",
+				groupIDUint, targetUserID, models.CoverageRequestOpen).
+				Order("date, hour").Find(&openRequests)
+
 			title := fmt.Sprintf("Coverage needed in %s", grp.Name)
-			content := fmt.Sprintf("%s needs coverage for their %s shift on %s.",
-				displayName(requester), formatHourAMPM(req.Hour), date.Format("Monday, January 2"))
+			content := buildCoverageRequestSummary(displayName(requester), openRequests)
 
 			if emailService != nil && emailService.IsConfigured() {
 				go func() {

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -649,8 +649,10 @@ func CreateCoverageRequestsBatch(db *gorm.DB, emailService *email.Service, group
 					Date: item.date.Format("2006-01-02"), Hour: item.hour, Reason: err.Error(),
 				})
 			case err != nil:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create coverage requests"})
-				return
+				logging.Error("Failed to create coverage request in batch", err)
+				response.Skipped = append(response.Skipped, coverageRequestBatchSkipped{
+					Date: item.date.Format("2006-01-02"), Hour: item.hour, Reason: "internal error, please try again",
+				})
 			default:
 				response.Created = append(response.Created, toCoverageRequestResponse(created))
 			}

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -21,6 +21,7 @@ import (
 var (
 	errNoMatchingSlot   = errors.New("no matching recurring shift for that date and hour")
 	errDuplicateRequest = errors.New("a coverage request already exists for that date and hour")
+	errPastDate         = errors.New("date must not be in the past")
 	errRequestNotFound  = errors.New("coverage request not found")
 	errRequestNotOpen   = errors.New("coverage request is no longer open")
 	errSelfClaim        = errors.New("cannot claim your own coverage request")
@@ -102,6 +103,95 @@ func formatHourAMPM(hour int) string {
 	return fmt.Sprintf("%d:00 %s", displayHour, period)
 }
 
+// createOneCoverageRequest validates and creates a single coverage
+// request: the date must not be in the past, the target user must have a
+// matching ShiftSlot for the date's weekday and the given hour, and there
+// must not already be an active (non-cancelled) request for that exact
+// date/hour. Returns the created row, or one of the sentinel errors
+// errPastDate / errNoMatchingSlot / errDuplicateRequest. Runs its own
+// transaction - a caller creating several requests (see
+// CreateCoverageRequestsBatch) calls this once per item rather than
+// wrapping the whole batch in one transaction, so one item's failure
+// doesn't roll back the others.
+func createOneCoverageRequest(db *gorm.DB, groupIDUint, targetUserID uint, date time.Time, hour int) (models.ShiftCoverageRequest, error) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if date.Before(today) {
+		return models.ShiftCoverageRequest{}, errPastDate
+	}
+
+	var created models.ShiftCoverageRequest
+	err := db.Transaction(func(tx *gorm.DB) error {
+		var slot models.ShiftSlot
+		if err := tx.Where("user_id = ? AND group_id = ? AND day_of_week = ? AND hour = ?",
+			targetUserID, groupIDUint, int(date.Weekday()), hour).First(&slot).Error; err != nil {
+			return errNoMatchingSlot
+		}
+
+		var existing models.ShiftCoverageRequest
+		err := tx.Where("group_id = ? AND requested_by_user_id = ? AND date = ? AND hour = ? AND status != ?",
+			groupIDUint, targetUserID, date, hour, models.CoverageRequestCancelled).
+			First(&existing).Error
+		if err == nil {
+			return errDuplicateRequest
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		created = models.ShiftCoverageRequest{
+			GroupID:           groupIDUint,
+			RequestedByUserID: targetUserID,
+			Date:              date,
+			Hour:              hour,
+			Status:            models.CoverageRequestOpen,
+		}
+		return tx.Create(&created).Error
+	})
+	return created, err
+}
+
+// notifyGroupOfOpenCoverageRequests sends one bulk notification listing
+// every currently-open coverage request the given user has in the group -
+// not just whatever was just created - so the group always sees the
+// complete, accurate picture in a single email/GroupMe post rather than
+// one fragment per request. No-ops if the user currently has no open
+// requests. Runs on rawDB (the unscoped db captured before the handler's
+// middleware.GetDB shadow) since callers invoke this after their own
+// create(s) have already committed.
+func notifyGroupOfOpenCoverageRequests(rawDB *gorm.DB, emailService *email.Service, groupMeService *groupme.Service, groupIDUint, targetUserID uint) {
+	var requester models.User
+	var grp models.Group
+	var openRequests []models.ShiftCoverageRequest
+	rawDB.First(&requester, targetUserID)
+	rawDB.Select("name").First(&grp, groupIDUint)
+	rawDB.Where("group_id = ? AND requested_by_user_id = ? AND status = ?",
+		groupIDUint, targetUserID, models.CoverageRequestOpen).
+		Order("date, hour").Find(&openRequests)
+	if len(openRequests) == 0 {
+		return
+	}
+
+	title := fmt.Sprintf("Coverage needed in %s", grp.Name)
+	content := buildCoverageRequestSummary(displayName(requester), openRequests)
+
+	if emailService != nil && emailService.IsConfigured() {
+		go func() {
+			bgCtx := context.Background()
+			if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, groupIDUint, title, content); err != nil {
+				logging.WithContext(bgCtx).Error("Error sending coverage request emails", err)
+			}
+		}()
+	}
+	if groupMeService != nil {
+		go func() {
+			bgCtx := context.Background()
+			if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, groupIDUint, title, content); err != nil {
+				logging.WithContext(bgCtx).Error("Error sending coverage request to GroupMe", err)
+			}
+		}()
+	}
+}
+
 // CreateCoverageRequest flags a specific future occurrence of the caller's
 // (or, for a group admin, another member's) recurring shift as needing
 // coverage. Requires group membership (or site admin) for self-requests;
@@ -148,16 +238,9 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 			targetUserID = *req.UserID
 		}
 
-		// time.Parse("2006-01-02", ...) already yields UTC midnight, matching
-		// how ShiftCoverageRequest.Date is stored and compared throughout.
 		date, err := time.Parse("2006-01-02", req.Date)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "date must be in YYYY-MM-DD format"})
-			return
-		}
-		today := time.Now().UTC().Truncate(24 * time.Hour)
-		if date.Before(today) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "date must not be in the past"})
 			return
 		}
 		if req.Hour < 8 || req.Hour > 17 {
@@ -172,36 +255,11 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 		}
 		groupIDUint := uint(groupIDUint64)
 
-		var created models.ShiftCoverageRequest
-		err = db.Transaction(func(tx *gorm.DB) error {
-			var slot models.ShiftSlot
-			if err := tx.Where("user_id = ? AND group_id = ? AND day_of_week = ? AND hour = ?",
-				targetUserID, groupIDUint, int(date.Weekday()), req.Hour).First(&slot).Error; err != nil {
-				return errNoMatchingSlot
-			}
-
-			var existing models.ShiftCoverageRequest
-			err := tx.Where("group_id = ? AND requested_by_user_id = ? AND date = ? AND hour = ? AND status != ?",
-				groupIDUint, targetUserID, date, req.Hour, models.CoverageRequestCancelled).
-				First(&existing).Error
-			if err == nil {
-				return errDuplicateRequest
-			}
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
-			}
-
-			created = models.ShiftCoverageRequest{
-				GroupID:           groupIDUint,
-				RequestedByUserID: targetUserID,
-				Date:              date,
-				Hour:              req.Hour,
-				Status:            models.CoverageRequestOpen,
-			}
-			return tx.Create(&created).Error
-		})
-
+		created, err := createOneCoverageRequest(db, groupIDUint, targetUserID, date, req.Hour)
 		switch {
+		case errors.Is(err, errPastDate):
+			c.JSON(http.StatusBadRequest, gin.H{"error": errPastDate.Error()})
+			return
 		case errors.Is(err, errNoMatchingSlot):
 			c.JSON(http.StatusBadRequest, gin.H{"error": errNoMatchingSlot.Error()})
 			return
@@ -227,41 +285,14 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 		// email because it happened to land inside the cooldown window. Runs
 		// on the outer (non-transaction) db since the transaction has
 		// already committed by this point, matching how the notification
-		// goroutines below already run post-commit.
+		// helper below already runs post-commit.
 		const coverageNotificationCooldown = 60 * time.Second
 		var recentCount int64
 		if err := rawDB.Model(&models.ShiftCoverageRequest{}).
 			Where("group_id = ? AND requested_by_user_id = ? AND id != ? AND created_at > ?",
 				groupIDUint, targetUserID, created.ID, time.Now().Add(-coverageNotificationCooldown)).
 			Count(&recentCount).Error; err == nil && recentCount == 0 {
-			var requester models.User
-			var grp models.Group
-			var openRequests []models.ShiftCoverageRequest
-			rawDB.First(&requester, targetUserID)
-			rawDB.Select("name").First(&grp, groupIDUint)
-			rawDB.Where("group_id = ? AND requested_by_user_id = ? AND status = ?",
-				groupIDUint, targetUserID, models.CoverageRequestOpen).
-				Order("date, hour").Find(&openRequests)
-
-			title := fmt.Sprintf("Coverage needed in %s", grp.Name)
-			content := buildCoverageRequestSummary(displayName(requester), openRequests)
-
-			if emailService != nil && emailService.IsConfigured() {
-				go func() {
-					bgCtx := context.Background()
-					if err := sendGroupAnnouncementEmails(bgCtx, rawDB, emailService, groupIDUint, title, content); err != nil {
-						logging.WithContext(bgCtx).Error("Error sending coverage request emails", err)
-					}
-				}()
-			}
-			if groupMeService != nil {
-				go func() {
-					bgCtx := context.Background()
-					if err := sendUpdateToGroupMe(bgCtx, rawDB, groupMeService, groupIDUint, title, content); err != nil {
-						logging.WithContext(bgCtx).Error("Error sending coverage request to GroupMe", err)
-					}
-				}()
-			}
+			notifyGroupOfOpenCoverageRequests(rawDB, emailService, groupMeService, groupIDUint, targetUserID)
 		}
 	}
 }

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -219,3 +219,142 @@ func CreateCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeServ
 		}
 	}
 }
+
+// ClaimCoverageRequest lets any group member (other than the original
+// requester) take an open coverage request, provided they don't already
+// have a conflicting shift at that exact date/hour in any group. Requires
+// group membership (or site admin).
+func ClaimCoverageRequest(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawDB := db
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		requestID, err := strconv.ParseUint(c.Param("requestId"), 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request ID"})
+			return
+		}
+
+		var claimed models.ShiftCoverageRequest
+		err = db.Transaction(func(tx *gorm.DB) error {
+			var reqRow models.ShiftCoverageRequest
+			if err := tx.Where("id = ? AND group_id = ?", requestID, groupIDParam).First(&reqRow).Error; err != nil {
+				return errRequestNotFound
+			}
+			if reqRow.Status != models.CoverageRequestOpen {
+				return errRequestNotOpen
+			}
+			if reqRow.RequestedByUserID == callerUserID {
+				return errSelfClaim
+			}
+
+			// Conflict check spans every group the claimant belongs to - a
+			// real-world time conflict doesn't respect group boundaries.
+			var conflictCount int64
+			if err := tx.Model(&models.ShiftSlot{}).
+				Where("user_id = ? AND day_of_week = ? AND hour = ?", callerUserID, int(reqRow.Date.Weekday()), reqRow.Hour).
+				Count(&conflictCount).Error; err != nil {
+				return err
+			}
+			if conflictCount > 0 {
+				return errClaimConflict
+			}
+			if err := tx.Model(&models.ShiftCoverageRequest{}).
+				Where("claimed_by_user_id = ? AND date = ? AND hour = ? AND status = ?",
+					callerUserID, reqRow.Date, reqRow.Hour, models.CoverageRequestClaimed).
+				Count(&conflictCount).Error; err != nil {
+				return err
+			}
+			if conflictCount > 0 {
+				return errClaimConflict
+			}
+
+			now := time.Now().UTC()
+			reqRow.Status = models.CoverageRequestClaimed
+			reqRow.ClaimedByUserID = &callerUserID
+			reqRow.ClaimedAt = &now
+			if err := tx.Save(&reqRow).Error; err != nil {
+				return err
+			}
+			claimed = reqRow
+			return nil
+		})
+
+		switch {
+		case errors.Is(err, errRequestNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": errRequestNotFound.Error()})
+			return
+		case errors.Is(err, errRequestNotOpen):
+			c.JSON(http.StatusConflict, gin.H{"error": errRequestNotOpen.Error()})
+			return
+		case errors.Is(err, errSelfClaim):
+			c.JSON(http.StatusBadRequest, gin.H{"error": errSelfClaim.Error()})
+			return
+		case errors.Is(err, errClaimConflict):
+			c.JSON(http.StatusConflict, gin.H{"error": errClaimConflict.Error()})
+			return
+		case err != nil:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to claim coverage request"})
+			return
+		}
+
+		c.JSON(http.StatusOK, toCoverageRequestResponse(claimed))
+
+		notifyRequesterOfClaim(rawDB, emailService, groupMeService, claimed, callerUserID)
+	}
+}
+
+// notifyRequesterOfClaim tells the original requester their shift is
+// covered. Runs in the background so it never delays the HTTP response.
+func notifyRequesterOfClaim(db *gorm.DB, emailService *email.Service, groupMeService *groupme.Service, req models.ShiftCoverageRequest, claimantID uint) {
+	if emailService == nil && groupMeService == nil {
+		return
+	}
+	go func() {
+		bgCtx := context.Background()
+		logger := logging.WithContext(bgCtx)
+
+		var requester, claimant models.User
+		if err := db.WithContext(bgCtx).First(&requester, req.RequestedByUserID).Error; err != nil {
+			logger.Error("Failed to load requester for coverage claim notification", err)
+			return
+		}
+		if err := db.WithContext(bgCtx).First(&claimant, claimantID).Error; err != nil {
+			logger.Error("Failed to load claimant for coverage claim notification", err)
+			return
+		}
+
+		title := "Your shift is covered"
+		content := fmt.Sprintf("%s will cover your %s shift on %s.",
+			displayName(claimant), formatHourAMPM(req.Hour), req.Date.Format("Monday, January 2"))
+
+		if emailService != nil && emailService.IsConfigured() && requester.EmailNotificationsEnabled {
+			if err := emailService.SendAnnouncementEmail(bgCtx, requester.Email, title, content); err != nil {
+				logger.Error("Failed to send coverage claim email", err)
+			}
+		}
+		if groupMeService != nil {
+			if err := sendUpdateToGroupMe(bgCtx, db, groupMeService, req.GroupID, title, content); err != nil {
+				logger.Error("Failed to send coverage claim GroupMe message", err)
+			}
+		}
+	}()
+}

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -412,22 +412,60 @@ func CancelCoverageRequest(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// State check first: an already-cancelled request is a 409 conflict
+		// for anyone, not an authorization failure for the owner. Checking
+		// this before the ownership/admin gate matches the state-before-
+		// identity ordering ClaimCoverageRequest uses above (errRequestNotOpen
+		// before errSelfClaim) - otherwise a non-admin owner whose own
+		// already-cancelled request they try to cancel again would fail the
+		// "is it still open" authorization check and get a misleading 403.
+		if reqRow.Status == models.CoverageRequestCancelled {
+			c.JSON(http.StatusConflict, gin.H{"error": "Coverage request is already cancelled"})
+			return
+		}
+
 		isAdminCaller := checkGroupAdminAccess(db, userID, isAdmin, groupIDParam)
 		isOwnOpenRequest := reqRow.RequestedByUserID == callerUserID && reqRow.Status == models.CoverageRequestOpen
 		if !isOwnOpenRequest && !isAdminCaller {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Cannot cancel this coverage request"})
 			return
 		}
-		if reqRow.Status == models.CoverageRequestCancelled {
-			c.JSON(http.StatusConflict, gin.H{"error": "Coverage request is already cancelled"})
-			return
-		}
 
-		if err := db.Model(&reqRow).Update("status", models.CoverageRequestCancelled).Error; err != nil {
+		// Conditional update, gated on the state actually authorized above,
+		// closes the race with a concurrent claim (or cancel) landing between
+		// the read above and this write - same technique as the conditional
+		// update in ClaimCoverageRequest. A non-admin owner may only flip
+		// open -> cancelled; an admin may flip open or claimed -> cancelled.
+		var result *gorm.DB
+		if isAdminCaller {
+			result = db.Model(&models.ShiftCoverageRequest{}).
+				Where("id = ? AND status IN ?", reqRow.ID, []models.CoverageRequestStatus{models.CoverageRequestOpen, models.CoverageRequestClaimed}).
+				Update("status", models.CoverageRequestCancelled)
+		} else {
+			result = db.Model(&models.ShiftCoverageRequest{}).
+				Where("id = ? AND requested_by_user_id = ? AND status = ?", reqRow.ID, callerUserID, models.CoverageRequestOpen).
+				Update("status", models.CoverageRequestCancelled)
+		}
+		if result.Error != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cancel coverage request"})
 			return
 		}
+		if result.RowsAffected == 0 {
+			// Someone else changed the request's state between our read and
+			// this write. For an admin, the only remaining state given the
+			// (open, claimed) guard is "already cancelled". For a non-admin
+			// owner, it most likely means someone claimed it out from under
+			// them (or cancelled it) - either way it's no longer cancellable
+			// by them.
+			if isAdminCaller {
+				c.JSON(http.StatusConflict, gin.H{"error": "Coverage request is already cancelled"})
+			} else {
+				c.JSON(http.StatusConflict, gin.H{"error": "Coverage request is no longer open"})
+			}
+			return
+		}
 
+		reqRow.Status = models.CoverageRequestCancelled
 		c.JSON(http.StatusOK, toCoverageRequestResponse(reqRow))
 	}
 }

--- a/internal/handlers/schedule_coverage_postgres_test.go
+++ b/internal/handlers/schedule_coverage_postgres_test.go
@@ -100,10 +100,10 @@ func TestGetGroupScheduleOverview_Postgres_ClaimedRequestShowsAsCovering(t *test
 	// A future Tuesday, computed relative to whenever this test actually
 	// runs (nextWeekday is the same helper every other coverage-request
 	// test in this package uses for exactly this reason) - createOneCoverageRequest
-	// rejects a same-day-or-past date, so a hard-coded date here would start
-	// failing - with a misleading "expected 201, got 400" error that points
-	// nowhere near the timezone fix this test exists to guard - the day
-	// after whatever date got hard-coded.
+	// rejects a past date, so a hard-coded date here would start failing
+	// the day after whatever date got hard-coded, with a misleading
+	// "expected 201, got 400" error that points nowhere near the
+	// timezone fix this test exists to guard.
 	date := nextWeekday(time.Tuesday)
 	parsedDate, err := time.Parse("2006-01-02", date)
 	if err != nil {

--- a/internal/handlers/schedule_coverage_postgres_test.go
+++ b/internal/handlers/schedule_coverage_postgres_test.go
@@ -1,0 +1,174 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
+)
+
+// These tests exist because a manual smoke test against a real Postgres
+// instance surfaced a bug no SQLite-backed test (every other test in this
+// package) could catch: gorm.io/driver/postgres (via pgx) decodes
+// `timestamptz` columns into time.Time using time.Local, not UTC. Any
+// ShiftCoverageRequest.Date read back from the database - as opposed to a
+// value freshly parsed from a request body - came back shifted to whatever
+// the process's local timezone was, silently corrupting every
+// .Format()/.Weekday() call on it: ClaimCoverageRequest's response date,
+// its cross-group weekday conflict check, GetGroupScheduleOverview's
+// date-keyed roster lookup (which broke entirely - a claimed request never
+// showed as "covering"), and notification content. Fixed by forcing
+// time.Local = time.UTC in internal/database's init() (see that file).
+// These tests fail against that pre-fix state and pass after it, using the
+// same reachable-Postgres-or-skip contract as search_postgres_test.go's
+// openSearchTestPostgres/envOrDefault/tcpReachable helpers (shared, defined
+// in that file, package-wide).
+
+func TestShiftCoverageRequestDate_PostgresRoundTrip(t *testing.T) {
+	db := openSearchTestPostgres(t)
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+
+	unique := time.Now().UnixNano()
+	requester := &models.User{
+		Username: fmt.Sprintf("pgdate-requester-%d", unique),
+		Email:    fmt.Sprintf("pgdate-requester-%d@example.com", unique),
+		Password: "x",
+	}
+	if err := tx.Create(requester).Error; err != nil {
+		t.Fatalf("create requester: %v", err)
+	}
+	group := &models.Group{Name: fmt.Sprintf("PgDateTest-%d", unique)}
+	if err := tx.Create(group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+
+	// 2026-08-11 is a Tuesday (weekday 2).
+	utcMidnight := time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+	created := &models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: requester.ID,
+		Date:              utcMidnight,
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := tx.Create(created).Error; err != nil {
+		t.Fatalf("create ShiftCoverageRequest: %v", err)
+	}
+
+	var fetched models.ShiftCoverageRequest
+	if err := tx.Where("id = ?", created.ID).First(&fetched).Error; err != nil {
+		t.Fatalf("re-fetch ShiftCoverageRequest: %v", err)
+	}
+
+	if got := fetched.Date.Format("2006-01-02"); got != "2026-08-11" {
+		t.Fatalf("Date.Format(\"2006-01-02\") after a real Postgres round-trip = %q, want \"2026-08-11\" (time.Local must be UTC - see internal/database's init())", got)
+	}
+	if got := fetched.Date.Weekday(); got != time.Tuesday {
+		t.Fatalf("Date.Weekday() after a real Postgres round-trip = %v, want Tuesday (time.Local must be UTC - see internal/database's init())", got)
+	}
+}
+
+func TestGetGroupScheduleOverview_Postgres_ClaimedRequestShowsAsCovering(t *testing.T) {
+	// End-to-end version of the same bug: this is the exact sequence (create
+	// -> claim -> view overview) manually verified against a real Postgres
+	// instance to surface it in the first place. Before the fix, the
+	// claimant never appeared as "covering" - GetGroupScheduleOverview's
+	// date-keyed lookup, built from a DB-read ShiftCoverageRequest.Date,
+	// silently failed to match the date computed by iterating the requested
+	// week, because the two representations disagreed by one day.
+	db := openSearchTestPostgres(t)
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+
+	unique := time.Now().UnixNano()
+	requester := CreateTestUser(t, tx, fmt.Sprintf("pgcov-req-%d", unique), fmt.Sprintf("pgcov-req-%d@example.com", unique), "password123", false)
+	claimant := CreateTestUser(t, tx, fmt.Sprintf("pgcov-claim-%d", unique), fmt.Sprintf("pgcov-claim-%d@example.com", unique), "password123", false)
+	group := CreateTestGroup(t, tx, fmt.Sprintf("PgCovTest-%d", unique), "Postgres coverage overlay test")
+	AddUserToGroupWithAdmin(t, tx, requester.ID, group.ID, false)
+	AddUserToGroupWithAdmin(t, tx, claimant.ID, group.ID, false)
+	if err := tx.Model(group).Update("scheduling_enabled", true).Error; err != nil {
+		t.Fatalf("enable scheduling: %v", err)
+	}
+
+	// 2026-08-11 is a Tuesday (weekday 2).
+	date := "2026-08-11"
+	if err := tx.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10}).Error; err != nil {
+		t.Fatalf("create shift slot: %v", err)
+	}
+
+	createBody := fmt.Sprintf(`{"date":"%s","hour":10}`, date)
+	createResp := performCreateCoverageRequest(tx, requester.ID, false, group.ID, createBody)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("expected 201 creating coverage request, got %d: %s", createResp.Code, createResp.Body.String())
+	}
+	var created coverageRequestResponse
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	claimResp := performClaimCoverageRequest(tx, claimant.ID, group.ID, created.ID)
+	if claimResp.Code != http.StatusOK {
+		t.Fatalf("expected 200 claiming coverage request, got %d: %s", claimResp.Code, claimResp.Body.String())
+	}
+
+	weekStart := "2026-08-09" // the Sunday that starts 2026-08-11's week
+	overview := performGetGroupScheduleOverview(tx, requester.ID, group.ID, weekStart)
+	if overview.Code != http.StatusOK {
+		t.Fatalf("expected 200 fetching overview, got %d: %s", overview.Code, overview.Body.String())
+	}
+	var body struct {
+		Slots []scheduleOverviewSlot `json:"slots"`
+	}
+	if err := json.Unmarshal(overview.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode overview response: %v", err)
+	}
+
+	var found bool
+	for _, s := range body.Slots {
+		if s.Date != date || s.Hour != 10 {
+			continue
+		}
+		for _, m := range s.Members {
+			if m.UserID == claimant.ID {
+				found = true
+				if m.Status != "covering" {
+					t.Fatalf("claimant's status = %q, want \"covering\" (time.Local must be UTC - see internal/database's init())", m.Status)
+				}
+			}
+			if m.UserID == requester.ID {
+				t.Fatalf("original requester still appears in the roster after their shift was claimed; got status %q", m.Status)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("claimant never appears in the overview roster for the claimed date/hour at all - the date-keyed lookup silently failed to match")
+	}
+}
+
+// performGetGroupScheduleOverview mirrors performCreateCoverageRequest's
+// pattern for GetGroupScheduleOverview, which existing SQLite tests
+// (TestGetGroupScheduleOverview_EffectiveRoster) set up inline rather than
+// via a shared helper - factored out here since this file needs the exact
+// same request shape.
+func performGetGroupScheduleOverview(db *gorm.DB, callerID uint, groupID uint, weekStart string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", false)
+		c.Next()
+	})
+	router.GET("/groups/:id/schedule/overview", GetGroupScheduleOverview(db))
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/overview?week_start=%s", groupID, weekStart), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}

--- a/internal/handlers/schedule_coverage_postgres_test.go
+++ b/internal/handlers/schedule_coverage_postgres_test.go
@@ -97,9 +97,20 @@ func TestGetGroupScheduleOverview_Postgres_ClaimedRequestShowsAsCovering(t *test
 		t.Fatalf("enable scheduling: %v", err)
 	}
 
-	// 2026-08-11 is a Tuesday (weekday 2).
-	date := "2026-08-11"
-	if err := tx.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10}).Error; err != nil {
+	// A future Tuesday, computed relative to whenever this test actually
+	// runs (nextWeekday is the same helper every other coverage-request
+	// test in this package uses for exactly this reason) - createOneCoverageRequest
+	// rejects a same-day-or-past date, so a hard-coded date here would start
+	// failing - with a misleading "expected 201, got 400" error that points
+	// nowhere near the timezone fix this test exists to guard - the day
+	// after whatever date got hard-coded.
+	date := nextWeekday(time.Tuesday)
+	parsedDate, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		t.Fatalf("parse computed date: %v", err)
+	}
+	dayOfWeek := int(parsedDate.Weekday())
+	if err := tx.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: dayOfWeek, Hour: 10}).Error; err != nil {
 		t.Fatalf("create shift slot: %v", err)
 	}
 
@@ -118,7 +129,7 @@ func TestGetGroupScheduleOverview_Postgres_ClaimedRequestShowsAsCovering(t *test
 		t.Fatalf("expected 200 claiming coverage request, got %d: %s", claimResp.Code, claimResp.Body.String())
 	}
 
-	weekStart := "2026-08-09" // the Sunday that starts 2026-08-11's week
+	weekStart := parsedDate.AddDate(0, 0, -dayOfWeek).Format("2006-01-02") // the Sunday that starts date's week
 	overview := performGetGroupScheduleOverview(tx, requester.ID, group.ID, weekStart)
 	if overview.Code != http.StatusOK {
 		t.Fatalf("expected 200 fetching overview, got %d: %s", overview.Code, overview.Body.String())

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -176,3 +176,109 @@ func TestCreateCoverageRequest(t *testing.T) {
 		}
 	})
 }
+
+func performClaimCoverageRequest(db *gorm.DB, callerID uint, groupID, requestID uint) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", false)
+		c.Next()
+	})
+	router.POST("/groups/:id/schedule/coverage-requests/:requestId/claim", ClaimCoverageRequest(db, nil, nil))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/groups/%d/schedule/coverage-requests/%d/claim", groupID, requestID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func createOpenCoverageRequest(t *testing.T, db *gorm.DB, groupID, userID uint, dayOfWeek, hour int, date time.Time) *models.ShiftCoverageRequest {
+	req := &models.ShiftCoverageRequest{
+		GroupID:           groupID,
+		RequestedByUserID: userID,
+		Date:              date,
+		Hour:              hour,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(req).Error; err != nil {
+		t.Fatalf("Failed to create coverage request: %v", err)
+	}
+	return req
+}
+
+func TestClaimCoverageRequest(t *testing.T) {
+	t.Run("happy path claims and updates status", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, claimant, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performClaimCoverageRequest(db, claimant.ID, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var updated models.ShiftCoverageRequest
+		if err := db.First(&updated, reqRow.ID).Error; err != nil {
+			t.Fatalf("Failed to reload request: %v", err)
+		}
+		if updated.Status != models.CoverageRequestClaimed {
+			t.Fatalf("Expected status claimed, got %s", updated.Status)
+		}
+		if updated.ClaimedByUserID == nil || *updated.ClaimedByUserID != claimant.ID {
+			t.Fatalf("Expected claimed_by_user_id %d, got %v", claimant.ID, updated.ClaimedByUserID)
+		}
+	})
+
+	t.Run("rejects claiming an already-claimed request", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, claimant, group := setupCoverageTestGroup(t, db)
+		thirdUser := CreateTestUser(t, db, "third", "third@example.com", "password123", false)
+		AddUserToGroupWithAdmin(t, db, thirdUser.ID, group.ID, false)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		first := performClaimCoverageRequest(db, claimant.ID, group.ID, reqRow.ID)
+		if first.Code != http.StatusOK {
+			t.Fatalf("Expected first claim to succeed, got %d: %s", first.Code, first.Body.String())
+		}
+		second := performClaimCoverageRequest(db, thirdUser.ID, group.ID, reqRow.ID)
+		if second.Code != http.StatusConflict {
+			t.Fatalf("Expected 409 on second claim, got %d: %s", second.Code, second.Body.String())
+		}
+	})
+
+	t.Run("rejects the requester claiming their own request", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performClaimCoverageRequest(db, requester.ID, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("rejects a claimant with a conflicting shift at that exact date/hour", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, claimant, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		// claimant already has their own Tuesday 10am shift in a different group.
+		otherGroup := CreateTestGroup(t, db, "Cats", "Cat volunteers")
+		AddUserToGroupWithAdmin(t, db, claimant.ID, otherGroup.ID, false)
+		if err := db.Create(&models.ShiftSlot{UserID: claimant.ID, GroupID: otherGroup.ID, DayOfWeek: 2, Hour: 10}).Error; err != nil {
+			t.Fatalf("Failed to create conflicting shift slot: %v", err)
+		}
+
+		w := performClaimCoverageRequest(db, claimant.ID, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusConflict {
+			t.Fatalf("Expected 409 on conflict, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -248,6 +248,33 @@ func TestCreateCoverageRequest(t *testing.T) {
 	})
 }
 
+func TestBuildCoverageRequestSummary(t *testing.T) {
+	t.Run("a single open request renders as one sentence, not a list", func(t *testing.T) {
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		summary := buildCoverageRequestSummary("Jane Doe", []models.ShiftCoverageRequest{
+			{Date: date, Hour: 10},
+		})
+		want := fmt.Sprintf("Jane Doe needs coverage for their 10:00 AM shift on %s.", date.Format("Monday, January 2"))
+		if summary != want {
+			t.Fatalf("Expected %q, got %q", want, summary)
+		}
+	})
+
+	t.Run("multiple open requests render as one bulk list, not separate messages", func(t *testing.T) {
+		tue, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		thu, _ := time.Parse("2006-01-02", nextWeekday(time.Thursday))
+		summary := buildCoverageRequestSummary("Jane Doe", []models.ShiftCoverageRequest{
+			{Date: tue, Hour: 10},
+			{Date: thu, Hour: 14},
+		})
+		want := fmt.Sprintf("Jane Doe needs coverage for 2 shifts:\n- %s at 10:00 AM\n- %s at 2:00 PM",
+			tue.Format("Monday, January 2"), thu.Format("Monday, January 2"))
+		if summary != want {
+			t.Fatalf("Expected %q, got %q", want, summary)
+		}
+	})
+}
+
 func performClaimCoverageRequest(db *gorm.DB, callerID uint, groupID, requestID uint) *httptest.ResponseRecorder {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+)
+
+func TestShiftCoverageRequestMigration(t *testing.T) {
+	db := SetupTestDB(t)
+	user := CreateTestUser(t, db, "volunteer1", "volunteer1@example.com", "password123", false)
+	group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+
+	req := &models.ShiftCoverageRequest{
+		GroupID:           group.ID,
+		RequestedByUserID: user.ID,
+		Date:              time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC),
+		Hour:              10,
+		Status:            models.CoverageRequestOpen,
+	}
+	if err := db.Create(req).Error; err != nil {
+		t.Fatalf("Failed to create ShiftCoverageRequest: %v", err)
+	}
+	if req.ID == 0 {
+		t.Fatal("Expected ShiftCoverageRequest to get an assigned ID")
+	}
+}

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -455,6 +456,126 @@ func TestCancelCoverageRequest(t *testing.T) {
 
 		w := performCancelCoverageRequest(db, other.ID, false, group.ID, reqRow.ID)
 
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func performCreateCoverageRequestsBatch(db *gorm.DB, callerID uint, groupID uint, body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", false)
+		c.Next()
+	})
+	router.POST("/groups/:id/schedule/coverage-requests/batch", CreateCoverageRequestsBatch(db, nil, nil))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/groups/%d/schedule/coverage-requests/batch", groupID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestCreateCoverageRequestsBatch(t *testing.T) {
+	t.Run("happy path creates multiple open requests and reports none skipped", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		// requester already has Tuesday 10am (from setupCoverageTestGroup); add Thursday 2pm too.
+		if err := db.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 4, Hour: 14}).Error; err != nil {
+			t.Fatalf("Failed to create second shift slot: %v", err)
+		}
+		tue := nextWeekday(time.Tuesday)
+		thu := nextWeekday(time.Thursday)
+		body := fmt.Sprintf(`{"requests":[{"date":"%s","hour":10},{"date":"%s","hour":14}]}`, tue, thu)
+
+		w := performCreateCoverageRequestsBatch(db, requester.ID, group.ID, body)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp coverageRequestBatchResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(resp.Created) != 2 {
+			t.Fatalf("Expected 2 created, got %d", len(resp.Created))
+		}
+		if len(resp.Skipped) != 0 {
+			t.Fatalf("Expected 0 skipped, got %d", len(resp.Skipped))
+		}
+	})
+
+	t.Run("a duplicate item is skipped with a reason while the rest still succeed", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		if err := db.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 4, Hour: 14}).Error; err != nil {
+			t.Fatalf("Failed to create second shift slot: %v", err)
+		}
+		tue := nextWeekday(time.Tuesday)
+		thu := nextWeekday(time.Thursday)
+
+		// Pre-create an open request for Tuesday so the batch's Tuesday item collides.
+		firstBody := fmt.Sprintf(`{"date":"%s","hour":10}`, tue)
+		if first := performCreateCoverageRequest(db, requester.ID, false, group.ID, firstBody); first.Code != http.StatusCreated {
+			t.Fatalf("Expected setup request to succeed, got %d: %s", first.Code, first.Body.String())
+		}
+
+		body := fmt.Sprintf(`{"requests":[{"date":"%s","hour":10},{"date":"%s","hour":14}]}`, tue, thu)
+		w := performCreateCoverageRequestsBatch(db, requester.ID, group.ID, body)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp coverageRequestBatchResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(resp.Created) != 1 {
+			t.Fatalf("Expected 1 created (Thursday), got %d", len(resp.Created))
+		}
+		if len(resp.Skipped) != 1 {
+			t.Fatalf("Expected 1 skipped (Tuesday, duplicate), got %d", len(resp.Skipped))
+		}
+		if resp.Skipped[0].Hour != 10 {
+			t.Fatalf("Expected the skipped item to be the Tuesday 10am one, got hour %d", resp.Skipped[0].Hour)
+		}
+	})
+
+	t.Run("empty requests array is rejected", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		w := performCreateCoverageRequestsBatch(db, requester.ID, group.ID, `{"requests":[]}`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("a structurally invalid item rejects the whole batch", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		tue := nextWeekday(time.Tuesday)
+		body := fmt.Sprintf(`{"requests":[{"date":"%s","hour":10},{"date":"not-a-date","hour":10}]}`, tue)
+		w := performCreateCoverageRequestsBatch(db, requester.ID, group.ID, body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+		var count int64
+		db.Model(&models.ShiftCoverageRequest{}).Where("group_id = ?", group.ID).Count(&count)
+		if count != 0 {
+			t.Fatalf("Expected no requests created when the batch is rejected, got %d", count)
+		}
+	})
+
+	t.Run("non-member is denied", func(t *testing.T) {
+		db := SetupTestDB(t)
+		_, _, group := setupCoverageTestGroup(t, db)
+		outsider := CreateTestUser(t, db, "outsider", "outsider@example.com", "password123", false)
+		tue := nextWeekday(time.Tuesday)
+		body := fmt.Sprintf(`{"requests":[{"date":"%s","hour":10}]}`, tue)
+		w := performCreateCoverageRequestsBatch(db, outsider.ID, group.ID, body)
 		if w.Code != http.StatusForbidden {
 			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
 		}

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -553,6 +553,27 @@ func TestCreateCoverageRequestsBatch(t *testing.T) {
 		}
 	})
 
+	t.Run("a batch exceeding the item cap is rejected and creates nothing", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+
+		items := make([]string, 0, 201)
+		for i := 0; i < 201; i++ {
+			items = append(items, `{"date":"2027-01-01","hour":10}`)
+		}
+		body := fmt.Sprintf(`{"requests":[%s]}`, strings.Join(items, ","))
+		w := performCreateCoverageRequestsBatch(db, requester.ID, group.ID, body)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+		var count int64
+		db.Model(&models.ShiftCoverageRequest{}).Where("group_id = ?", group.ID).Count(&count)
+		if count != 0 {
+			t.Fatalf("Expected no requests created when the batch exceeds the item cap, got %d", count)
+		}
+	})
+
 	t.Run("a structurally invalid item rejects the whole batch", func(t *testing.T) {
 		db := SetupTestDB(t)
 		requester, _, group := setupCoverageTestGroup(t, db)

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -282,3 +282,83 @@ func TestClaimCoverageRequest(t *testing.T) {
 		}
 	})
 }
+
+func performCancelCoverageRequest(db *gorm.DB, callerID uint, isAdmin bool, groupID, requestID uint) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", isAdmin)
+		c.Next()
+	})
+	router.DELETE("/groups/:id/schedule/coverage-requests/:requestId", CancelCoverageRequest(db))
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/groups/%d/schedule/coverage-requests/%d", groupID, requestID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestCancelCoverageRequest(t *testing.T) {
+	t.Run("requester can cancel their own open request", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performCancelCoverageRequest(db, requester.ID, false, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var updated models.ShiftCoverageRequest
+		db.First(&updated, reqRow.ID)
+		if updated.Status != models.CoverageRequestCancelled {
+			t.Fatalf("Expected status cancelled, got %s", updated.Status)
+		}
+	})
+
+	t.Run("requester cannot cancel after it's claimed", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, claimant, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+		if claim := performClaimCoverageRequest(db, claimant.ID, group.ID, reqRow.ID); claim.Code != http.StatusOK {
+			t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+		}
+
+		w := performCancelCoverageRequest(db, requester.ID, false, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("group admin can cancel any request", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		admin := CreateTestUser(t, db, "groupadmin", "groupadmin@example.com", "password123", false)
+		AddUserToGroupWithAdmin(t, db, admin.ID, group.ID, true)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performCancelCoverageRequest(db, admin.ID, false, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("non-admin, non-requester cannot cancel", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performCancelCoverageRequest(db, other.ID, false, group.ID, reqRow.ID)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -112,16 +112,45 @@ func TestCreateCoverageRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects a past or same-day date", func(t *testing.T) {
+	t.Run("rejects a past date", func(t *testing.T) {
 		db := SetupTestDB(t)
 		requester, _, group := setupCoverageTestGroup(t, db)
-		today := time.Now().UTC().Format("2006-01-02")
+		yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
 
-		body := fmt.Sprintf(`{"date":"%s","hour":10}`, today)
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, yesterday)
 		w := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
 
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("accepts a same-day date", func(t *testing.T) {
+		// Same-day requests are legitimate (e.g. realizing this afternoon you
+		// can't make a shift later today) and must match the frontend's UTC
+		// calendar-date notion of "today" exactly. The requester needs a
+		// ShiftSlot matching today's actual weekday/hour, not the fixed
+		// Tuesday 10am slot setupCoverageTestGroup wires up, since "today"
+		// varies with when the test runs.
+		db := SetupTestDB(t)
+		requester := CreateTestUser(t, db, "requester", "requester@example.com", "password123", false)
+		group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+		AddUserToGroupWithAdmin(t, db, requester.ID, group.ID, false)
+		if err := db.Model(group).Update("scheduling_enabled", true).Error; err != nil {
+			t.Fatalf("Failed to enable scheduling: %v", err)
+		}
+		now := time.Now().UTC()
+		slot := &models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: int(now.Weekday()), Hour: 10}
+		if err := db.Create(slot).Error; err != nil {
+			t.Fatalf("Failed to create shift slot: %v", err)
+		}
+		today := now.Format("2006-01-02")
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, today)
+		w := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 
@@ -160,6 +189,48 @@ func TestCreateCoverageRequest(t *testing.T) {
 		}
 		if created.RequestedByUserID != requester.ID {
 			t.Fatalf("Expected request to be for requester %d, got %d", requester.ID, created.RequestedByUserID)
+		}
+	})
+
+	t.Run("second request within the cooldown window still succeeds", func(t *testing.T) {
+		// Guards the notification-cooldown check added in CreateCoverageRequest:
+		// the recent-request count query now runs unconditionally (even with
+		// nil emailService/groupMeService, as performCreateCoverageRequest
+		// always passes), so a rapid cancel-and-recreate cycle by the same
+		// user must not error or panic - it should just skip notifications,
+		// which this test can't directly observe without mocking the
+		// email/GroupMe services, so it asserts the structural outcome
+		// instead: both rows get created successfully.
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date := nextWeekday(time.Tuesday)
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, date)
+
+		first := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+		if first.Code != http.StatusCreated {
+			t.Fatalf("Expected first request to succeed, got %d: %s", first.Code, first.Body.String())
+		}
+		var firstCreated models.ShiftCoverageRequest
+		if err := db.Where("group_id = ? AND requested_by_user_id = ?", group.ID, requester.ID).First(&firstCreated).Error; err != nil {
+			t.Fatalf("Expected first request to be persisted: %v", err)
+		}
+		if err := db.Model(&firstCreated).Update("status", models.CoverageRequestCancelled).Error; err != nil {
+			t.Fatalf("Failed to cancel first request: %v", err)
+		}
+
+		second := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+		if second.Code != http.StatusCreated {
+			t.Fatalf("Expected second request within cooldown to still succeed, got %d: %s", second.Code, second.Body.String())
+		}
+
+		var count int64
+		if err := db.Model(&models.ShiftCoverageRequest{}).
+			Where("group_id = ? AND requested_by_user_id = ?", group.ID, requester.ID).
+			Count(&count).Error; err != nil {
+			t.Fatalf("Failed to count requests: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("Expected 2 requests to exist (one cancelled, one active), got %d", count)
 		}
 	})
 

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -1,10 +1,16 @@
 package handlers
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
+	"gorm.io/gorm"
 )
 
 func TestShiftCoverageRequestMigration(t *testing.T) {
@@ -25,4 +31,148 @@ func TestShiftCoverageRequestMigration(t *testing.T) {
 	if req.ID == 0 {
 		t.Fatal("Expected ShiftCoverageRequest to get an assigned ID")
 	}
+}
+
+func setupCoverageTestGroup(t *testing.T, db *gorm.DB) (requester, other *models.User, group *models.Group) {
+	requester = CreateTestUser(t, db, "requester", "requester@example.com", "password123", false)
+	other = CreateTestUser(t, db, "other", "other@example.com", "password123", false)
+	group = CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, requester.ID, group.ID, false)
+	AddUserToGroupWithAdmin(t, db, other.ID, group.ID, false)
+	if err := db.Model(group).Update("scheduling_enabled", true).Error; err != nil {
+		t.Fatalf("Failed to enable scheduling: %v", err)
+	}
+	// requester has a recurring Tuesday 10am shift.
+	slot := &models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10}
+	if err := db.Create(slot).Error; err != nil {
+		t.Fatalf("Failed to create shift slot: %v", err)
+	}
+	return requester, other, group
+}
+
+func performCreateCoverageRequest(db *gorm.DB, callerID uint, isAdmin bool, groupID uint, body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", isAdmin)
+		c.Next()
+	})
+	router.POST("/groups/:id/schedule/coverage-requests", CreateCoverageRequest(db, nil, nil))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/groups/%d/schedule/coverage-requests", groupID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// nextWeekday returns the next future date (strictly after today) that
+// falls on the given time.Weekday, formatted as "2006-01-02".
+func nextWeekday(weekday time.Weekday) string {
+	today := time.Now().UTC()
+	daysAhead := (int(weekday) - int(today.Weekday()) + 7) % 7
+	if daysAhead == 0 {
+		daysAhead = 7
+	}
+	return today.AddDate(0, 0, daysAhead).Format("2006-01-02")
+}
+
+func TestCreateCoverageRequest(t *testing.T) {
+	t.Run("happy path creates an open request", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date := nextWeekday(time.Tuesday)
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, date)
+		w := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created models.ShiftCoverageRequest
+		if err := db.Where("group_id = ? AND requested_by_user_id = ?", group.ID, requester.ID).First(&created).Error; err != nil {
+			t.Fatalf("Expected request to be persisted: %v", err)
+		}
+		if created.Status != models.CoverageRequestOpen {
+			t.Fatalf("Expected status open, got %s", created.Status)
+		}
+	})
+
+	t.Run("rejects a date whose weekday has no matching shift", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date := nextWeekday(time.Wednesday) // requester's slot is Tuesday
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, date)
+		w := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("rejects a past or same-day date", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		today := time.Now().UTC().Format("2006-01-02")
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, today)
+		w := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("rejects a duplicate open request for the same date and hour", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date := nextWeekday(time.Tuesday)
+		body := fmt.Sprintf(`{"date":"%s","hour":10}`, date)
+
+		first := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+		if first.Code != http.StatusCreated {
+			t.Fatalf("Expected first request to succeed, got %d: %s", first.Code, first.Body.String())
+		}
+		second := performCreateCoverageRequest(db, requester.ID, false, group.ID, body)
+		if second.Code != http.StatusConflict {
+			t.Fatalf("Expected 409 on duplicate, got %d: %s", second.Code, second.Body.String())
+		}
+	})
+
+	t.Run("group admin can create on behalf of a member", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		admin := CreateTestUser(t, db, "groupadmin", "groupadmin@example.com", "password123", false)
+		AddUserToGroupWithAdmin(t, db, admin.ID, group.ID, true)
+		date := nextWeekday(time.Tuesday)
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10,"user_id":%d}`, date, requester.ID)
+		w := performCreateCoverageRequest(db, admin.ID, false, group.ID, body)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created models.ShiftCoverageRequest
+		if err := db.Where("group_id = ?", group.ID).First(&created).Error; err != nil {
+			t.Fatalf("Expected request to be persisted: %v", err)
+		}
+		if created.RequestedByUserID != requester.ID {
+			t.Fatalf("Expected request to be for requester %d, got %d", requester.ID, created.RequestedByUserID)
+		}
+	})
+
+	t.Run("non-admin cannot create on behalf of another member", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		date := nextWeekday(time.Tuesday)
+
+		body := fmt.Sprintf(`{"date":"%s","hour":10,"user_id":%d}`, date, requester.ID)
+		w := performCreateCoverageRequest(db, other.ID, false, group.ID, body)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
 }

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -872,14 +872,20 @@ func TestGetGroupScheduleOverview_NonAdminMemberCanAccess(t *testing.T) {
 func TestGetGroupScheduleOverview_EffectiveRoster(t *testing.T) {
 	db := SetupTestDB(t)
 	requester := CreateTestUser(t, db, "requester", "requester@example.com", "password123", false)
+	requester2 := CreateTestUser(t, db, "requester2", "requester2@example.com", "password123", false)
 	claimant := CreateTestUser(t, db, "claimant", "claimant@example.com", "password123", false)
 	viewer := CreateTestUser(t, db, "viewer", "viewer@example.com", "password123", false)
 	group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
-	for _, u := range []*models.User{requester, claimant, viewer} {
+	for _, u := range []*models.User{requester, requester2, claimant, viewer} {
 		AddUserToGroupWithAdmin(t, db, u.ID, group.ID, false)
 	}
 	db.Model(group).Update("scheduling_enabled", true)
 	db.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10})
+	// requester2 shares the exact same recurring (day_of_week, hour) bucket
+	// as requester - this is what makes it possible for two different
+	// members to each file their own coverage request for the same
+	// calendar date/hour.
+	db.Create(&models.ShiftSlot{UserID: requester2.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10})
 
 	weekStart := time.Now().UTC().Truncate(24 * time.Hour)
 	weekStart = weekStart.AddDate(0, 0, -int(weekStart.Weekday())) // this week's Sunday
@@ -980,6 +986,71 @@ func TestGetGroupScheduleOverview_EffectiveRoster(t *testing.T) {
 		}
 		if !claimantPresent {
 			t.Fatal("Expected claimant to appear in the roster, tagged covering")
+		}
+	})
+
+	t.Run("two members sharing the same bucket each get their own open request", func(t *testing.T) {
+		req1 := &models.ShiftCoverageRequest{GroupID: group.ID, RequestedByUserID: requester.ID, Date: tuesday, Hour: 10, Status: models.CoverageRequestOpen}
+		req2 := &models.ShiftCoverageRequest{GroupID: group.ID, RequestedByUserID: requester2.ID, Date: tuesday, Hour: 10, Status: models.CoverageRequestOpen}
+		db.Create(req1)
+		db.Create(req2)
+		defer db.Delete(req1)
+		defer db.Delete(req2)
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("user_id", viewer.ID)
+			c.Set("is_admin", false)
+			c.Next()
+		})
+		router.GET("/groups/:id/schedule/overview", GetGroupScheduleOverview(db))
+
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/overview?week_start=%s", group.ID, weekStart.Format("2006-01-02")), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body struct {
+			Slots []scheduleOverviewSlot `json:"slots"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		var m1, m2 *scheduleOverviewMember
+		for i, s := range body.Slots {
+			if s.Date != tuesday.Format("2006-01-02") || s.Hour != 10 {
+				continue
+			}
+			for j, m := range s.Members {
+				if m.UserID == requester.ID {
+					m1 = &body.Slots[i].Members[j]
+				}
+				if m.UserID == requester2.ID {
+					m2 = &body.Slots[i].Members[j]
+				}
+			}
+		}
+		if m1 == nil || m2 == nil {
+			t.Fatalf("Expected both requester and requester2 to appear in the roster, got requester=%v requester2=%v", m1, m2)
+		}
+		if m1.Status != "needs_coverage" || m2.Status != "needs_coverage" {
+			t.Fatalf("Expected both members tagged needs_coverage, got requester=%s requester2=%s", m1.Status, m2.Status)
+		}
+		if m1.CoverageRequestID == nil || m2.CoverageRequestID == nil {
+			t.Fatal("Expected both members to carry a coverage_request_id")
+		}
+		if *m1.CoverageRequestID == *m2.CoverageRequestID {
+			t.Fatal("Expected requester and requester2 to reference distinct coverage requests")
+		}
+		if *m1.CoverageRequestID != req1.ID {
+			t.Fatalf("Expected requester's coverage_request_id to be %d, got %d", req1.ID, *m1.CoverageRequestID)
+		}
+		if *m2.CoverageRequestID != req2.ID {
+			t.Fatalf("Expected requester2's coverage_request_id to be %d, got %d", req2.ID, *m2.CoverageRequestID)
 		}
 	})
 }

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -397,6 +397,107 @@ func TestUpdateMySchedule_CancelsOrphanedCoverageRequests(t *testing.T) {
 	}
 }
 
+// TestUpdateMemberSchedule_CancelsRedundantClaimsForNewSlots verifies the
+// root-cause fix for a claimant later gaining a conflicting ShiftSlot:
+// Alice requests coverage for her Tuesday 10am shift, Bob claims it (Bob
+// has no Tuesday 10am ShiftSlot of his own at that point). An admin then
+// edits Bob's schedule to add a Tuesday 10am slot. Without cancelling the
+// redundant claim, Bob would render twice in GetGroupScheduleOverview for
+// that slot - once as a normal member (his new ShiftSlot), once as
+// "covering" (his old claim).
+func TestUpdateMemberSchedule_CancelsRedundantClaimsForNewSlots(t *testing.T) {
+	db := SetupTestDB(t)
+	admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+	alice := CreateTestUser(t, db, "alice", "alice@test.com", "password123", false)
+	bob := CreateTestUser(t, db, "bob", "bob@test.com", "password123", false)
+	group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, alice.ID, group.ID, false)
+	AddUserToGroupWithAdmin(t, db, bob.ID, group.ID, false)
+
+	db.Create(&models.ShiftSlot{UserID: alice.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10})
+
+	date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+	reqRow := createOpenCoverageRequest(t, db, group.ID, alice.ID, 2, 10, date)
+	if claim := performClaimCoverageRequest(db, bob.ID, group.ID, reqRow.ID); claim.Code != http.StatusOK {
+		t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+	}
+
+	// Admin adds Bob to Tuesday 10am, colliding with the claim he already
+	// holds for that weekday/hour.
+	c, w := setupGroupTestContext(admin.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "userId", Value: fmt.Sprintf("%d", bob.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, bob.ID),
+		bytes.NewBufferString(`{"slots":[{"day_of_week":2,"hour":10}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateMemberSchedule(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated models.ShiftCoverageRequest
+	if err := db.First(&updated, reqRow.ID).Error; err != nil {
+		t.Fatalf("failed to reload coverage request: %v", err)
+	}
+	if updated.Status != models.CoverageRequestCancelled {
+		t.Errorf("expected the redundant claim to be cancelled once the claimant gained a colliding ShiftSlot, got %s", updated.Status)
+	}
+}
+
+// TestUpdateMemberSchedule_KeepsClaimsForDifferentSlots is the companion
+// case to TestUpdateMemberSchedule_CancelsRedundantClaimsForNewSlots: a
+// claim for a weekday/hour that does NOT collide with the newly-added slot
+// must survive the schedule edit.
+func TestUpdateMemberSchedule_KeepsClaimsForDifferentSlots(t *testing.T) {
+	db := SetupTestDB(t)
+	admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+	alice := CreateTestUser(t, db, "alice", "alice@test.com", "password123", false)
+	bob := CreateTestUser(t, db, "bob", "bob@test.com", "password123", false)
+	group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, alice.ID, group.ID, false)
+	AddUserToGroupWithAdmin(t, db, bob.ID, group.ID, false)
+
+	// Alice's shift needing coverage is Wednesday 9am, not Tuesday 10am.
+	db.Create(&models.ShiftSlot{UserID: alice.ID, GroupID: group.ID, DayOfWeek: 3, Hour: 9})
+
+	wedDate, _ := time.Parse("2006-01-02", nextWeekday(time.Wednesday))
+	reqRow := createOpenCoverageRequest(t, db, group.ID, alice.ID, 3, 9, wedDate)
+	if claim := performClaimCoverageRequest(db, bob.ID, group.ID, reqRow.ID); claim.Code != http.StatusOK {
+		t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+	}
+
+	// Admin adds Bob to Tuesday 10am - a different weekday/hour than his
+	// Wednesday 9am claim, so the claim must not be cancelled.
+	c, w := setupGroupTestContext(admin.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "userId", Value: fmt.Sprintf("%d", bob.ID)},
+	}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/%d", group.ID, bob.ID),
+		bytes.NewBufferString(`{"slots":[{"day_of_week":2,"hour":10}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateMemberSchedule(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated models.ShiftCoverageRequest
+	if err := db.First(&updated, reqRow.ID).Error; err != nil {
+		t.Fatalf("failed to reload coverage request: %v", err)
+	}
+	if updated.Status != models.CoverageRequestClaimed {
+		t.Errorf("expected the claim for a non-colliding weekday/hour to survive, got %s", updated.Status)
+	}
+}
+
 func TestGetMemberSchedule(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/networkengineer-cloud/go-volunteer-media/internal/models"
@@ -724,12 +725,25 @@ func TestGetGroupScheduleOverview(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name: "regular member is denied",
+			// Access was widened to any group member (not just group/site
+			// admins) - see TestGetGroupScheduleOverview_NonAdminMemberCanAccess
+			// for a more targeted test of the same behavior.
+			name: "regular member can access",
 			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
 				regular := CreateTestUser(t, db, "regular", "regular@test.com", "password123", false)
 				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
 				AddUserToGroupWithAdmin(t, db, regular.ID, group.ID, false)
 				return regular, group
+			},
+			isAdmin:        false,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "non-member is denied",
+			setupFunc: func(db *gorm.DB) (*models.User, *models.Group) {
+				outsider := CreateTestUser(t, db, "outsider", "outsider@test.com", "password123", false)
+				group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+				return outsider, group
 			},
 			isAdmin:        false,
 			expectedStatus: http.StatusForbidden,
@@ -828,4 +842,144 @@ func TestGetGroupScheduleOverview(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetGroupScheduleOverview_NonAdminMemberCanAccess(t *testing.T) {
+	db := SetupTestDB(t)
+	member := CreateTestUser(t, db, "member1", "member1@example.com", "password123", false)
+	group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, member.ID, group.ID, false)
+	db.Model(group).Update("scheduling_enabled", true)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", member.ID)
+		c.Set("is_admin", false)
+		c.Next()
+	})
+	router.GET("/groups/:id/schedule/overview", GetGroupScheduleOverview(db))
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/overview", group.ID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 for non-admin member, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetGroupScheduleOverview_EffectiveRoster(t *testing.T) {
+	db := SetupTestDB(t)
+	requester := CreateTestUser(t, db, "requester", "requester@example.com", "password123", false)
+	claimant := CreateTestUser(t, db, "claimant", "claimant@example.com", "password123", false)
+	viewer := CreateTestUser(t, db, "viewer", "viewer@example.com", "password123", false)
+	group := CreateTestGroup(t, db, "Dogs", "Dog volunteers")
+	for _, u := range []*models.User{requester, claimant, viewer} {
+		AddUserToGroupWithAdmin(t, db, u.ID, group.ID, false)
+	}
+	db.Model(group).Update("scheduling_enabled", true)
+	db.Create(&models.ShiftSlot{UserID: requester.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10})
+
+	weekStart := time.Now().UTC().Truncate(24 * time.Hour)
+	weekStart = weekStart.AddDate(0, 0, -int(weekStart.Weekday())) // this week's Sunday
+	tuesday := weekStart.AddDate(0, 0, 2)
+
+	t.Run("open request keeps requester listed, flagged needs_coverage", func(t *testing.T) {
+		reqRow := &models.ShiftCoverageRequest{GroupID: group.ID, RequestedByUserID: requester.ID, Date: tuesday, Hour: 10, Status: models.CoverageRequestOpen}
+		db.Create(reqRow)
+		defer db.Delete(reqRow)
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("user_id", viewer.ID)
+			c.Set("is_admin", false)
+			c.Next()
+		})
+		router.GET("/groups/:id/schedule/overview", GetGroupScheduleOverview(db))
+
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/overview?week_start=%s", group.ID, weekStart.Format("2006-01-02")), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body struct {
+			Slots []scheduleOverviewSlot `json:"slots"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		found := false
+		for _, s := range body.Slots {
+			if s.Date != tuesday.Format("2006-01-02") || s.Hour != 10 {
+				continue
+			}
+			for _, m := range s.Members {
+				if m.UserID == requester.ID {
+					found = true
+					if m.Status != "needs_coverage" {
+						t.Fatalf("Expected requester status needs_coverage, got %s", m.Status)
+					}
+					if !m.Claimable {
+						t.Fatal("Expected viewer to be able to claim")
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatal("Expected requester to still appear in the roster")
+		}
+	})
+
+	t.Run("claimed request swaps requester for claimant", func(t *testing.T) {
+		claimedAt := time.Now().UTC()
+		reqRow := &models.ShiftCoverageRequest{
+			GroupID: group.ID, RequestedByUserID: requester.ID, Date: tuesday, Hour: 10,
+			Status: models.CoverageRequestClaimed, ClaimedByUserID: &claimant.ID, ClaimedAt: &claimedAt,
+		}
+		db.Create(reqRow)
+		defer db.Delete(reqRow)
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("user_id", viewer.ID)
+			c.Set("is_admin", false)
+			c.Next()
+		})
+		router.GET("/groups/:id/schedule/overview", GetGroupScheduleOverview(db))
+
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/overview?week_start=%s", group.ID, weekStart.Format("2006-01-02")), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		var body struct {
+			Slots []scheduleOverviewSlot `json:"slots"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &body)
+
+		var requesterPresent, claimantPresent bool
+		for _, s := range body.Slots {
+			if s.Date != tuesday.Format("2006-01-02") || s.Hour != 10 {
+				continue
+			}
+			for _, m := range s.Members {
+				if m.UserID == requester.ID {
+					requesterPresent = true
+				}
+				if m.UserID == claimant.ID && m.Status == "covering" {
+					claimantPresent = true
+				}
+			}
+		}
+		if requesterPresent {
+			t.Fatal("Expected requester to be removed from the roster once claimed")
+		}
+		if !claimantPresent {
+			t.Fatal("Expected claimant to appear in the roster, tagged covering")
+		}
+	})
 }

--- a/internal/handlers/schedule_test.go
+++ b/internal/handlers/schedule_test.go
@@ -86,6 +86,50 @@ func TestRemoveMemberFromGroupDeletesShiftSlots(t *testing.T) {
 	}
 }
 
+// TestRemoveMemberFromGroupCancelsCoverageRequests verifies that removing a
+// member from a group also cancels any non-cancelled ShiftCoverageRequest in
+// that group where the removed member is either the original requester or
+// the claimant. Without this, a removed member who had claimed someone
+// else's open request would keep showing up in the schedule overview
+// roster tagged "covering" even though they're no longer in the group.
+func TestRemoveMemberFromGroupCancelsCoverageRequests(t *testing.T) {
+	db := SetupTestDB(t)
+	admin := CreateTestUser(t, db, "admin", "admin@test.com", "password123", true)
+	requester := CreateTestUser(t, db, "requester", "requester@test.com", "password123", false)
+	claimant := CreateTestUser(t, db, "claimant", "claimant@test.com", "password123", false)
+	group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, requester.ID, group.ID, false)
+	AddUserToGroupWithAdmin(t, db, claimant.ID, group.ID, false)
+
+	date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+	reqRow := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+	if claim := performClaimCoverageRequest(db, claimant.ID, group.ID, reqRow.ID); claim.Code != http.StatusOK {
+		t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+	}
+
+	c, w := setupGroupTestContext(admin.ID, true)
+	c.Params = gin.Params{
+		{Key: "id", Value: fmt.Sprintf("%d", group.ID)},
+		{Key: "userId", Value: fmt.Sprintf("%d", claimant.ID)},
+	}
+	c.Request = httptest.NewRequest("DELETE", fmt.Sprintf("/api/groups/%d/members/%d", group.ID, claimant.ID), nil)
+
+	handler := RemoveMemberFromGroup(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated models.ShiftCoverageRequest
+	if err := db.First(&updated, reqRow.ID).Error; err != nil {
+		t.Fatalf("failed to reload coverage request: %v", err)
+	}
+	if updated.Status != models.CoverageRequestCancelled {
+		t.Fatalf("expected coverage request status to be cancelled after claimant left the group, got %s", updated.Status)
+	}
+}
+
 func TestGetMySchedule(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -295,6 +339,61 @@ func TestUpdateMySchedule(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestUpdateMySchedule_CancelsOrphanedCoverageRequests verifies that
+// editing a recurring schedule cancels any open/claimed
+// ShiftCoverageRequest the user made as the original requester whose
+// weekday/hour no longer has a matching ShiftSlot row after the edit -
+// otherwise GetGroupScheduleOverview can never surface that request again
+// (it can only show a coverage request tied to a weekday/hour that still
+// has a ShiftSlot), silently hiding even an already-claimed request from
+// the only view that shows it. A request for a weekday/hour the user KEPT
+// must NOT be cancelled.
+func TestUpdateMySchedule_CancelsOrphanedCoverageRequests(t *testing.T) {
+	db := SetupTestDB(t)
+	user := CreateTestUser(t, db, "vol1", "vol1@test.com", "password123", false)
+	group := createSchedulingEnabledGroup(t, db, "Dogs", "Dog volunteers")
+	AddUserToGroupWithAdmin(t, db, user.ID, group.ID, false)
+
+	// Two recurring slots: Tuesday 10am and Wednesday 9am.
+	db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 2, Hour: 10})
+	db.Create(&models.ShiftSlot{UserID: user.ID, GroupID: group.ID, DayOfWeek: 3, Hour: 9})
+
+	tuesdayDate, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+	wednesdayDate, _ := time.Parse("2006-01-02", nextWeekday(time.Wednesday))
+	orphaned := createOpenCoverageRequest(t, db, group.ID, user.ID, 2, 10, tuesdayDate)
+	kept := createOpenCoverageRequest(t, db, group.ID, user.ID, 3, 9, wednesdayDate)
+
+	// New schedule drops Tuesday 10am but keeps Wednesday 9am.
+	c, w := setupGroupTestContext(user.ID, false)
+	c.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", group.ID)}}
+	c.Request = httptest.NewRequest("PUT", fmt.Sprintf("/api/groups/%d/schedule/me", group.ID),
+		bytes.NewBufferString(`{"slots":[{"day_of_week":3,"hour":9}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := UpdateMySchedule(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updatedOrphaned models.ShiftCoverageRequest
+	if err := db.First(&updatedOrphaned, orphaned.ID).Error; err != nil {
+		t.Fatalf("failed to reload orphaned request: %v", err)
+	}
+	if updatedOrphaned.Status != models.CoverageRequestCancelled {
+		t.Errorf("expected orphaned coverage request (dropped weekday/hour) to be cancelled, got %s", updatedOrphaned.Status)
+	}
+
+	var updatedKept models.ShiftCoverageRequest
+	if err := db.First(&updatedKept, kept.ID).Error; err != nil {
+		t.Fatalf("failed to reload kept request: %v", err)
+	}
+	if updatedKept.Status != models.CoverageRequestOpen {
+		t.Errorf("expected coverage request for a retained weekday/hour to remain open, got %s", updatedKept.Status)
 	}
 }
 
@@ -1051,6 +1150,61 @@ func TestGetGroupScheduleOverview_EffectiveRoster(t *testing.T) {
 		}
 		if *m2.CoverageRequestID != req2.ID {
 			t.Fatalf("Expected requester2's coverage_request_id to be %d, got %d", req2.ID, *m2.CoverageRequestID)
+		}
+	})
+}
+
+// TestParseWeekStart verifies parseWeekStart's Sunday-snapping behavior for
+// a non-Sunday input, and that an empty string defaults to the current
+// week's Sunday. Every existing GetGroupScheduleOverview test either omits
+// week_start or pre-computes a Sunday before passing it, so the snapping
+// logic (ref.AddDate(0, 0, -int(ref.Weekday()))) itself was previously
+// unverified by any test.
+func TestParseWeekStart(t *testing.T) {
+	t.Run("a non-Sunday input snaps back to that week's Sunday", func(t *testing.T) {
+		// 2026-08-12 is a Wednesday; that week's Sunday is 2026-08-09.
+		got, err := parseWeekStart("2026-08-12")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("expected %s, got %s", want.Format("2006-01-02"), got.Format("2006-01-02"))
+		}
+		if got.Weekday() != time.Sunday {
+			t.Fatalf("expected result to be a Sunday, got %s", got.Weekday())
+		}
+	})
+
+	t.Run("a Sunday input is returned unchanged", func(t *testing.T) {
+		got, err := parseWeekStart("2026-08-09")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("expected %s, got %s", want.Format("2006-01-02"), got.Format("2006-01-02"))
+		}
+	})
+
+	t.Run("an empty string defaults to the current week's Sunday", func(t *testing.T) {
+		got, err := parseWeekStart("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Weekday() != time.Sunday {
+			t.Fatalf("expected result to be a Sunday, got %s", got.Weekday())
+		}
+		now := time.Now().UTC()
+		wantWeekStart := now.Truncate(24 * time.Hour).AddDate(0, 0, -int(now.Weekday()))
+		if !got.Equal(wantWeekStart) {
+			t.Fatalf("expected %s (this week's Sunday), got %s", wantWeekStart.Format("2006-01-02"), got.Format("2006-01-02"))
+		}
+	})
+
+	t.Run("an invalid date string is rejected", func(t *testing.T) {
+		if _, err := parseWeekStart("not-a-date"); err == nil {
+			t.Fatal("expected an error for an invalid date string")
 		}
 	})
 }

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -55,6 +55,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&models.AnimalNameHistory{},
 		&models.APIToken{},
 		&models.ShiftSlot{},
+		&models.ShiftCoverageRequest{},
 	)
 	if err != nil {
 		t.Fatalf("Failed to run migrations: %v", err)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -529,3 +529,33 @@ type ShiftSlot struct {
 	User      User      `gorm:"foreignKey:UserID" json:"-"`
 	Group     Group     `gorm:"foreignKey:GroupID" json:"-"`
 }
+
+// CoverageRequestStatus is the lifecycle state of a ShiftCoverageRequest.
+type CoverageRequestStatus string
+
+const (
+	CoverageRequestOpen      CoverageRequestStatus = "open"
+	CoverageRequestClaimed   CoverageRequestStatus = "claimed"
+	CoverageRequestCancelled CoverageRequestStatus = "cancelled"
+)
+
+// ShiftCoverageRequest is a one-off exception against a specific calendar
+// occurrence of a volunteer's recurring ShiftSlot. It never modifies
+// ShiftSlot itself - the recurring pattern stays the source of truth for
+// every date except the one named here. Date is date-only (time component
+// truncated to UTC midnight).
+type ShiftCoverageRequest struct {
+	ID                uint                  `gorm:"primaryKey" json:"id"`
+	CreatedAt         time.Time             `json:"created_at"`
+	UpdatedAt         time.Time             `json:"updated_at"`
+	GroupID           uint                  `gorm:"not null;index:idx_coverage_request_group_date" json:"group_id"`
+	RequestedByUserID uint                  `gorm:"not null;index" json:"requested_by_user_id"`
+	Date              time.Time             `gorm:"not null;index:idx_coverage_request_group_date" json:"date"`
+	Hour              int                   `gorm:"not null" json:"hour"`
+	Status            CoverageRequestStatus `gorm:"not null;default:open;index" json:"status"`
+	ClaimedByUserID   *uint                 `json:"claimed_by_user_id"`
+	ClaimedAt         *time.Time            `json:"claimed_at"`
+	RequestedByUser   User                  `gorm:"foreignKey:RequestedByUserID" json:"-"`
+	ClaimedByUser     *User                 `gorm:"foreignKey:ClaimedByUserID" json:"-"`
+	Group             Group                 `gorm:"foreignKey:GroupID" json:"-"`
+}

--- a/second-review-fix-report.md
+++ b/second-review-fix-report.md
@@ -1,0 +1,185 @@
+# Second-Review Fix Wave — Shift Coverage Requests
+
+Fixes 4 "Important" issues raised by an independent second-pass code review
+of the completed Shift Coverage Requests feature branch.
+
+## Fix 1 — Frontend/backend disagreement on "future"
+
+**Backend** (`internal/handlers/schedule_coverage.go`): `CreateCoverageRequest`'s
+date check changed from `!date.After(today)` (strictly future) to
+`date.Before(today)` (same-day-or-later allowed, only the past rejected).
+Error message updated to "date must not be in the past".
+
+**Frontend** (`frontend/src/pages/group/ScheduleOverview.tsx`):
+- `todayIso()` simplified from a local-calendar-date-wrapped-in-`Date.UTC()`
+  computation (which was actually local time despite the `Date.UTC` call) to
+  `new Date().toISOString().slice(0, 10)`, which is genuinely the UTC
+  calendar date — now matching the backend's clock exactly.
+- The "Request coverage" button visibility condition changed from
+  `date > today` to `date >= today` to match the backend now allowing
+  same-day requests.
+- All three `.catch(...)` handlers (`handleClaim`, `handleCancelRequest`,
+  `handleRequestCoverage`) now extract `err.response?.data?.error` with the
+  existing fixed string as fallback (matching the `GroupsPage.tsx` /
+  `GroupPage.tsx` inline pattern), and each now also calls `loadOverview()`
+  inside the catch block so a failed action doesn't leave stale UI state.
+
+**Tests:**
+- Go: split the old "rejects a past or same-day date" test in
+  `schedule_coverage_test.go` into "rejects a past date" (yesterday, still
+  400) and a new "accepts a same-day date" test (creates a fresh group/user
+  with a ShiftSlot matching *today's actual* weekday/hour, since the fixed
+  Tuesday-10am fixture used elsewhere doesn't track the real clock; asserts
+  201).
+- Frontend: added "shows a Request coverage button for the current user's
+  own name on the same day (today counts as future)" (pins the clock to the
+  slot's own date, asserts the button renders), and "surfaces the backend
+  error message when a claim fails, and reloads the overview" (asserts
+  `mockShowError` gets the backend's `error` string, and `getOverview` is
+  called one additional time from inside the catch).
+
+## Fix 2 — Unthrottled group-wide broadcast
+
+`CreateCoverageRequest` now runs a cooldown check on `rawDB` (the
+outer/non-transaction db, since it runs post-commit) immediately before the
+notification blocks: counts other non-self `ShiftCoverageRequest` rows by
+the same `(group_id, requested_by_user_id)` created in the last 5 minutes.
+If any exist, both the email and GroupMe notification blocks are skipped
+entirely (the request itself is still created and returned normally either
+way).
+
+Notification content was also fixed to include names: `title` is now
+`"Coverage needed in {group.Name}"` and `content` is now
+`"{displayName(requester)} needs coverage for their {hour} shift on
+{date}."` — loaded via `rawDB.First(&requester, targetUserID)` and
+`rawDB.Select("name").First(&grp, groupIDUint)`, reusing the existing
+`displayName` helper (not redefined).
+
+**Test:** added "second request within the cooldown window still succeeds"
+to `schedule_coverage_test.go` — creates a request, cancels it, immediately
+creates a second one for the same requester/group, and asserts both the
+second create returns 201 and both rows (one cancelled, one active) exist in
+the DB. This also structurally exercises the cooldown-check code path with
+`nil` email/GroupMe services (as `performCreateCoverageRequest` always
+passes), confirming it doesn't panic or error when those services are nil.
+Directly asserting "no notification was sent" isn't practical without a
+mock email/GroupMe service, per the task's own acknowledgment.
+
+## Fix 3 — Symmetric conflict check for claimants gaining a ShiftSlot
+
+**Root-cause fix** (`internal/handlers/schedule.go`): added
+`cancelRedundantClaimsForNewSlots(tx, userID, groupID, slots)`, following the
+same style as the existing `cancelOrphanedRequesterCoverageRequests` helper.
+It loads all `claimed` `ShiftCoverageRequest` rows where this user is the
+claimant, and cancels any whose `(weekday, hour)` now collides with a slot
+just added to the user's own recurring schedule. Wired into
+`replaceGroupScheduleForUser`'s existing transaction, immediately after the
+`cancelOrphanedRequesterCoverageRequests` call — both helpers run inside the
+same transaction as the slot replace (no second transaction opened).
+
+**Defensive backstop** (`GetGroupScheduleOverview`, same file): the loop
+appending `covering` entries from `claimedByDateHour` now builds a
+`seenUserIDs` set from the bucket's already-constructed `members` slice
+first, and skips (and marks-seen) any claimant already present, so no future
+code path can produce a duplicate `user_id` in one slot's member list.
+
+**Tests:** added to `schedule_test.go`:
+- `TestUpdateMemberSchedule_CancelsRedundantClaimsForNewSlots` — Alice
+  requests Tuesday 10am coverage, Bob claims it, an admin then adds Bob to
+  Tuesday 10am via `UpdateMemberSchedule`; asserts the claim's status flips
+  to `cancelled`.
+- `TestUpdateMemberSchedule_KeepsClaimsForDifferentSlots` — companion case:
+  Bob's claim is for Wednesday 9am, the admin adds him to Tuesday 10am
+  (a different weekday/hour); asserts the claim stays `claimed` (no
+  over-cancellation).
+
+Both pass.
+
+## Fix 4 — Same user claiming two different requests at the same date/hour
+
+**Backend index** (`internal/database/database.go`, `createCustomIndexes`):
+added a second partial unique index immediately after the existing
+`idx_coverage_request_active_unique` block, matching its exact style (raw
+SQL via `db.Exec`, `logging.WithField("error", ...).Warn(...)` on failure,
+`logging.Info(...)` on success):
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coverage_request_claimed_unique
+ON shift_coverage_requests (claimed_by_user_id, date, hour)
+WHERE status = 'claimed'
+```
+
+This is on a different column set (`claimed_by_user_id` vs.
+`requested_by_user_id` in the existing index) so it doesn't conflict with or
+duplicate the existing one — one prevents duplicate *open* requests by the
+requester, the other prevents duplicate *claims* by the claimant.
+
+**Frontend hardening** (`ScheduleOverview.tsx`): the Claim button's
+`disabled` condition changed from `busyRequestId === member.coverage_request_id`
+to `busyRequestId !== null` (combined with the existing `|| member.conflict`),
+so any claim in flight disables every Claim button in the popover, not just
+the one clicked. (The Cancel-request button's disabled condition was left
+unchanged per the task spec — only Claim was in scope.)
+
+**Tests:**
+- Go: added `TestCreateCustomIndexes_CoverageRequestClaimedUnique` to
+  `internal/database/database_test.go`, mirroring
+  `TestCreateCustomIndexes_CoverageRequestActiveUnique`'s exact structure
+  (per-test-run unique shared-cache sqlite DSN, `AutoMigrate` +
+  `createCustomIndexes`). Creates two different open requests (different
+  requesters) at the same `(date, hour)`, claims the first with a shared
+  claimant (succeeds), confirms the second, still-open request for a
+  different requester is unaffected, then attempts to claim the second
+  request with the SAME claimant at the same `(date, hour)` via a direct
+  `Updates(...)` call — asserts this is rejected by the unique index.
+- Frontend: added "disables every Claim button in the popover while any
+  claim is in flight, not just the one clicked" — two `needs_coverage`
+  members in one popover, clicks the first Claim button, asserts BOTH
+  buttons are disabled while the claim is pending.
+
+## Files changed
+
+- `internal/handlers/schedule_coverage.go` — Fix 1 (backend date check), Fix 2 (cooldown + notification content)
+- `internal/handlers/schedule_coverage_test.go` — Fix 1 test split, Fix 2 test
+- `internal/handlers/schedule.go` — Fix 3 (new helper + wiring, dedupe backstop)
+- `internal/handlers/schedule_test.go` — Fix 3 tests
+- `internal/database/database.go` — Fix 4 (new partial unique index)
+- `internal/database/database_test.go` — Fix 4 test
+- `frontend/src/pages/group/ScheduleOverview.tsx` — Fix 1 (todayIso, button visibility, toast pattern), Fix 4 (Claim button disabled condition)
+- `frontend/src/pages/group/ScheduleOverview.test.tsx` — Fix 1 and Fix 4 frontend tests
+
+## Self-review
+
+- Confirmed `date.Before(today)` rejects yesterday and earlier, accepts
+  today and later — verified via the new "rejects a past date" /
+  "accepts a same-day date" test pair, both passing.
+- Confirmed Fix 3's two helpers (`cancelOrphanedRequesterCoverageRequests`,
+  `cancelRedundantClaimsForNewSlots`) both run inside the single
+  `db.Transaction(...)` closure already present in
+  `replaceGroupScheduleForUser` — no second transaction was introduced.
+- Confirmed Fix 4's new index (`claimed_by_user_id, date, hour` WHERE
+  `status = 'claimed'`) is on a distinct column set from the existing
+  `idx_coverage_request_active_unique` (`group_id, requested_by_user_id,
+  date, hour` WHERE `status <> 'cancelled'`) — no conflict or duplication.
+- All four fixes have a regression test that would have caught the original
+  bug, except Fix 2's notification-suppression itself (can't assert "no
+  email sent" without mocking the email/GroupMe services, as anticipated in
+  the task) — its test instead proves the cooldown code path doesn't break
+  normal request creation and exercises the nil-service path explicitly.
+
+## Verification run at the end
+
+- `go test ./internal/handlers/...` — 1 pre-existing unrelated failure only:
+  `TestCreateGroup/accepts_valid_GroupMe_bot_id` (all other subtests,
+  including every new/modified coverage-request and schedule test, pass).
+- `go test ./internal/database/...` — all pass, including the new
+  `TestCreateCustomIndexes_CoverageRequestClaimedUnique`.
+- `npx vitest run` (frontend) — 411/412 pass; the 1 failure is the
+  pre-existing unrelated `AnimalForm.test.tsx` case.
+- `npx tsc --noEmit` — clean, no errors.
+
+## Concerns
+
+None outstanding. All four fixes are self-contained, tested, and the full
+verification suite matches the expected pre-existing baseline exactly (no
+new failures introduced anywhere).


### PR DESCRIPTION
## Summary
- Volunteers can flag a specific upcoming date/hour of their recurring shift as needing coverage; any other group member can claim it (first-come, no approval), which updates the effective schedule for that one date only — the underlying recurring `ShiftSlot` pattern is never touched.
- New `ShiftCoverageRequest` model + three endpoints (create/claim/cancel), each authorization-checked and race-safe (conditional updates + `RowsAffected` checks close the concurrent-claim/cancel windows; a partial unique index backstops concurrent duplicate-create attempts).
- `GET .../schedule/overview` — previously an admin-only day-of-week heatmap — is widened to all group members and rebuilt into a real per-week calendar (`week_start` param, actual dates) that computes an "effective roster" per date/hour by overlaying coverage-request state onto the base recurring roster.
- Frontend: the existing member-list popover in the schedule Overview gains inline "Request coverage" / "Claim" / "Cancel request" actions plus week navigation — deliberately reusing that popover instead of adding a new tab/screen, since the mobile tab bar is already crowded.
- Coverage requests are correctly cleaned up (cancelled) when the underlying `ShiftSlot` they depend on disappears — a member is removed from the group, or a user edits their recurring schedule and drops the day/hour a pending request was for.
- Email/GroupMe notifications on request-created (to the group) and request-claimed (to the requester), respecting `User.EmailNotificationsEnabled` and the group's GroupMe config, matching the existing notification patterns used elsewhere in the app.

## Bulk coverage requests (date-range form)
Follow-up to the single-request flow above: a volunteer needing coverage for *several* shifts at once (e.g. "I'm out all next week") previously triggered one email per shift, fragmented and noisy.
- New `POST .../schedule/coverage-requests/batch` endpoint creates several coverage requests in one call, best-effort (one invalid item doesn't block the rest, capped at 200 items/request), then sends exactly **one** notification listing everything currently open for that user — not one per item.
- New `RequestCoverageRangeForm`, reached via a "Request Coverage for a Date Range" button on the schedule's Individual view: pick a start/end date, every real occurrence of your own recurring shifts in that range is pre-checked in a list (derived from your *persisted* schedule, not any unsaved in-progress edits), uncheck any you don't need, submit — a created/skipped summary (with reasons) is shown before the modal closes.
- Reuses the app's existing shared `Modal` component, matching how `AnnouncementForm` is already wired into `GroupPage.tsx`.

### Test plan (original feature)
- [x] `go test ./...` — matches `main`'s baseline exactly: only the pre-existing, unrelated `TestCreateGroup/accepts_valid_GroupMe_bot_id` failure (confirmed present on `main` before this branch's first commit); no regressions.
- [x] `npx vitest run` (frontend) — 408/409 passing; only the pre-existing, unrelated `AnimalForm.test.tsx` failure (confirmed present on `main`), untouched by this branch's diff.
- [x] `npx tsc --noEmit` clean.
- [x] Every task implemented via subagent-driven-development: 9 planned tasks, each independently task-reviewed (spec compliance + code quality), with 4 tasks going through a fix round for real bugs caught in review (two TOCTOU races on concurrent claim/cancel, a status-code ordering bug, a map-keying bug that could silently drop one member's coverage flag when two people share a recurring slot).
- [x] A final whole-branch review (on top of all 9 task reviews) caught 4 additional cross-task/integration issues a narrow task-scoped review couldn't see — a 4th check-then-write race on duplicate-create, coverage requests going orphaned when pre-existing code deletes the underlying `ShiftSlot`, a dead-code disabled-button path, and a fully-built-but-unreachable cancel UI. All 4 fixed and re-reviewed clean in a single fix wave.
- [x] A follow-up independent review (fresh subagent, no prior context) caught 4 more real issues: a UTC/local "today" mismatch, an unthrottled group-broadcast spam vector, a missing symmetric conflict-check when a claimant later gains the slot directly, and a second unfixed claim race. All fixed and re-reviewed clean.

### Test plan (bulk coverage requests)
- [x] `go test ./...` and `npx vitest run` clean, matching the same pre-existing baseline failures noted above; `npx tsc --noEmit` clean.
- [x] 6-task plan via subagent-driven-development, each task-reviewed; 2 tasks went through a fix round (a silent-loss-on-infra-error bug in the batch handler, and 3 tests with hardcoded near-term dates that would break the next calendar day).
- [x] A scoped final review of this plan's diff caught 4 more cross-task issues: an `onSuccess` wiring bug that made the entire created/skipped result screen unreachable (and made an all-skipped batch a silent no-op), the form reading unsaved schedule-editor state instead of the persisted schedule, no server-side cap on batch size, and batch creation silently suppressing the single-create endpoint's notification for a short window afterward. All fixed and re-reviewed clean.
- [ ] Manual smoke test against a live local Postgres not performed in this session (needs interactive UI verification) — recommended before merge for both the original and bulk-request flows, particularly to exercise the new partial unique indexes and `date` column equality behavior under Postgres specifically (verified so far only against SQLite).

🤖 Generated with subagent-driven-development