### PR TITLE
Add Needs Coverage list to the Schedule tab

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -453,6 +453,7 @@ func main() {
 			group.GET("/schedule/me", handlers.GetMySchedule(db))
 			group.PUT("/schedule/me", handlers.UpdateMySchedule(db))
 			group.GET("/schedule/overview", handlers.GetGroupScheduleOverview(db))
+			group.GET("/schedule/coverage-requests", handlers.ListCoverageRequests(db))
 			group.POST("/schedule/coverage-requests", handlers.CreateCoverageRequest(db, emailService, groupMeService))
 			group.POST("/schedule/coverage-requests/batch", handlers.CreateCoverageRequestsBatch(db, emailService, groupMeService))
 			group.POST("/schedule/coverage-requests/:requestId/claim", handlers.ClaimCoverageRequest(db, emailService, groupMeService))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -674,6 +674,16 @@ export interface CoverageRequestBatchResult {
   skipped: CoverageRequestBatchSkipped[];
 }
 
+export interface CoverageRequestListItem {
+  id: number;
+  group_id: number;
+  requested_by_user_id: number;
+  requested_by_name: string;
+  date: string;
+  hour: number;
+  claimable: boolean;
+}
+
 export const scheduleApi = {
   getMine: (groupId: number, options?: { signal?: AbortSignal }) =>
     api.get<ScheduleResponse>(`/groups/${groupId}/schedule/me`, { signal: options?.signal }),
@@ -700,6 +710,8 @@ export const scheduleApi = {
     api.delete<CoverageRequest>(`/groups/${groupId}/schedule/coverage-requests/${requestId}`),
   createCoverageRequestsBatch: (groupId: number, requests: CoverageRequestBatchItem[]) =>
     api.post<CoverageRequestBatchResult>(`/groups/${groupId}/schedule/coverage-requests/batch`, { requests }),
+  listCoverageRequests: (groupId: number, options?: { signal?: AbortSignal }) =>
+    api.get<CoverageRequestListItem[]>(`/groups/${groupId}/schedule/coverage-requests`, { signal: options?.signal }),
 };
 
 // Animals API

--- a/frontend/src/pages/group/NeedsCoverageList.css
+++ b/frontend/src/pages/group/NeedsCoverageList.css
@@ -25,13 +25,13 @@
   font-weight: 600;
 }
 
-/* Descendant selector (not just .needs-coverage-list__claim) so this
-   reliably beats the global `.btn-primary, .btn-secondary` rule despite
-   equal specificity - ties go to whichever rule loads later in the
-   cascade, which depends on module import order rather than anything
-   visible here. Same technique as
-   .schedule-overview__cell-wrapper .schedule-grid__slot in
-   ScheduleOverview.css. */
+/* Descendant selector (not just .needs-coverage-list__claim), so this has
+   strictly higher specificity (0,2,0) than any single-class
+   `.btn-secondary` rule (0,1,0) elsewhere in the app and wins regardless
+   of module import/cascade order - a single-class override here would
+   only tie on specificity and be at the mercy of load order instead.
+   Same technique as .schedule-overview__cell-wrapper .schedule-grid__slot
+   in ScheduleOverview.css. */
 .needs-coverage-list .needs-coverage-list__claim {
   font-size: 0.8rem;
   padding: 0.25rem 0.75rem;

--- a/frontend/src/pages/group/NeedsCoverageList.css
+++ b/frontend/src/pages/group/NeedsCoverageList.css
@@ -1,0 +1,55 @@
+.needs-coverage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.needs-coverage-list__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--neutral-200);
+}
+
+.needs-coverage-list__row:last-child {
+  border-bottom: none;
+}
+
+.needs-coverage-list__details {
+  color: var(--text-primary);
+}
+
+.needs-coverage-list__name {
+  font-weight: 600;
+}
+
+/* Descendant selector (not just .needs-coverage-list__claim) so this
+   reliably beats the global `.btn-primary, .btn-secondary` rule despite
+   equal specificity - ties go to whichever rule loads later in the
+   cascade, which depends on module import order rather than anything
+   visible here. Same technique as
+   .schedule-overview__cell-wrapper .schedule-grid__slot in
+   ScheduleOverview.css. */
+.needs-coverage-list .needs-coverage-list__claim {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.75rem;
+  /* Some unrelated page's globally-scoped `.btn-secondary` rule sets
+     width: 100% and, since no other `.btn-secondary` rule in the app
+     happens to redeclare `width`, that declaration wins by default even
+     here (CSS cascades per-property, not per-rule) - explicit auto is
+     what actually stops this button from stretching to fill the row. */
+  width: auto;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.needs-coverage-list__empty {
+  color: var(--text-secondary);
+  padding: 1rem 0;
+}
+
+[data-theme='dark'] .needs-coverage-list__row {
+  border-color: var(--neutral-300);
+}

--- a/frontend/src/pages/group/NeedsCoverageList.test.tsx
+++ b/frontend/src/pages/group/NeedsCoverageList.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import NeedsCoverageList from './NeedsCoverageList';
+import { scheduleApi } from '../../api/client';
+import type { AxiosResponse } from 'axios';
+import type { CoverageRequestListItem } from '../../api/client';
+
+vi.mock('../../api/client', () => ({
+  scheduleApi: {
+    listCoverageRequests: vi.fn(),
+    claimCoverageRequest: vi.fn(),
+  },
+}));
+
+const mockShowSuccess = vi.fn();
+const mockShowError = vi.fn();
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}));
+
+function mockList(items: CoverageRequestListItem[]) {
+  vi.mocked(scheduleApi.listCoverageRequests).mockResolvedValue({ data: items } as unknown as AxiosResponse<CoverageRequestListItem[]>);
+}
+
+describe('NeedsCoverageList', () => {
+  beforeEach(() => {
+    mockList([]);
+    mockShowSuccess.mockClear();
+    mockShowError.mockClear();
+  });
+
+  it('loads open coverage requests for the group on mount', async () => {
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+    await waitFor(() => expect(scheduleApi.listCoverageRequests).toHaveBeenCalledWith(7, expect.objectContaining({ signal: expect.any(AbortSignal) })));
+  });
+
+  it('shows an empty state when nothing needs coverage', async () => {
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+    expect(await screen.findByText(/no shifts currently need coverage/i)).toBeInTheDocument();
+  });
+
+  it('lists an open request with requester name, date and time', async () => {
+    mockList([
+      { id: 5, group_id: 7, requested_by_user_id: 2, requested_by_name: 'Jane Doe', date: '2026-08-11', hour: 9, claimable: true },
+    ]);
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+
+    expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText(/9:00 AM/)).toBeInTheDocument();
+  });
+
+  it('claiming a shift calls claimCoverageRequest and refetches the list', async () => {
+    mockList([
+      { id: 5, group_id: 7, requested_by_user_id: 2, requested_by_name: 'Jane Doe', date: '2026-08-11', hour: 9, claimable: true },
+    ]);
+    vi.mocked(scheduleApi.claimCoverageRequest).mockResolvedValue({} as unknown as AxiosResponse);
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+
+    await screen.findByRole('button', { name: /claim/i });
+    const callsBeforeClaim = vi.mocked(scheduleApi.listCoverageRequests).mock.calls.length;
+    fireEvent.click(screen.getByRole('button', { name: /claim/i }));
+
+    await waitFor(() => expect(scheduleApi.claimCoverageRequest).toHaveBeenCalledWith(7, 5));
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalled());
+    // Claiming triggers exactly one refetch so the list reflects the new state.
+    await waitFor(() => expect(scheduleApi.listCoverageRequests).toHaveBeenCalledTimes(callsBeforeClaim + 1));
+  });
+
+  it('shows a failure toast and does not crash when claiming fails', async () => {
+    mockList([
+      { id: 5, group_id: 7, requested_by_user_id: 2, requested_by_name: 'Jane Doe', date: '2026-08-11', hour: 9, claimable: true },
+    ]);
+    vi.mocked(scheduleApi.claimCoverageRequest).mockRejectedValue({ response: { data: { error: 'Already claimed' } } });
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /claim/i }));
+
+    await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('Already claimed'));
+  });
+
+  it('disables the Claim button and explains why when the viewer has a conflicting shift', async () => {
+    mockList([
+      { id: 5, group_id: 7, requested_by_user_id: 2, requested_by_name: 'Jane Doe', date: '2026-08-11', hour: 9, claimable: false },
+    ]);
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+
+    const claimButton = await screen.findByRole('button', { name: /claim/i });
+    expect(claimButton).toBeDisabled();
+    expect(claimButton).toHaveAttribute('title', expect.stringMatching(/conflicting shift/i));
+  });
+
+  it('does not show a Claim button for the viewer\'s own request', async () => {
+    mockList([
+      { id: 5, group_id: 7, requested_by_user_id: 1, requested_by_name: 'Me', date: '2026-08-11', hour: 9, claimable: false },
+    ]);
+    render(<NeedsCoverageList groupId={7} currentUserId={1} />);
+
+    await screen.findByText('Me');
+    expect(screen.queryByRole('button', { name: /claim/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/group/NeedsCoverageList.tsx
+++ b/frontend/src/pages/group/NeedsCoverageList.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { scheduleApi } from '../../api/client';
+import type { CoverageRequestListItem } from '../../api/client';
+import { useToast } from '../../hooks/useToast';
+import { formatHourLabel } from './scheduleGrid';
+import SkeletonLoader from '../../components/SkeletonLoader';
+import ErrorState from '../../components/ErrorState';
+import './NeedsCoverageList.css';
+
+export interface NeedsCoverageListProps {
+  groupId: number;
+  currentUserId: number;
+}
+
+function formatDateLabel(isoDate: string): string {
+  const opts: Intl.DateTimeFormatOptions = { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' };
+  return new Date(`${isoDate}T00:00:00Z`).toLocaleDateString(undefined, opts);
+}
+
+const NeedsCoverageList: React.FC<NeedsCoverageListProps> = ({ groupId, currentUserId }) => {
+  const toast = useToast();
+  const [items, setItems] = useState<CoverageRequestListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyRequestId, setBusyRequestId] = useState<number | null>(null);
+
+  // Cancels any in-flight request before starting a new one, matching the
+  // AbortController pattern already used by ScheduleTab/ScheduleOverview's
+  // own loaders, so a superseded fetch (e.g. a rapid claim-then-refetch)
+  // can't land after a newer one and overwrite it.
+  const loadAbortControllerRef = useRef<AbortController | null>(null);
+  const loadRequests = useCallback(() => {
+    loadAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    loadAbortControllerRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+    scheduleApi.listCoverageRequests(groupId, { signal: controller.signal })
+      .then(res => setItems(res.data))
+      .catch(err => {
+        if (axios.isCancel(err)) return;
+        setError('Unable to load shifts that need coverage.');
+      })
+      .finally(() => {
+        if (loadAbortControllerRef.current === controller) {
+          setLoading(false);
+        }
+      });
+  }, [groupId]);
+
+  useEffect(() => {
+    loadRequests();
+  }, [loadRequests]);
+
+  useEffect(() => {
+    return () => {
+      loadAbortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const handleClaim = (requestId: number) => {
+    setBusyRequestId(requestId);
+    scheduleApi.claimCoverageRequest(groupId, requestId)
+      .then(() => {
+        toast.showSuccess('Shift claimed.');
+        loadRequests();
+      })
+      .catch(err => {
+        toast.showError(err.response?.data?.error || 'Failed to claim shift.');
+        loadRequests();
+      })
+      .finally(() => setBusyRequestId(null));
+  };
+
+  if (loading) {
+    return <SkeletonLoader variant="card" count={1} />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={loadRequests} />;
+  }
+
+  if (items.length === 0) {
+    return <p className="needs-coverage-list__empty">No shifts currently need coverage.</p>;
+  }
+
+  return (
+    <ul className="needs-coverage-list">
+      {items.map(item => (
+        <li key={item.id} className="needs-coverage-list__row">
+          <span className="needs-coverage-list__details">
+            <span className="needs-coverage-list__date">{formatDateLabel(item.date)}</span>
+            {' at '}
+            <span className="needs-coverage-list__hour">{formatHourLabel(item.hour)}</span>
+            {' — '}
+            <span className="needs-coverage-list__name">{item.requested_by_name}</span>
+          </span>
+          {item.requested_by_user_id !== currentUserId && (
+            <button
+              type="button"
+              className="btn-secondary needs-coverage-list__claim"
+              disabled={!item.claimable || busyRequestId === item.id}
+              title={!item.claimable ? 'You already have a conflicting shift at this time' : undefined}
+              onClick={() => handleClaim(item.id)}
+            >
+              Claim
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default NeedsCoverageList;

--- a/frontend/src/pages/group/ScheduleOverview.css
+++ b/frontend/src/pages/group/ScheduleOverview.css
@@ -39,7 +39,7 @@
      light tier-3 (~rgb(77,151,135)): white ~3.45:1 (fails) / dark ~5.1:1 (passes)
      dark  tier-3 (~rgb(9,130,105)):  white ~4.76:1 (passes)
      light tier-4 (solid brand #006b54): white ~6.5:1 (passes)
-     dark  tier-4 (solid brand #00a87e): white ~3.0:1 (fails) / dark ~6.9:1 (passes) */
+     dark  tier-4 (solid brand #00a87e): white ~3.0:1 (fails) / dark ~5.8:1 (passes) */
 .schedule-grid__slot--tier-3 {
   color: #111827;
 }

--- a/frontend/src/pages/group/ScheduleTab.test.tsx
+++ b/frontend/src/pages/group/ScheduleTab.test.tsx
@@ -4,7 +4,7 @@ import ScheduleTab from './ScheduleTab';
 import { scheduleApi, groupsApi } from '../../api/client';
 import { CanceledError } from 'axios';
 import type { AxiosResponse } from 'axios';
-import type { ScheduleResponse, GroupMember, ScheduleOverviewResponse } from '../../api/client';
+import type { ScheduleResponse, GroupMember, ScheduleOverviewResponse, CoverageRequestListItem } from '../../api/client';
 import { ToastProvider } from '../../contexts/ToastContext';
 
 vi.mock('../../api/client', () => ({
@@ -14,6 +14,7 @@ vi.mock('../../api/client', () => ({
     getForMember: vi.fn(),
     updateForMember: vi.fn(),
     getOverview: vi.fn(),
+    listCoverageRequests: vi.fn(),
   },
   groupsApi: {
     getMembers: vi.fn(),
@@ -34,6 +35,7 @@ describe('ScheduleTab', () => {
     vi.mocked(scheduleApi.updateMine).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleResponse>);
     vi.mocked(groupsApi.getMembers).mockResolvedValue({ data: [] } as unknown as AxiosResponse<GroupMember[]>);
     vi.mocked(scheduleApi.getOverview).mockResolvedValue({ data: { slots: [] } } as unknown as AxiosResponse<ScheduleOverviewResponse>);
+    vi.mocked(scheduleApi.listCoverageRequests).mockResolvedValue({ data: [] } as unknown as AxiosResponse<CoverageRequestListItem[]>);
   });
 
   it('loads and displays the caller\'s own schedule by default', async () => {
@@ -182,6 +184,17 @@ describe('ScheduleTab', () => {
 
     await waitFor(() => expect(overviewButton).toHaveClass('schedule-tab__view-toggle-btn--active'));
     expect(individualButton).not.toHaveClass('schedule-tab__view-toggle-btn--active');
+  });
+
+  it('offers a Needs Coverage toggle that loads the open-requests list', async () => {
+    renderScheduleTab(false);
+    await waitFor(() => expect(scheduleApi.getMine).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: /needs coverage/i }));
+
+    await waitFor(() => expect(scheduleApi.listCoverageRequests).toHaveBeenCalledWith(1, expect.objectContaining({ signal: expect.any(AbortSignal) })));
+    expect(await screen.findByText(/no shifts currently need coverage/i)).toBeInTheDocument();
+    expect(screen.queryByRole('table', { name: /weekly shift schedule/i })).not.toBeInTheDocument();
   });
 
   it('opens the bulk request-coverage form when viewing my own schedule, and hides it when viewing another member\'s', async () => {

--- a/frontend/src/pages/group/ScheduleTab.tsx
+++ b/frontend/src/pages/group/ScheduleTab.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../../hooks/useToast';
 import SkeletonLoader from '../../components/SkeletonLoader';
 import ErrorState from '../../components/ErrorState';
 import ScheduleOverview from './ScheduleOverview';
+import NeedsCoverageList from './NeedsCoverageList';
 import Modal from '../../components/Modal';
 import RequestCoverageRangeForm from './RequestCoverageRangeForm';
 import { DAYS, HOURS, slotKey, formatHourLabel } from './scheduleGrid';
@@ -26,7 +27,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [viewMode, setViewMode] = useState<'individual' | 'overview'>('individual');
+  const [viewMode, setViewMode] = useState<'individual' | 'overview' | 'needs-coverage'>('individual');
   const [showRequestRangeModal, setShowRequestRangeModal] = useState(false);
 
   // Cancels any in-flight request before starting a new one - matching
@@ -138,11 +139,24 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ groupId, canManageMembers, cu
         >
           Overview
         </button>
+        <button
+          type="button"
+          className={`schedule-tab__view-toggle-btn ${viewMode === 'needs-coverage' ? 'schedule-tab__view-toggle-btn--active' : ''}`}
+          onClick={() => setViewMode('needs-coverage')}
+        >
+          Needs Coverage
+        </button>
       </div>
 
-      {viewMode === 'overview' ? (
+      {viewMode === 'overview' && (
         <ScheduleOverview groupId={groupId} totalMembers={members.length} currentUserId={currentUserId} />
-      ) : (
+      )}
+
+      {viewMode === 'needs-coverage' && (
+        <NeedsCoverageList groupId={groupId} currentUserId={currentUserId} />
+      )}
+
+      {viewMode === 'individual' && (
         <>
           {selectedUserId === null && (
             <button

--- a/internal/handlers/schedule_coverage.go
+++ b/internal/handlers/schedule_coverage.go
@@ -56,6 +56,16 @@ func toCoverageRequestResponse(r models.ShiftCoverageRequest) coverageRequestRes
 	}
 }
 
+type coverageRequestListItem struct {
+	ID                uint   `json:"id"`
+	GroupID           uint   `json:"group_id"`
+	RequestedByUserID uint   `json:"requested_by_user_id"`
+	RequestedByName   string `json:"requested_by_name"`
+	Date              string `json:"date"`
+	Hour              int    `json:"hour"`
+	Claimable         bool   `json:"claimable"`
+}
+
 // displayName mirrors the first/last-name-with-username-fallback logic used
 // for member display names elsewhere, for use in notification text.
 func displayName(u models.User) string {
@@ -455,6 +465,124 @@ func notifyRequesterOfClaim(db *gorm.DB, emailService *email.Service, groupMeSer
 			}
 		}
 	}()
+}
+
+// slotConflictKey/claimConflictKey key the maps loadUserConflictKeys
+// returns: weekday+hour for a recurring ShiftSlot, and date+hour for an
+// already-claimed ShiftCoverageRequest.
+func slotConflictKey(dayOfWeek, hour int) string {
+	return fmt.Sprintf("%d-%d", dayOfWeek, hour)
+}
+
+func claimConflictKey(date time.Time, hour int) string {
+	return fmt.Sprintf("%s-%d", date.Format("2006-01-02"), hour)
+}
+
+// loadUserConflictKeys loads every recurring ShiftSlot and already-claimed
+// ShiftCoverageRequest userID has (in any group - a real-world time
+// conflict doesn't respect group boundaries), keyed for O(1) lookup. Two
+// queries regardless of how many coverage requests are being checked
+// against them, so ListCoverageRequests can annotate every row in the
+// group without a per-row round trip.
+func loadUserConflictKeys(db *gorm.DB, userID uint) (slotKeys, claimKeys map[string]struct{}, err error) {
+	var slots []models.ShiftSlot
+	if err := db.Where("user_id = ?", userID).Find(&slots).Error; err != nil {
+		return nil, nil, err
+	}
+	slotKeys = make(map[string]struct{}, len(slots))
+	for _, s := range slots {
+		slotKeys[slotConflictKey(s.DayOfWeek, s.Hour)] = struct{}{}
+	}
+
+	var claimed []models.ShiftCoverageRequest
+	if err := db.Where("claimed_by_user_id = ? AND status = ?", userID, models.CoverageRequestClaimed).Find(&claimed).Error; err != nil {
+		return nil, nil, err
+	}
+	claimKeys = make(map[string]struct{}, len(claimed))
+	for _, r := range claimed {
+		claimKeys[claimConflictKey(r.Date, r.Hour)] = struct{}{}
+	}
+	return slotKeys, claimKeys, nil
+}
+
+// isRequestClaimableGiven reports whether userID could claim req right
+// now, given userID's own conflict keys (see loadUserConflictKeys): not
+// their own request, and no conflicting ShiftSlot or already-claimed
+// coverage request at that exact date/hour. Mirrors the checks
+// ClaimCoverageRequest itself makes inside its transaction; this read-only
+// version is for annotating list results and is not the source of the
+// atomicity guarantee - the conditional update in ClaimCoverageRequest is.
+func isRequestClaimableGiven(req models.ShiftCoverageRequest, userID uint, slotKeys, claimKeys map[string]struct{}) bool {
+	if req.RequestedByUserID == userID {
+		return false
+	}
+	if _, conflict := slotKeys[slotConflictKey(int(req.Date.Weekday()), req.Hour)]; conflict {
+		return false
+	}
+	_, conflict := claimKeys[claimConflictKey(req.Date, req.Hour)]
+	return !conflict
+}
+
+// ListCoverageRequests returns every currently-open, not-yet-past coverage
+// request in the group, soonest first, so members can see at a glance what
+// still needs a volunteer without having to spot it in the schedule
+// overview heatmap. Each item is annotated with whether the viewer could
+// claim it, so the frontend can disable the Claim button without a second
+// round trip. Requires group membership (or site admin).
+func ListCoverageRequests(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		db := middleware.GetDB(c, db)
+		groupIDParam := c.Param("id")
+
+		userID, _ := c.Get("user_id")
+		isAdmin, _ := c.Get("is_admin")
+
+		if !checkGroupAccess(db, userID, isAdmin, groupIDParam) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+		if !requireSchedulingEnabled(c, db, groupIDParam) {
+			return
+		}
+
+		callerUserID, ok := middleware.GetUserID(c)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "User context not found"})
+			return
+		}
+
+		today := time.Now().UTC().Truncate(24 * time.Hour)
+		var requests []models.ShiftCoverageRequest
+		if err := db.Preload("RequestedByUser").
+			Where("group_id = ? AND status = ? AND date >= ?", groupIDParam, models.CoverageRequestOpen, today).
+			Order("date, hour").
+			Find(&requests).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load coverage requests"})
+			return
+		}
+
+		slotKeys, claimKeys, err := loadUserConflictKeys(db, callerUserID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load coverage requests"})
+			return
+		}
+
+		items := make([]coverageRequestListItem, 0, len(requests))
+		for _, r := range requests {
+			claimable := isRequestClaimableGiven(r, callerUserID, slotKeys, claimKeys)
+			items = append(items, coverageRequestListItem{
+				ID:                r.ID,
+				GroupID:           r.GroupID,
+				RequestedByUserID: r.RequestedByUserID,
+				RequestedByName:   displayName(r.RequestedByUser),
+				Date:              r.Date.Format("2006-01-02"),
+				Hour:              r.Hour,
+				Claimable:         claimable,
+			})
+		}
+
+		c.JSON(http.StatusOK, items)
+	}
 }
 
 // CancelCoverageRequest withdraws a coverage request. The original

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -624,6 +624,42 @@ func TestListCoverageRequests(t *testing.T) {
 		}
 	})
 
+	t.Run("marks as not claimable when the viewer already has a different claimed request at that date/hour", func(t *testing.T) {
+		// Distinct from the ShiftSlot-conflict case above: this exercises the
+		// claimKeys half of loadUserConflictKeys/isRequestClaimableGiven,
+		// which a recurring-slot conflict never touches.
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		thirdUser := CreateTestUser(t, db, "third", "third@example.com", "password123", false)
+		AddUserToGroupWithAdmin(t, db, thirdUser.ID, group.ID, false)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+
+		// other already covers requester's Tuesday 10am shift.
+		firstReq := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+		if claim := performClaimCoverageRequest(db, other.ID, group.ID, firstReq.ID); claim.Code != http.StatusOK {
+			t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+		}
+
+		// thirdUser separately needs coverage for that exact same date/hour.
+		secondReq := createOpenCoverageRequest(t, db, group.ID, thirdUser.ID, 2, 10, date)
+
+		w := performListCoverageRequests(db, other.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 1 || items[0].ID != secondReq.ID {
+			t.Fatalf("Expected exactly thirdUser's open request, got %+v", items)
+		}
+		if items[0].Claimable {
+			t.Fatalf("Expected claimable false since the viewer already has a claimed shift at that date/hour")
+		}
+	})
+
 	t.Run("non-member is denied", func(t *testing.T) {
 		db := SetupTestDB(t)
 		_, _, group := setupCoverageTestGroup(t, db)

--- a/internal/handlers/schedule_coverage_test.go
+++ b/internal/handlers/schedule_coverage_test.go
@@ -479,6 +479,164 @@ func performCreateCoverageRequestsBatch(db *gorm.DB, callerID uint, groupID uint
 	return w
 }
 
+func performListCoverageRequests(db *gorm.DB, callerID uint, isAdmin bool, groupID uint) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		c.Set("is_admin", isAdmin)
+		c.Next()
+	})
+	router.GET("/groups/:id/schedule/coverage-requests", ListCoverageRequests(db))
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%d/schedule/coverage-requests", groupID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestListCoverageRequests(t *testing.T) {
+	t.Run("returns an open upcoming request with requester name and claimable true for another member", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performListCoverageRequests(db, other.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("Expected 1 open request, got %d", len(items))
+		}
+		if items[0].RequestedByName != "requester" {
+			t.Fatalf("Expected requested_by_name %q, got %q", "requester", items[0].RequestedByName)
+		}
+		if !items[0].Claimable {
+			t.Fatalf("Expected claimable true for another member")
+		}
+	})
+
+	t.Run("excludes claimed and cancelled requests", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, claimant, group := setupCoverageTestGroup(t, db)
+		thirdUser := CreateTestUser(t, db, "third", "third@example.com", "password123", false)
+		AddUserToGroupWithAdmin(t, db, thirdUser.ID, group.ID, false)
+		tue, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+
+		claimedReq := createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, tue)
+		if claim := performClaimCoverageRequest(db, claimant.ID, group.ID, claimedReq.ID); claim.Code != http.StatusOK {
+			t.Fatalf("Expected claim to succeed, got %d: %s", claim.Code, claim.Body.String())
+		}
+		cancelledReq := createOpenCoverageRequest(t, db, group.ID, requester.ID, 4, 14, tue.AddDate(0, 0, 2))
+		if cancel := performCancelCoverageRequest(db, requester.ID, false, group.ID, cancelledReq.ID); cancel.Code != http.StatusOK {
+			t.Fatalf("Expected cancel to succeed, got %d: %s", cancel.Code, cancel.Body.String())
+		}
+
+		w := performListCoverageRequests(db, thirdUser.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("Expected 0 open requests, got %d", len(items))
+		}
+	})
+
+	t.Run("excludes a request whose date has since passed", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		yesterday := time.Now().UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+		createOpenCoverageRequest(t, db, group.ID, requester.ID, int(yesterday.Weekday()), 10, yesterday)
+
+		w := performListCoverageRequests(db, other.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("Expected past-dated request to be excluded, got %d", len(items))
+		}
+	})
+
+	t.Run("marks the requester's own request as not claimable", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, _, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		w := performListCoverageRequests(db, requester.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("Expected 1 open request, got %d", len(items))
+		}
+		if items[0].Claimable {
+			t.Fatalf("Expected claimable false for the requester's own request")
+		}
+	})
+
+	t.Run("marks as not claimable when the viewer has a conflicting shift at that date/hour", func(t *testing.T) {
+		db := SetupTestDB(t)
+		requester, other, group := setupCoverageTestGroup(t, db)
+		date, _ := time.Parse("2006-01-02", nextWeekday(time.Tuesday))
+		createOpenCoverageRequest(t, db, group.ID, requester.ID, 2, 10, date)
+
+		otherGroup := CreateTestGroup(t, db, "Cats", "Cat volunteers")
+		AddUserToGroupWithAdmin(t, db, other.ID, otherGroup.ID, false)
+		if err := db.Create(&models.ShiftSlot{UserID: other.ID, GroupID: otherGroup.ID, DayOfWeek: 2, Hour: 10}).Error; err != nil {
+			t.Fatalf("Failed to create conflicting shift slot: %v", err)
+		}
+
+		w := performListCoverageRequests(db, other.ID, false, group.ID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var items []coverageRequestListItem
+		if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("Expected 1 open request, got %d", len(items))
+		}
+		if items[0].Claimable {
+			t.Fatalf("Expected claimable false when the viewer has a conflicting shift")
+		}
+	})
+
+	t.Run("non-member is denied", func(t *testing.T) {
+		db := SetupTestDB(t)
+		_, _, group := setupCoverageTestGroup(t, db)
+		outsider := CreateTestUser(t, db, "outsider", "outsider@example.com", "password123", false)
+
+		w := performListCoverageRequests(db, outsider.ID, false, group.ID)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
 func TestCreateCoverageRequestsBatch(t *testing.T) {
 	t.Run("happy path creates multiple open requests and reports none skipped", func(t *testing.T) {
 		db := SetupTestDB(t)


### PR DESCRIPTION
## Summary
- Adds a "Needs Coverage" toggle to the group Schedule tab: a flat, scannable list of every open coverage request in the group (date, time, requester, Claim button), backed by a new `GET /groups/:id/schedule/coverage-requests` endpoint. Previously this state only surfaced inside the schedule overview heatmap's popovers.
- Fixes a WCAG contrast figure in a code comment (dark-mode tier-4 heatmap cell text was documented as ~6.9:1 contrast; independently recomputed to ~5.8:1 — still passes AA, just corrects the documented number).

Note: this branch was rebased onto current `main` to drop earlier commits that were superseded by #280/#281 (independent, already-merged UX polish that touched the same files); the diff now contains only what's described above.

## Test plan
- [x] `go test ./internal/handlers/...` — new `TestListCoverageRequests` (7 subtests, including a claim-conflict path added after review) passing; full suite passing except a pre-existing, unrelated `TestCreateGroup` failure (reproduced on a clean checkout, not touched by this change)
- [x] `npx vitest run` (frontend) — new `NeedsCoverageList.test.tsx` (7 tests) and updated `ScheduleTab.test.tsx` passing; full suite passing except one pre-existing, unrelated `AnimalForm.test.tsx` failure
- [x] Manually verified end-to-end in the browser: seeded an open coverage request as one demo user, logged in as another, confirmed it appears in the new list with the requester's name, claimed it, confirmed it disappears and a success toast shows
- [x] Independent code review (fresh-context subagent) returned "Ready with fixes"; addressed all findings: added a test for the previously-uncovered claim-conflict path (verified it fails on a deliberately broken version and passes on the correct one) and fixed two comment inaccuracies

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DZ4wgD69TPeySrgYQVcNid