### PR TITLE
Address scheduling UX feedback: reorder, inline names, smaller buttons

### DIFF
--- a/frontend/src/pages/GroupPage.css
+++ b/frontend/src/pages/GroupPage.css
@@ -275,8 +275,8 @@
 /* Group Admin Quick Links */
 .group-admin-links {
   display: flex;
-  gap: 0.75rem;
-  padding: 1rem 1.5rem;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
   background: var(--surface);
   border-radius: 12px;
   border: 1px solid var(--neutral-200);
@@ -286,7 +286,7 @@
 }
 
 .group-admin-links__title {
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: var(--text-secondary);
   margin-right: 0.5rem;
@@ -295,13 +295,13 @@
 .group-admin-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
   border: 1px solid var(--neutral-300);
-  border-radius: 8px;
+  border-radius: 6px;
   text-decoration: none;
   color: var(--text-primary);
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   font-weight: 500;
   transition: all 0.2s ease;
   background: var(--surface);
@@ -314,8 +314,8 @@
 }
 
 .group-admin-link svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   color: var(--brand);
 }
 

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -40,15 +40,25 @@
 /* Overview slots hold member names now (not just heatmap color), so they
    need to grow to fit text and left-align content instead of centering an
    empty square. Scoped to .schedule-overview so ScheduleTab's own (still
-   empty, fixed-height) individual-view slots are unaffected. */
+   empty, fixed-height) individual-view slots are unaffected.
+
+   `.schedule-grid__row { display: contents }` makes each slot a direct
+   grid item of `.schedule-grid`, and grid items get an automatic min-width
+   equal to their content's min-content size unless the item's own overflow
+   is non-visible - without `overflow: hidden`/`min-width: 0` here, a single
+   long unbroken name (e.g. a long surname) would force this slot (and its
+   1fr column) to grow to fit it instead of the child's `text-overflow:
+   ellipsis` ever kicking in. */
 .schedule-overview .schedule-grid__slot {
   height: auto;
   min-height: 32px;
+  min-width: 0;
   padding: 3px 4px;
   display: flex;
   align-items: flex-start;
   text-align: left;
   cursor: pointer;
+  overflow: hidden;
 }
 
 .schedule-overview__names {

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -32,9 +32,28 @@
   background: var(--brand);
 }
 
-.schedule-grid__slot--tier-3,
+/* Tier-3/4 cells now render real member-name text (not just an empty
+   colored square), so the text color needs to pass WCAG AA (4.5:1) against
+   each tier's actual mixed background - which isn't the same call in both
+   themes. Verified via relative-luminance contrast math:
+     light tier-3 (~rgb(77,151,135)): white ~3.45:1 (fails) / dark ~5.1:1 (passes)
+     dark  tier-3 (~rgb(9,130,105)):  white ~4.76:1 (passes)
+     light tier-4 (solid brand #006b54): white ~6.5:1 (passes)
+     dark  tier-4 (solid brand #00a87e): white ~3.0:1 (fails) / dark ~6.9:1 (passes) */
+.schedule-grid__slot--tier-3 {
+  color: #111827;
+}
+
+[data-theme='dark'] .schedule-grid__slot--tier-3 {
+  color: var(--brand-contrast);
+}
+
 .schedule-grid__slot--tier-4 {
-  color: #fff;
+  color: var(--brand-contrast);
+}
+
+[data-theme='dark'] .schedule-grid__slot--tier-4 {
+  color: #111827;
 }
 
 /* Overview slots hold member names now (not just heatmap color), so they

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -32,6 +32,44 @@
   background: var(--brand);
 }
 
+.schedule-grid__slot--tier-3,
+.schedule-grid__slot--tier-4 {
+  color: #fff;
+}
+
+/* Overview slots hold member names now (not just heatmap color), so they
+   need to grow to fit text and left-align content instead of centering an
+   empty square. Scoped to .schedule-overview so ScheduleTab's own (still
+   empty, fixed-height) individual-view slots are unaffected. */
+.schedule-overview .schedule-grid__slot {
+  height: auto;
+  min-height: 32px;
+  padding: 3px 4px;
+  display: flex;
+  align-items: flex-start;
+  text-align: left;
+  cursor: pointer;
+}
+
+.schedule-overview__names {
+  display: block;
+  width: 100%;
+}
+
+.schedule-overview__name {
+  display: block;
+  font-size: 0.65rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.schedule-overview__name--more {
+  font-style: italic;
+  opacity: 0.85;
+}
+
 .schedule-overview__popover {
   /* top/left are set inline from the clicked cell's live bounding rect (see
      ScheduleOverview.tsx) so the popover is positioned relative to the

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -130,6 +130,36 @@ describe('ScheduleOverview', () => {
     await waitFor(() => expect(screen.queryByRole('list')).not.toBeInTheDocument());
   });
 
+  it('caps the names shown directly in a cell and collapses the rest into a "+N more" indicator', async () => {
+    const members = Array.from({ length: 5 }, (_, i) => ({
+      user_id: i + 2,
+      username: `vol${i + 1}`,
+      first_name: `Member`,
+      last_name: `${i + 1}`,
+      status: 'normal' as const,
+    }));
+    mockOverview({
+      week_start: '2026-08-09',
+      slots: [{ date: '2026-08-11', day_of_week: 2, hour: 9, members }],
+    });
+    render(<ScheduleOverview groupId={7} totalMembers={5} currentUserId={1} />);
+
+    const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*5 available/i });
+
+    // Only the first MAX_VISIBLE_NAMES (3) render inline in the cell...
+    expect(within(cell).getByText('Member 1.')).toBeInTheDocument();
+    expect(within(cell).getByText('Member 2.')).toBeInTheDocument();
+    expect(within(cell).getByText('Member 3.')).toBeInTheDocument();
+    expect(within(cell).queryByText('Member 4.')).not.toBeInTheDocument();
+    expect(within(cell).getByText('+2 more')).toBeInTheDocument();
+
+    // ...but all 5 are still available via the popover.
+    fireEvent.click(cell);
+    const popover = await screen.findByRole('list');
+    expect(within(popover).getAllByRole('listitem')).toHaveLength(5);
+    expect(within(popover).getByText('Member 4')).toBeInTheDocument();
+  });
+
   it('renders every member in a long list even though the popover box is height-capped', async () => {
     // jsdom doesn't compute layout, so this can't verify the CSS
     // max-height/overflow-y clamp actually kicks in visually (that's

--- a/frontend/src/pages/group/ScheduleOverview.test.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import ScheduleOverview from './ScheduleOverview';
 import { scheduleApi } from '../../api/client';
 import type { AxiosResponse } from 'axios';
@@ -85,9 +85,14 @@ describe('ScheduleOverview', () => {
     render(<ScheduleOverview groupId={7} totalMembers={4} currentUserId={1} />);
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
+    // The cell shows who's scheduled directly, without needing a click.
+    expect(within(cell).getByText('vol1')).toBeInTheDocument();
+
     fireEvent.click(cell);
 
-    expect(await screen.findByText('vol1')).toBeInTheDocument();
+    // The popover repeats the same fallback name alongside its actions.
+    const popover = await screen.findByRole('list');
+    expect(within(popover).getByText('vol1')).toBeInTheDocument();
   });
 
   it('falls back to a data-derived denominator when totalMembers is 0 but slots have members', async () => {
@@ -118,10 +123,11 @@ describe('ScheduleOverview', () => {
 
     const cell = await screen.findByRole('cell', { name: /Tue 9:00 AM.*1 available/i });
     fireEvent.click(cell);
-    expect(await screen.findByText('vol1')).toBeInTheDocument();
+    const popover = await screen.findByRole('list');
+    expect(within(popover).getByText('vol1')).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);
-    await waitFor(() => expect(screen.queryByText('vol1')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('list')).not.toBeInTheDocument());
   });
 
   it('renders every member in a long list even though the popover box is height-capped', async () => {

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -369,7 +369,9 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                       {visibleMembers.map(member => (
                         <span key={member.user_id} className="schedule-overview__name">
                           {shortDisplayName(member)}
-                          {member.status === 'needs_coverage' && ' ⚠'}
+                          {member.status === 'needs_coverage' && (
+                            <span className="schedule-overview__tag" aria-hidden="true"> ⚠</span>
+                          )}
                         </span>
                       ))}
                       {overflowCount > 0 && (

--- a/frontend/src/pages/group/ScheduleOverview.tsx
+++ b/frontend/src/pages/group/ScheduleOverview.tsx
@@ -19,6 +19,20 @@ function memberDisplayName(member: ScheduleOverviewMember): string {
   return [member.first_name, member.last_name].filter(Boolean).join(' ') || member.username;
 }
 
+// Compact name shown directly in a cell (e.g. "Jane D.") so who's scheduled
+// is visible at a glance, without the click the full popover requires.
+// Deliberately distinct from memberDisplayName's full "First Last" - keeps
+// cells narrow and avoids duplicate-text ambiguity with the popover.
+function shortDisplayName(member: ScheduleOverviewMember): string {
+  if (!member.first_name) return member.username;
+  return member.last_name ? `${member.first_name} ${member.last_name.charAt(0)}.` : member.first_name;
+}
+
+// Caps how many names render inline per cell before collapsing the rest
+// into a "+N more" indicator, so a heavily-staffed slot can't blow out the
+// row height for the whole week.
+const MAX_VISIBLE_NAMES = 3;
+
 interface PopoverPosition {
   top: number;
   left: number;
@@ -331,6 +345,9 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                 );
               }
 
+              const visibleMembers = members.slice(0, MAX_VISIBLE_NAMES);
+              const overflowCount = members.length - visibleMembers.length;
+
               return (
                 <div key={key} className="schedule-overview__cell-wrapper">
                   <button
@@ -347,7 +364,21 @@ const ScheduleOverview: React.FC<ScheduleOverviewProps> = ({ groupId, totalMembe
                         setActiveCellKey(key);
                       }
                     }}
-                  />
+                  >
+                    <span className="schedule-overview__names">
+                      {visibleMembers.map(member => (
+                        <span key={member.user_id} className="schedule-overview__name">
+                          {shortDisplayName(member)}
+                          {member.status === 'needs_coverage' && ' ⚠'}
+                        </span>
+                      ))}
+                      {overflowCount > 0 && (
+                        <span className="schedule-overview__name schedule-overview__name--more">
+                          +{overflowCount} more
+                        </span>
+                      )}
+                    </span>
+                  </button>
                   {isActive && popoverPosition && (
                     <div
                       className="schedule-overview__popover"

--- a/frontend/src/pages/group/ScheduleTab.css
+++ b/frontend/src/pages/group/ScheduleTab.css
@@ -79,6 +79,11 @@
   margin-top: 1rem;
 }
 
+.schedule-tab__request-range {
+  display: block;
+  margin-bottom: 1rem;
+}
+
 [data-theme='dark'] .schedule-grid__slot {
   border-color: var(--neutral-300);
 }

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -198,9 +198,9 @@ describe('ScheduleTab', () => {
   });
 
   it('offers the request-coverage form only the persisted schedule, not an unsaved toggle', async () => {
-    // Regression test: the "Request Coverage for a Date Range" button sits
-    // directly below "Save Schedule", so "toggle a cell, then open Request
-    // Coverage without saving" is a natural flow. The form's candidate list
+    // Regression test: "toggle a cell, then open Request Coverage without
+    // saving" is a natural flow regardless of the button's position on the
+    // page. The form's candidate list
     // must reflect only what's actually persisted server-side (savedSlots),
     // not the live, possibly-unsaved grid selection - otherwise the form
     // pre-checks occurrences the backend will just skip (unsaved additions)

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -144,6 +144,16 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
         <ScheduleOverview groupId={groupId} totalMembers={members.length} currentUserId={currentUserId} />
       ) : (
         <>
+          {selectedUserId === null && (
+            <button
+              type="button"
+              className="btn-secondary schedule-tab__request-range"
+              onClick={() => setShowRequestRangeModal(true)}
+            >
+              Request Coverage for a Date Range
+            </button>
+          )}
+
           {canManageMembers && (
             <div className="schedule-tab__picker">
               <label htmlFor="schedule-member-select">Viewing schedule for</label>
@@ -198,16 +208,6 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
           <button type="button" className="btn-primary schedule-tab__save" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving…' : 'Save Schedule'}
           </button>
-
-          {selectedUserId === null && (
-            <button
-              type="button"
-              className="btn-secondary schedule-tab__request-range"
-              onClick={() => setShowRequestRangeModal(true)}
-            >
-              Request Coverage for a Date Range
-            </button>
-          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
Follow-up on review feedback for the group scheduling feature (#277, #278, #279):
- Moves "Request Coverage for a Date Range" above the volunteer picker/grid in the Individual view, since it's expected to be the most-used action (schedules themselves don't change often).
- Overview cells now show scheduled members' names directly (up to 3, with a "+N more" indicator), instead of requiring a click just to see who's on. Clicking a cell still opens a popover, but now only for taking action (claim / request coverage / cancel).
- Shrinks the Quick Actions toolbar buttons on the group page (padding, font-size, icon size).

## Test plan
- [x] `vitest run` for `ScheduleTab`, `ScheduleOverview`, and `GroupPage` (39/39 passing)
- [x] `tsc --noEmit` clean
- [ ] Manual check in browser for cell text wrapping/overflow at various group sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LFQZ2kTx2jbxyaLk2YrjQ