### PR TITLE
Gate the Schedule tab behind a LaunchDarkly feature flag

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.12.2",
         "docx-preview": "0.3.7",
         "dompurify": "^3.3.1",
+        "launchdarkly-react-client-sdk": "^3.9.4",
         "mammoth": "^1.12.0",
         "pdfjs-dist": "^4.10.38",
         "react": "^19.1.1",
@@ -3279,7 +3280,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3819,6 +3819,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4175,6 +4190,47 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/launchdarkly-js-client-sdk": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.9.5.tgz",
+      "integrity": "sha512-VYIqarCd1tOt8C701Eu2TQNCfsd/mMw4Eu+yi/C4yT3nuQLd614hbPOGbJrpB3WFVWmePEgcPeLxYenj4nCs+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "launchdarkly-js-sdk-common": "5.8.3"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.8.3.tgz",
+      "integrity": "sha512-IYf022xU3x3UMESumqbkkbPi2F4qEkZt+MEW2lwNKDuekWE6s/rm2PHF0el6gZKtDP5qn84w2UtvPydsnIttTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
+    "node_modules/launchdarkly-react-client-sdk": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.9.4.tgz",
+      "integrity": "sha512-26270FX3IfuBBgGKYNWgNkY7YhNLKB4hzAnblnt7Wfp7suVTxB+L2LeymG1Mm6gRPTs8V43A/Ua1HYUycoJbGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2",
+        "launchdarkly-js-client-sdk": "^3.9.5",
+        "lodash.camelcase": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.3 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4213,6 +4269,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.12.2",
     "docx-preview": "0.3.7",
     "dompurify": "^3.3.1",
+    "launchdarkly-react-client-sdk": "^3.9.4",
     "mammoth": "^1.12.0",
     "pdfjs-dist": "^4.10.38",
     "react": "^19.1.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
+import { withLDProvider, useLDClient } from 'launchdarkly-react-client-sdk';
 import { AuthProvider } from './contexts/AuthContext';
 import { SiteSettingsProvider } from './contexts/SiteSettingsContext';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -89,6 +90,21 @@ const GroupAdminRoute: React.FC<{ children: React.ReactNode }> = ({ children }) 
   return <GroupAdminRouteInner>{children}</GroupAdminRouteInner>;
 };
 
+// Switches the LaunchDarkly context from the anonymous default (set at
+// provider init, before auth resolves) to the logged-in user once known, so
+// user-targeted flags (e.g. Schedule tab access) evaluate correctly.
+const LDIdentifyUser: React.FC = () => {
+  const { user } = useAuth();
+  const ldClient = useLDClient();
+
+  useEffect(() => {
+    if (!ldClient || !user) return;
+    ldClient.identify({ kind: 'user', key: String(user.id), email: user.email, name: user.username, username: user.username });
+  }, [ldClient, user]);
+
+  return null;
+};
+
 // UsersRoute - allows access if user is site admin or group admin
 const UsersRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, isAdmin, user, isLoading } = useAuth();
@@ -107,6 +123,7 @@ function App() {
       <ThemeProvider>
         <SiteSettingsProvider>
           <AuthProvider>
+            <LDIdentifyUser />
             <ToastProvider>
               <Navigation />
               <main id="main-content" role="main">
@@ -277,4 +294,16 @@ function App() {
   );
 }
 
-export default App;
+// LaunchDarkly is optional: without a client-side ID (VITE_LAUNCHDARKLY_CLIENT_ID
+// unset), App renders unwrapped and useFlags() falls back to {}, so any
+// LD-gated feature defaults to hidden rather than crashing the app.
+const ldClientSideId = import.meta.env.VITE_LAUNCHDARKLY_CLIENT_ID as string | undefined;
+
+const AppWithProviders = ldClientSideId
+  ? withLDProvider({
+      clientSideID: ldClientSideId,
+      context: { kind: 'user', key: 'anonymous', anonymous: true },
+    })(App)
+  : App;
+
+export default AppWithProviders;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,8 +98,15 @@ const LDIdentifyUser: React.FC = () => {
   const ldClient = useLDClient();
 
   useEffect(() => {
-    if (!ldClient || !user) return;
-    ldClient.identify({ kind: 'user', key: String(user.id), email: user.email, name: user.username, username: user.username });
+    if (!ldClient) return;
+    if (user) {
+      ldClient.identify({ kind: 'user', key: String(user.id), email: user.email, name: user.username, username: user.username });
+    } else {
+      // Resets the context back to anonymous on logout - otherwise the
+      // previous user's identity (and their flag targeting) would stick
+      // around in the LD client for the rest of the browser session.
+      ldClient.identify({ kind: 'user', key: 'anonymous', anonymous: true });
+    }
   }, [ldClient, user]);
 
   return null;

--- a/frontend/src/pages/GroupPage.test.tsx
+++ b/frontend/src/pages/GroupPage.test.tsx
@@ -9,6 +9,16 @@ import type { AxiosResponse } from 'axios';
 import { AuthProvider } from '../contexts/AuthContext';
 import { ToastProvider } from '../contexts/ToastContext';
 
+// GroupPage isn't wrapped in a real LDProvider here (that only happens in App.tsx),
+// so useFlags() would otherwise return {} and hide LD-gated UI like the Schedule
+// tab. Routed through a controllable mock (mockUseFlags) defaulting to flag-on,
+// so most tests exercise the same group.scheduling_enabled/membership logic
+// they did before the flag existed, while a dedicated test below can flip it off.
+const mockUseFlags = vi.fn(() => ({ scheduleTabAccess: true }));
+vi.mock('launchdarkly-react-client-sdk', () => ({
+  useFlags: () => mockUseFlags(),
+}));
+
 // Mock the API client. GroupPage's 'animals' view only needs group/membership/animal
 // data plus the site-wide group switcher list and the length-of-stay preference; the
 // members/documents view APIs are intentionally left unmocked since this test never
@@ -119,6 +129,10 @@ describe('GroupPage', () => {
     // Default view for most tests below; the 'activity' view tests further
     // down override this in their own beforeEach.
     mockUseSearchParams.mockReturnValue([new URLSearchParams('view=animals'), vi.fn()]);
+
+    // Default flag-on so most tests exercise the same scheduling logic they
+    // did before the flag existed; the dedicated flag test overrides this.
+    mockUseFlags.mockReturnValue({ scheduleTabAccess: true });
   });
 
   const renderGroupPage = () => {
@@ -490,6 +504,17 @@ describe('GroupPage', () => {
 
       renderGroupPage();
       expect(await screen.findByRole('tab', { name: /schedule/i })).toBeInTheDocument();
+    });
+
+    it('does not show the Schedule tab when the LaunchDarkly flag is off, even with scheduling enabled', async () => {
+      mockUseFlags.mockReturnValue({ scheduleTabAccess: false });
+      vi.mocked(groupsApi.getById).mockResolvedValue({
+        data: { ...mockGroup, scheduling_enabled: true },
+      } as AxiosResponse<Group>);
+
+      renderGroupPage();
+      await screen.findByRole('tab', { name: /animals/i });
+      expect(screen.queryByRole('tab', { name: /schedule/i })).not.toBeInTheDocument();
     });
 
     it('does not show the scheduling toggle button to a regular member', async () => {

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { groupsApi, animalsApi, authApi, updatesApi, groupDocumentsApi } from '../api/client';
 import ConfirmDialog from '../components/ConfirmDialog';
 import type { Group, Animal, GroupMembership, ActivityItem, GroupMember, UserSkillTag, GroupDocument } from '../api/client';
@@ -32,6 +33,9 @@ const NAME_SEARCH_DEBOUNCE_MS = 400;
 const GroupPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth(); // Ensure user is authenticated; also need their id for schedule actions
+  // Gates the Schedule tab to specific LaunchDarkly-targeted users while it's
+  // being rolled out, on top of the existing group.scheduling_enabled toggle.
+  const { scheduleTabAccess } = useFlags();
   const navigate = useNavigate();
   const toast = useToast();
   const [searchParams] = useSearchParams();
@@ -684,7 +688,7 @@ const GroupPage: React.FC = () => {
               <span>Documents</span>
             </button>
           )}
-          {group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && (
+          {scheduleTabAccess && group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && (
             <button
               role="tab"
               aria-selected={viewMode === 'schedule'}
@@ -1615,7 +1619,7 @@ const GroupPage: React.FC = () => {
         </div>
       )}
 
-      {viewMode === 'schedule' && group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && id && (
+      {viewMode === 'schedule' && scheduleTabAccess && group.scheduling_enabled && (membership?.is_member || membership?.is_site_admin) && id && (
         <div
           role="tabpanel"
           id="schedule-panel"

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -199,14 +199,22 @@ const GroupPage: React.FC = () => {
   // Update view mode when URL search params change
   useEffect(() => {
     const viewParam = searchParams.get('view') as ViewMode;
+    const isMember = membership?.is_member || membership?.is_site_admin;
     if (viewParam && (viewParam === 'activity' || viewParam === 'animals' || viewParam === 'protocols' || viewParam === 'documents')) {
       setViewMode(viewParam);
-    } else if ((viewParam === 'members' || viewParam === 'schedule') && (membership?.is_member || membership?.is_site_admin)) {
+    } else if (viewParam === 'members' && isMember) {
       setViewMode(viewParam);
-    } else if ((viewParam === 'members' || viewParam === 'schedule') && !membership?.is_member && !membership?.is_site_admin) {
+    } else if (viewParam === 'schedule' && isMember && scheduleTabAccess) {
+      setViewMode(viewParam);
+    } else if (viewParam === 'members' || viewParam === 'schedule') {
+      // Covers both a non-member deep-linking to a members-only view, and a
+      // member deep-linking to ?view=schedule without scheduleTabAccess -
+      // without this, viewMode would flip to 'schedule' while both the tab
+      // button and its content panel stay hidden, leaving a blank panel
+      // with no tab selected.
       setViewMode('activity');
     }
-  }, [searchParams, membership]);
+  }, [searchParams, membership, scheduleTabAccess]);
 
   // Once-per-page-visit data: email preferences, group details/membership,
   // and the full groups list (for the switcher). Deliberately depends only


### PR DESCRIPTION
## Summary
- Adds `launchdarkly-react-client-sdk` and wraps the app in `withLDProvider`, opt-in via `VITE_LAUNCHDARKLY_CLIENT_ID` — without it set, the app renders unwrapped and any LD-gated feature defaults to hidden (fail-closed), so this is a no-op for anyone not configuring LD.
- Adds an `LDIdentifyUser` component that switches the LD context from anonymous to the logged-in user (`key`, `email`, `name`, `username`) once auth resolves, so targeting rules can match on whichever attribute is easiest.
- Gates the Schedule tab (nav button + content panel in `GroupPage.tsx`) behind a new `schedule-tab-access` flag, on top of the existing per-group `scheduling_enabled` toggle — lets rollout be staged to specific users while the feature matures.
- Frontend-only gating (no backend enforcement): the `/schedule/*` routes are still protected by existing group membership/admin auth, this flag is purely a staged-rollout UI gate, not a security boundary.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/App.tsx src/pages/GroupPage.tsx` — clean (pre-existing warnings elsewhere unchanged)
- [x] `npx vitest run` — all pass except one pre-existing, unrelated `AnimalForm.test.tsx` failure (confirmed present on unmodified `main` via `git stash`)
- [x] `npm run build` — succeeds
- [x] Manually verified in the LaunchDarkly dashboard: flag off by default, rule targeting a specific username set to `true`, confirmed tab shows/hides accordingly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LB9xVktw23T8sAdtW9XXpq