### PR TITLE
Restyle Schedule tab's Individual/Overview toggle, week nav, and secondary buttons

### DIFF
--- a/frontend/src/pages/group/RequestCoverageRangeForm.css
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.css
@@ -56,3 +56,34 @@
   justify-content: flex-end;
   gap: 0.5rem;
 }
+
+/* Styled directly on its own class rather than via a `.schedule-tab
+   .btn-secondary`-style descendant selector: Modal renders this form's
+   content through a React portal to document.body, so it's never a DOM
+   descendant of .schedule-tab regardless of the component tree, and a
+   scoped descendant selector can never reach it. */
+.request-coverage-range-form__cancel-btn {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.request-coverage-range-form__cancel-btn:hover:not(:disabled) {
+  background: var(--neutral-50);
+}
+
+.request-coverage-range-form__cancel-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.request-coverage-range-form__cancel-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}

--- a/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import RequestCoverageRangeForm, { computeCandidateOccurrences } from './RequestCoverageRangeForm';
+import Modal from '../../components/Modal';
 import { scheduleApi } from '../../api/client';
 import type { AxiosResponse } from 'axios';
 import type { CoverageRequestBatchResult, ScheduleSlot } from '../../api/client';
@@ -198,5 +199,35 @@ describe('RequestCoverageRangeForm', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('styles the Cancel button correctly even though Modal renders it via a portal outside .schedule-tab', () => {
+    // Regression test: ScheduleTab.css's .schedule-tab .btn-secondary rule
+    // is a descendant selector, but Modal renders its children via
+    // createPortal(..., document.body) - so when this form is opened from
+    // ScheduleTab (as it always is in the real app), the Cancel button ends
+    // up as a DOM sibling of .schedule-tab, not a descendant of it, and
+    // that scoped rule can never match it regardless of the React
+    // component tree. The fix must not depend on DOM-tree ancestry, so
+    // this test renders through the real Modal - inside a real
+    // .schedule-tab wrapper, matching how ScheduleTab.tsx actually uses
+    // it - to prove the button is styled correctly wherever the portal
+    // happens to place it.
+    render(
+      <div className="schedule-tab">
+        <Modal isOpen={true} onClose={() => {}} title="Request Coverage for a Date Range">
+          <RequestCoverageRangeForm groupId={7} slots={slots} onCancel={() => {}} />
+        </Modal>
+      </div>
+    );
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    expect(cancelButton).toHaveClass('request-coverage-range-form__cancel-btn');
+
+    // Confirms the portal actually did what this test exists to guard
+    // against: the button is NOT inside .schedule-tab in the DOM, so any
+    // fix relying on a `.schedule-tab .btn-secondary`-style descendant
+    // selector would silently fail to reach it.
+    expect(cancelButton.closest('.schedule-tab')).toBeNull();
   });
 });

--- a/frontend/src/pages/group/RequestCoverageRangeForm.tsx
+++ b/frontend/src/pages/group/RequestCoverageRangeForm.tsx
@@ -231,7 +231,7 @@ const RequestCoverageRangeForm: React.FC<RequestCoverageRangeFormProps> = ({ gro
       )}
 
       <div className="request-coverage-range-form__actions">
-        <button type="button" className="btn-secondary" onClick={onCancel} disabled={submitting}>
+        <button type="button" className="request-coverage-range-form__cancel-btn" onClick={onCancel} disabled={submitting}>
           Cancel
         </button>
         <button

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -115,3 +115,29 @@
   padding: 0.15rem 0.5rem;
   white-space: nowrap;
 }
+
+.schedule-overview__week-nav-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.schedule-overview__week-nav-btn:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.schedule-overview__week-nav-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -36,6 +36,14 @@ describe('ScheduleOverview', () => {
     await waitFor(() => expect(scheduleApi.getOverview).toHaveBeenCalledWith(7, expect.objectContaining({ signal: expect.any(AbortSignal) })));
   });
 
+  it('styles the week navigation arrows as compact icon buttons', async () => {
+    render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
+    await waitFor(() => expect(scheduleApi.getOverview).toHaveBeenCalled());
+
+    expect(screen.getByRole('button', { name: 'Previous week' })).toHaveClass('schedule-overview__week-nav-btn');
+    expect(screen.getByRole('button', { name: 'Next week' })).toHaveClass('schedule-overview__week-nav-btn');
+  });
+
   it('renders a tier class proportional to how many members are available', async () => {
     mockOverview({
       week_start: '2026-08-09',

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -288,11 +288,11 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
   return (
     <div className="schedule-overview">
       <div className="schedule-overview__week-nav">
-        <button type="button" className="btn-secondary" onClick={() => setWeekStart(addDays(weekStart, -7))} aria-label="Previous week">
+        <button type="button" className="schedule-overview__week-nav-btn" onClick={() => setWeekStart(addDays(weekStart, -7))} aria-label="Previous week">
           ◀
         </button>
         <span>{formatWeekLabel(weekStart)}</span>
-        <button type="button" className="btn-secondary" onClick={() => setWeekStart(addDays(weekStart, 7))} aria-label="Next week">
+        <button type="button" className="schedule-overview__week-nav-btn" onClick={() => setWeekStart(addDays(weekStart, 7))} aria-label="Next week">
           ▶
         </button>
       </div>

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -119,16 +119,29 @@
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 0.625rem 1.25rem;
   font-weight: 600;
-  font-size: 0.9375rem;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.schedule-tab .btn-secondary:hover,
-.schedule-overview .btn-secondary:hover {
+/* Popover action buttons (.schedule-overview__action) keep their own
+   smaller sizing from ScheduleOverview.css -- excluded here so this
+   scoped rule doesn't out-specificity that padding/font-size. */
+.schedule-tab .btn-secondary:not(.schedule-overview__action),
+.schedule-overview .btn-secondary:not(.schedule-overview__action) {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+}
+
+.schedule-tab .btn-secondary:hover:not(:disabled),
+.schedule-overview .btn-secondary:hover:not(:disabled) {
   background: var(--neutral-50);
+}
+
+.schedule-tab .btn-secondary:disabled,
+.schedule-overview .btn-secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .schedule-tab .btn-secondary:focus-visible,

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -18,9 +18,39 @@
 }
 
 .schedule-tab__view-toggle {
-  display: flex;
-  gap: 0.5rem;
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
   margin-bottom: 1rem;
+}
+
+.schedule-tab__view-toggle-btn {
+  padding: 0.5rem 1.25rem;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.schedule-tab__view-toggle-btn:hover {
+  background: var(--neutral-50);
+  color: var(--text-primary);
+}
+
+.schedule-tab__view-toggle-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: -2px;
+}
+
+.schedule-tab__view-toggle-btn--active,
+.schedule-tab__view-toggle-btn--active:hover {
+  background: var(--brand);
+  color: var(--brand-contrast);
 }
 
 .schedule-grid {

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -112,3 +112,27 @@
 [data-theme='dark'] .schedule-grid__slot {
   border-color: var(--neutral-300);
 }
+
+.schedule-tab .btn-secondary,
+.schedule-overview .btn-secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.625rem 1.25rem;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.schedule-tab .btn-secondary:hover,
+.schedule-overview .btn-secondary:hover {
+  background: var(--neutral-50);
+}
+
+.schedule-tab .btn-secondary:focus-visible,
+.schedule-overview .btn-secondary:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -169,6 +169,21 @@ describe('ScheduleTab', () => {
     expect(await screen.findByLabelText(/viewing schedule for/i)).toBeInTheDocument();
   });
 
+  it('applies the active toggle style to the selected view', async () => {
+    renderScheduleTab(false);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+
+    const individualButton = screen.getByRole('button', { name: /individual/i });
+    const overviewButton = screen.getByRole('button', { name: /overview/i });
+    expect(individualButton).toHaveClass('schedule-tab__view-toggle-btn--active');
+    expect(overviewButton).not.toHaveClass('schedule-tab__view-toggle-btn--active');
+
+    fireEvent.click(overviewButton);
+
+    await waitFor(() => expect(overviewButton).toHaveClass('schedule-tab__view-toggle-btn--active'));
+    expect(individualButton).not.toHaveClass('schedule-tab__view-toggle-btn--active');
+  });
+
   it('opens the bulk request-coverage form when viewing my own schedule, and hides it when viewing another member\'s', async () => {
     vi.mocked(scheduleApi.getMine).mockResolvedValue({
       data: { slots: [{ day_of_week: 2, hour: 9 }] },

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -126,14 +126,14 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
       <div className="schedule-tab__view-toggle" role="group" aria-label="Schedule view">
         <button
           type="button"
-          className={viewMode === 'individual' ? 'btn-primary' : 'btn-secondary'}
+          className={`schedule-tab__view-toggle-btn ${viewMode === 'individual' ? 'schedule-tab__view-toggle-btn--active' : ''}`}
           onClick={() => setViewMode('individual')}
         >
           Individual
         </button>
         <button
           type="button"
-          className={viewMode === 'overview' ? 'btn-primary' : 'btn-secondary'}
+          className={`schedule-tab__view-toggle-btn ${viewMode === 'overview' ? 'schedule-tab__view-toggle-btn--active' : ''}`}
           onClick={() => setViewMode('overview')}
         >
           Overview


### PR DESCRIPTION
## Summary
- The Schedule tab's "Individual"/"Overview" toggle, week-nav arrows, and several action buttons ("Request Coverage for a Date Range", and the Overview popover's "Claim"/"Cancel request"/"Request coverage") all used a `.btn-secondary` class that was never defined in any CSS scope reaching them, so they rendered with plain browser-default chrome instead of the app's design system.
- Individual/Overview toggle is now a single bordered segmented pill, with the active side filled brand-teal — matching the visual weight of a real control instead of two mismatched buttons.
- Week-nav `◀`/`▶` are now small square icon buttons instead of full-size text buttons.
- Added a real, scoped `.btn-secondary` definition (nested under `.schedule-tab`/`.schedule-overview`, never a bare global selector) for the remaining buttons — deliberately scoped so it can't change button appearance anywhere else in the app.
- Fixed a specificity collision the scoped rule introduced against the popover's `.schedule-overview__action` sizing (which would have made Claim/Cancel/Request-coverage buttons render oversized inside the 140–220px popover), and added `:disabled` styling so disabled popover buttons render visibly disabled instead of looking clickable.
- All new/changed CSS uses only existing theme custom properties, so both light and dark themes are correct automatically. No behavior changes — click handlers, aria-labels, and component logic are untouched; only `className` values and CSS changed.

## Test plan
- [x] `ScheduleTab.test.tsx` / `ScheduleOverview.test.tsx` — 29/29 passing, including new tests asserting the toggle's active-class state transitions and the week-nav buttons' new class
- [x] Full frontend suite — 422/423 passing (1 pre-existing `AnimalForm.test.tsx` failure, confirmed unrelated and already failing on `main`)
- [x] `tsc -b` type-check — pre-existing errors in `AnimalForm.tsx`/`PhotoGallery.tsx`, confirmed already present on `main`, none in touched files
- [x] Manual verification against a local dev stack (logged in as a real demo user) in both light and dark theme: toggle pill, week-nav icon buttons, and Request Coverage button all render correctly
- [x] Executed via subagent-driven development: 3 implementation tasks + 1 verification task, each independently task-reviewed, plus a final whole-branch review that caught and fixed the specificity/disabled-state issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)