### PR TITLE
Thread VITE_LAUNCHDARKLY_CLIENT_ID through the Docker build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -73,6 +73,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_SHA=${{ github.sha }}
+            VITE_LAUNCHDARKLY_CLIENT_ID=${{ secrets.VITE_LAUNCHDARKLY_CLIENT_ID }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 
+# Vite inlines VITE_-prefixed env vars into import.meta.env.* at build time
+# (not read at container runtime), and .env files are excluded from the
+# build context by .dockerignore - so this must arrive as a build-arg from
+# CI (build-image.yml) rather than a .env file. Not a secret: LaunchDarkly's
+# client-side ID is designed to be exposed in browser JS.
+ARG VITE_LAUNCHDARKLY_CLIENT_ID=""
+ENV VITE_LAUNCHDARKLY_CLIENT_ID=${VITE_LAUNCHDARKLY_CLIENT_ID}
+
 # Copy frontend files
 COPY frontend/package*.json ./
 COPY frontend/ ./

--- a/scripts/deploy-ghcr-az.sh
+++ b/scripts/deploy-ghcr-az.sh
@@ -19,6 +19,11 @@ set -euo pipefail
 #   REPO: ghcr.io/networkengineer-cloud/go-volunteer-media
 #   APP_NAME: Override app name (default: ca-volunteer-media-{env})
 #   RG: Override resource group (default: rg-volunteer-media-{env})
+#   VITE_LAUNCHDARKLY_CLIENT_ID: LaunchDarkly client-side ID baked into the
+#     frontend bundle at build time (not read at container runtime - Vite
+#     inlines VITE_-prefixed vars during `vite build`). Not a secret: LD's
+#     client-side ID is designed to be exposed in browser JS. Leave unset
+#     to build without LaunchDarkly, same as before this var existed.
 
 # Defaults
 ENVIRONMENT="dev"
@@ -26,6 +31,7 @@ IMAGE_TAG=""
 REPO="${REPO:-ghcr.io/networkengineer-cloud/go-volunteer-media}"
 APP_NAME=""
 RG=""
+VITE_LAUNCHDARKLY_CLIENT_ID="${VITE_LAUNCHDARKLY_CLIENT_ID:-}"
 ROLLBACK_REVISION=""
 LIST_REVISIONS=false
 SKIP_BUILD=false
@@ -161,6 +167,7 @@ if [[ "${SKIP_BUILD}" == false ]]; then
   docker build --platform linux/amd64 \
     --cache-from "${REPO}:${IMAGE_TAG}" \
     --build-arg GIT_SHA="${GIT_SHA}" \
+    --build-arg VITE_LAUNCHDARKLY_CLIENT_ID="${VITE_LAUNCHDARKLY_CLIENT_ID}" \
     -t "${FULL_IMAGE_TAG}" \
     -t "${REPO}:${IMAGE_TAG}" \
     --label "revision=${REVISION_TAG}" \


### PR DESCRIPTION
## Summary
- Fixes the Schedule-tab LaunchDarkly flag (#284) never actually working in deployed images. Root cause: Vite inlines `VITE_*` env vars into `import.meta.env.*` at *build* time, not container runtime, and `.env` is excluded from the Docker build context by `.dockerignore`. The `frontend-builder` stage had no path to receive `VITE_LAUNCHDARKLY_CLIENT_ID` at all — only `GIT_SHA` was passed as a build-arg — so the built bundle never contained a LaunchDarkly client-side ID regardless of any local `.env` edit.
- Adds `ARG`/`ENV VITE_LAUNCHDARKLY_CLIENT_ID` (default `""`) to the `frontend-builder` stage in `Dockerfile`, and passes it as a build-arg in `build-image.yml` from a new `secrets.VITE_LAUNCHDARKLY_CLIENT_ID` repo secret — matching how every other piece of build config in this repo's workflows is threaded through secrets.
- Default-empty means any build without the secret configured behaves exactly as before (LD provider skipped, flag defaults closed) — this is additive, not a behavior change for anyone not using LaunchDarkly.

## Test plan
- [x] Verified directly against the Docker layer, not just locally in Vite: `docker build --target frontend-builder --build-arg VITE_LAUNCHDARKLY_CLIENT_ID=verifytestid123 .` then `docker run ... grep` — confirmed the literal client-side ID is inlined into the built bundle.
- [x] Negative control: same build with no build-arg — confirmed the ID is absent from the bundle, reproducing the original silent-miss behavior this PR fixes.
- [x] `docker build --target frontend-builder` succeeds in both cases with no other changes to build output.

## Follow-up needed
Add a repo secret `VITE_LAUNCHDARKLY_CLIENT_ID` in GitHub settings (Settings → Secrets and variables → Actions) with the LaunchDarkly Test/Prod environment's client-side ID before this takes effect in a deployed build. Not sensitive data — LD's client-side ID is designed to be exposed in browser JS — stored as a secret here only for consistency with this repo's existing convention.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LB9xVktw23T8sAdtW9XXpq