### PR TITLE
Allow LaunchDarkly's API domains through the CSP connect-src

### DIFF
--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -565,6 +565,9 @@ func TestSecurityHeaders(t *testing.T) {
 				"frame-src 'self' blob:",
 				"frame-ancestors 'none'",
 				"base-uri 'self'",
+				// LaunchDarkly's browser SDK needs these connect-src exceptions
+				// to evaluate flags at all - see security.go's comment.
+				"connect-src 'self' https://app.launchdarkly.com https://events.launchdarkly.com https://clientstream.launchdarkly.com",
 			}
 			for _, directive := range expectedCSPDirectives {
 				if !containsSubstring(cspHeader, directive) {

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -27,7 +27,10 @@ func SecurityHeaders() gin.HandlerFunc {
 			"media-src 'self' blob:; " +
 			"font-src 'self' data:; " +
 			"frame-src 'self' blob:; " +
-			"connect-src 'self'; " +
+			// LaunchDarkly's JS SDK calls these three domains: app.launchdarkly.com
+			// for flag evaluation, events.launchdarkly.com for analytics, and
+			// clientstream.launchdarkly.com for live flag-change streaming.
+			"connect-src 'self' https://app.launchdarkly.com https://events.launchdarkly.com https://clientstream.launchdarkly.com; " +
 			"frame-ancestors 'none'; " +
 			"base-uri 'self'; " +
 			"form-action 'self'"


### PR DESCRIPTION
## Summary
Root cause of "the schedule-tab-access flag isn't evaluating, even for a targeted user": the app's Content-Security-Policy sets `connect-src 'self'` only. Every request LaunchDarkly's browser SDK makes was being blocked by the browser itself before it ever left the page - confirmed via browser console showing CSP violations for all three LD domains the SDK actually calls (verified against the SDK's own source, not guessed):
- `app.launchdarkly.com` - flag evaluation
- `events.launchdarkly.com` - analytics
- `clientstream.launchdarkly.com` - live flag-change streaming

The LD dashboard's "This flag isn't in your code yet - hasn't received any evaluations" banner was accurate: the SDK loaded and ran, it just could never reach LaunchDarkly at all, so the flag was always evaluating to its closed-by-default fallback regardless of targeting rules or which client-side ID was configured.

## Test plan
- [x] `go test ./internal/middleware/...` - added a `connect-src` assertion to the existing `TestSecurityHeaders` test covering all three domains, passes
- [x] `go build ./...` - succeeds (pre-existing embed error for `frontend/dist` only appears when the frontend hasn't been built locally, unrelated to this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LB9xVktw23T8sAdtW9XXpq